### PR TITLE
feat: Added checkbox for locking color map range

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@
           <span id="color_ramp"></span>
         </div>
         <label for="color_ramp" id="color_ramp_max">0.0</label>
+        <input type="checkbox" id="lock_range_checkbox" />
+        <label for="lock_range_checkbox">Lock Color Map Range</label>
       </div>
     </div>
     <div id="app"></div>

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -17,7 +17,6 @@ import {
 
 import ColorRamp from "./ColorRamp";
 import Dataset from "./Dataset";
-import { FeatureData } from "./Dataset";
 import { FeatureDataType } from "./types";
 import { packDataTexture } from "./utils/texture_utils";
 import vertexShader from "./shaders/colorize.vert";

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -17,6 +17,7 @@ import {
 
 import ColorRamp from "./ColorRamp";
 import Dataset from "./Dataset";
+import { FeatureData } from "./Dataset";
 import { FeatureDataType } from "./types";
 import { packDataTexture } from "./utils/texture_utils";
 import vertexShader from "./shaders/colorize.vert";
@@ -166,16 +167,17 @@ export default class ColorizeCanvas {
     this.setUniform("highlightedId", id);
   }
 
-  setFeature(name: string): void {
+  getFeatureData(name: string): FeatureData | null {
     if (!this.dataset?.features.hasOwnProperty(name)) {
-      return;
+      return null;
     }
+    return this.dataset.features[name];
+  }
 
-    const { tex, min, max } = this.dataset.features[name];
-
+  setFeature(tex: Texture, min: number, max: number): void {
     this.setUniform("featureData", tex);
     this.setUniform("featureMin", min);
-    this.setUniform("featureMax", max / 1.5);
+    this.setUniform("featureMax", max);
   }
 
   async setFrame(index: number): Promise<void> {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -178,7 +178,7 @@ export default class ColorizeCanvas {
     if(!this.dataset?.hasFeature(name)) {
       return;
     }
-    const featureData = this.dataset?.getFeatureData(name)!;
+    const featureData = this.dataset.getFeatureData(name)!;
     this.featureName = name;
     this.setUniform("featureData", featureData.tex);
     // Don't update the range values when locked

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -192,7 +192,7 @@ export default class ColorizeCanvas {
     this.setUniform("featureMax", this.colorMapRangeMax);
   }
 
-  setColorMapRangeLock(locked: boolean) {
+  setColorMapRangeLock(locked: boolean): void {
     this.isColorMapRangeLocked = locked;
     if (this.featureName) {  // trigger update for color map range
       this.setFeature(this.featureName);

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -175,10 +175,10 @@ export default class ColorizeCanvas {
   }
 
   setFeature(name: string): void {
-    const featureData = this.dataset?.getFeatureData(name);
-    if (!featureData) {
+    if(!this.dataset?.hasFeature(name)) {
       return;
     }
+    const featureData = this.dataset?.getFeatureData(name)!;
     this.featureName = name;
     this.setUniform("featureData", featureData.tex);
     // Don't update the range values when locked
@@ -186,7 +186,6 @@ export default class ColorizeCanvas {
     if (!this.isColorMapRangeLocked) {
       this.colorMapRangeMin = featureData.min;
       this.colorMapRangeMax = featureData.max;
-      console.log("Update");
     }
     this.setUniform("featureMin", this.colorMapRangeMin);
     this.setUniform("featureMax", this.colorMapRangeMax);

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -167,13 +167,6 @@ export default class ColorizeCanvas {
     this.setUniform("highlightedId", id);
   }
 
-  getFeatureData(name: string): FeatureData | null {
-    if (!this.dataset || !Object.keys(this.dataset.features).includes(name)) {
-      return null;
-    }
-    return this.dataset.features[name];
-  }
-
   setFeature(tex: Texture, min: number, max: number): void {
     this.setUniform("featureData", tex);
     this.setUniform("featureMin", min);

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -77,6 +77,10 @@ export default class ColorizeCanvas {
   private pickRenderTarget: WebGLRenderTarget;
 
   private dataset: Dataset | null;
+  private featureName: string | null;
+  private isColorMapRangeLocked: boolean;
+  private colorMapRangeMin: number;
+  private colorMapRangeMax: number;
 
   constructor() {
     this.geometry = new PlaneGeometry(2, 2);
@@ -112,6 +116,10 @@ export default class ColorizeCanvas {
     this.checkPixelRatio();
 
     this.dataset = null;
+    this.featureName = null;
+    this.isColorMapRangeLocked = false;
+    this.colorMapRangeMin = 0;
+    this.colorMapRangeMax = 0;
   }
 
   get domElement(): HTMLCanvasElement {
@@ -166,10 +174,37 @@ export default class ColorizeCanvas {
     this.setUniform("highlightedId", id);
   }
 
-  setFeature(tex: Texture, min: number, max: number): void {
-    this.setUniform("featureData", tex);
-    this.setUniform("featureMin", min);
-    this.setUniform("featureMax", max);
+  setFeature(name: string): void {
+    const featureData = this.dataset?.getFeatureData(name);
+    if (!featureData) {
+      return;
+    }
+    this.featureName = name;
+    this.setUniform("featureData", featureData.tex);
+    // Don't update the range values when locked
+    // TODO: Decide if feature range should be unlocked when the feature changes.
+    if (!this.isColorMapRangeLocked) {
+      this.colorMapRangeMin = featureData.min;
+      this.colorMapRangeMax = featureData.max;
+      console.log("Update");
+    }
+    this.setUniform("featureMin", this.colorMapRangeMin);
+    this.setUniform("featureMax", this.colorMapRangeMax);
+  }
+
+  setColorMapRangeLock(locked: boolean) {
+    this.isColorMapRangeLocked = locked;
+    if (this.featureName) {  // trigger update for color map range
+      this.setFeature(this.featureName);
+    }
+  }
+
+  getColorMapRangeMin(): number {
+    return this.colorMapRangeMin;
+  }
+
+  getColorMapRangeMax(): number {
+    return this.colorMapRangeMax;
   }
 
   async setFrame(index: number): Promise<void> {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -81,6 +81,10 @@ export default class Dataset {
     };
   }
 
+  public hasFeature(name: string): boolean {
+    return this.featureNames.includes(name);
+  }
+
   public getFeatureData(name: string): FeatureData | null {
     if (Object.keys(this.features).includes(name)) {
       return this.features[name];

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -81,6 +81,14 @@ export default class Dataset {
     };
   }
 
+  public getFeatureData(name: string): FeatureData | null {
+    if (Object.keys(this.features).includes(name)) {
+      return this.features[name];
+    } else {
+      return null;
+    }
+  }
+
   private async loadOutliers(): Promise<void> {
     if (!this.outlierFile) {
       return;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -17,7 +17,7 @@ type DatasetManifest = {
   times?: string;
 };
 
-type FeatureData = {
+export type FeatureData = {
   data: Float32Array;
   tex: Texture;
   min: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -302,7 +302,7 @@ function handleFeatureChange({ currentTarget }: Event): void {
 }
 
 function updateFeature(newFeatureName: string): void {
-  const featureData = canv.getFeatureData(newFeatureName);
+  const featureData = dataset?.getFeatureData(newFeatureName)
   if (!featureData) {
     return;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -300,7 +300,7 @@ function handleFeatureChange({ currentTarget }: Event): void {
 }
 
 function updateFeature(newFeatureName: string): void {
-  const featureData = dataset?.getFeatureData(newFeatureName)
+  const featureData = dataset?.getFeatureData(newFeatureName);
   if (!featureData) {
     return;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -263,7 +263,7 @@ async function loadDataset(name: string): Promise<void> {
   resetTrackUI();
 
   // Only change the feature if there's no equivalent in the new dataset
-  if (!dataset.featureNames.includes(featureName)) {
+  if (!dataset.hasFeature(featureName)) {
     featureName = dataset.featureNames[0];
   }
 
@@ -300,8 +300,7 @@ function handleFeatureChange({ currentTarget }: Event): void {
 }
 
 function updateFeature(newFeatureName: string): void {
-  const featureData = dataset?.getFeatureData(newFeatureName);
-  if (!featureData) {
+  if (!dataset?.hasFeature(newFeatureName)) {
     return;
   }
   featureName = newFeatureName;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,6 @@ const colorRampSelectEl: HTMLSelectElement = document.querySelector("#color_ramp
 const colorRampContainerEl: HTMLDivElement = document.querySelector("#color_ramp_container")!;
 const colorRampMinEl: HTMLLabelElement = document.querySelector("#color_ramp_min")!;
 const colorRampMaxEl: HTMLLabelElement = document.querySelector("#color_ramp_max")!;
-let colorRampMin: number = 0;
-let colorRampMax: number = 0;
 const trackInput: HTMLInputElement = document.querySelector("#trackValue")!;
 const findTrackBtn: HTMLButtonElement = document.querySelector("#findTrackBtn")!;
 const lockRangeCheckbox: HTMLInputElement = document.querySelector("#lock_range_checkbox")!;
@@ -307,29 +305,21 @@ function updateFeature(newFeatureName: string): void {
     return;
   }
   featureName = newFeatureName;
-  // TODO: Decide if feature range should be unlocked when the feature changes.
-  // Don't update the range values when locked
-  if (!lockRangeCheckbox.checked) {
-    colorRampMin = featureData.min;
-    colorRampMax = featureData.max;
-  }
 
-  canv.setFeature(featureData.tex, colorRampMin, colorRampMax);
+  canv.setFeature(featureName);
   canv.render();
   // only update plot if active
   if (selectedTrack) {
     plot.plot(selectedTrack, featureName, timeControls.getCurrentFrame());
   }
-  colorRampMinEl.innerText = `${colorRampMin}`;
-  colorRampMaxEl.innerText = `${colorRampMax}`;
+  colorRampMinEl.innerText = `${canv.getColorMapRangeMin()}`;
+  colorRampMaxEl.innerText = `${canv.getColorMapRangeMax()}`;
 }
 
 function handleLockRangeCheckboxChange(): void {
-  // When the lock is disabled, reset the color ramp min and max to match the
-  // currently selected feature.
-  if (!lockRangeCheckbox.checked) {
-    updateFeature(featureName);
-  }
+  canv.setColorMapRangeLock(lockRangeCheckbox.checked);
+  colorRampMinEl.innerText = `${canv.getColorMapRangeMin()}`;
+  colorRampMaxEl.innerText = `${canv.getColorMapRangeMax()}`;
 }
 
 function handleCanvasClick(event: MouseEvent): void {


### PR DESCRIPTION
Problem
=======
Implements #3, add an option to fix the extremes of the range as the min/max across datasets.

Solution
========
- Adds a checkbox ('Lock Color Map Range') that locks the current min/max range values of the currently selected feature.
- Unchecking the checkbox resets the labels to the range of the currently selected feature.
- When switching datasets, the currently selected feature will remain selected unless there's no equivalent in the new dataset.

## Type of change
* New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/f7a9f21b-5c43-4828-88c3-c90877b643a4)
