### PR TITLE
feat: Editable ranges and masking for color map

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,9 @@
         </div>
         <input type="number" id="color_ramp_max" style="width: 80px; text-align: start;" value="0" min="0"/>
         <input type="checkbox" id="lock_range_checkbox" />
-        <label for="lock_range_checkbox">Lock Color Map Range</label>
+        <label for="lock_range_checkbox">Lock color map range</label>
+        <input type="checkbox" id="mask_range_checkbox" />
+        <label for="mask_range_checkbox">Hide values outside of range</label>
       </div>
     </div>
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -41,11 +41,11 @@
       <label for="feature">Feature</label>
       <select name="Feature" id="feature"></select>
       <div id="labeled_color_ramp">
-        <label for="color_ramp" id="color_ramp_min" style="min-width: 20px; text-align: end;">0.0</label>
+        <input type="number" id="color_ramp_min" style="width: 50px; text-align: start;" value="0" min="0"/>
         <div id="color_ramp_container">
           <span id="color_ramp"></span>
         </div>
-        <label for="color_ramp" id="color_ramp_max">0.0</label>
+        <input type="number" id="color_ramp_max" style="width: 80px; text-align: start;" value="0" min="0"/>
         <input type="checkbox" id="lock_range_checkbox" />
         <label for="lock_range_checkbox">Lock Color Map Range</label>
       </div>

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -37,6 +37,7 @@ type ColorizeUniformTypes = {
   backgroundColor: Color;
   outlierColor: Color;
   highlightedId: number;
+  hideOutOfRange: boolean;
 };
 
 type ColorizeUniforms = { [K in keyof ColorizeUniformTypes]: Uniform<ColorizeUniformTypes[K]> };
@@ -60,6 +61,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
     backgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
     outlierColor: new Uniform(new Color(OUTLIER_COLOR_DEFAULT)),
     highlightedId: new Uniform(-1),
+    hideOutOfRange: new Uniform(false),
   };
 };
 
@@ -79,6 +81,7 @@ export default class ColorizeCanvas {
   private dataset: Dataset | null;
   private featureName: string | null;
   private colorMapRangeLocked: boolean;
+  private hideValuesOutOfRange: boolean;
   private colorMapRangeMin: number;
   private colorMapRangeMax: number;
 
@@ -118,6 +121,7 @@ export default class ColorizeCanvas {
     this.dataset = null;
     this.featureName = null;
     this.colorMapRangeLocked = false;
+    this.hideValuesOutOfRange = false;
     this.colorMapRangeMin = 0;
     this.colorMapRangeMax = 0;
   }
@@ -199,6 +203,15 @@ export default class ColorizeCanvas {
     }
   }
 
+  isColorMapRangeLocked(): boolean {
+    return this.colorMapRangeLocked;
+  }
+
+  setHideValuesOutOfRange(hide: boolean) {
+    this.hideValuesOutOfRange = hide;
+    this.setUniform("hideOutOfRange", this.hideValuesOutOfRange);
+  }
+
   setColorMapRangeMin(newMin: number): void {
     this.colorMapRangeMin = newMin;
     this.colorMapRangeLocked = true;
@@ -217,10 +230,6 @@ export default class ColorizeCanvas {
 
   getColorMapRangeMax(): number {
     return this.colorMapRangeMax;
-  }
-
-  isColorMapRangeLocked(): boolean {
-    return this.colorMapRangeLocked;
   }
 
   async setFrame(index: number): Promise<void> {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -207,7 +207,7 @@ export default class ColorizeCanvas {
     return this.colorMapRangeLocked;
   }
 
-  setHideValuesOutOfRange(hide: boolean) {
+  setHideValuesOutOfRange(hide: boolean): void {
     this.hideValuesOutOfRange = hide;
     this.setUniform("hideOutOfRange", this.hideValuesOutOfRange);
   }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -78,7 +78,7 @@ export default class ColorizeCanvas {
 
   private dataset: Dataset | null;
   private featureName: string | null;
-  private isColorMapRangeLocked: boolean;
+  private colorMapRangeLocked: boolean;
   private colorMapRangeMin: number;
   private colorMapRangeMax: number;
 
@@ -117,7 +117,7 @@ export default class ColorizeCanvas {
 
     this.dataset = null;
     this.featureName = null;
-    this.isColorMapRangeLocked = false;
+    this.colorMapRangeLocked = false;
     this.colorMapRangeMin = 0;
     this.colorMapRangeMax = 0;
   }
@@ -183,7 +183,7 @@ export default class ColorizeCanvas {
     this.setUniform("featureData", featureData.tex);
     // Don't update the range values when locked
     // TODO: Decide if feature range should be unlocked when the feature changes.
-    if (!this.isColorMapRangeLocked) {
+    if (!this.colorMapRangeLocked) {
       this.colorMapRangeMin = featureData.min;
       this.colorMapRangeMax = featureData.max;
     }
@@ -193,10 +193,22 @@ export default class ColorizeCanvas {
   }
 
   setColorMapRangeLock(locked: boolean): void {
-    this.isColorMapRangeLocked = locked;
+    this.colorMapRangeLocked = locked;
     if (this.featureName) {  // trigger update for color map range
       this.setFeature(this.featureName);
     }
+  }
+
+  setColorMapRangeMin(newMin: number): void {
+    this.colorMapRangeMin = newMin;
+    this.colorMapRangeLocked = true;
+    this.setUniform("featureMin", this.colorMapRangeMin);
+  }
+
+  setColorMapRangeMax(newMax: number): void {
+    this.colorMapRangeMax = newMax;
+    this.colorMapRangeLocked = true;
+    this.setUniform("featureMax", this.colorMapRangeMax);
   }
 
   getColorMapRangeMin(): number {
@@ -205,6 +217,10 @@ export default class ColorizeCanvas {
 
   getColorMapRangeMax(): number {
     return this.colorMapRangeMax;
+  }
+
+  isColorMapRangeLocked(): boolean {
+    return this.colorMapRangeLocked;
   }
 
   async setFrame(index: number): Promise<void> {

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -13,6 +13,8 @@ uniform vec3 outlierColor;
 
 uniform int highlightedId;
 
+uniform bool hideOutOfRange;  // bool
+
 in vec2 vUv;
 
 layout(location = 0) out vec4 gOutputColor;
@@ -92,6 +94,10 @@ void main() {
     gOutputColor = vec4(outlierColor, 1.0);
   } else {
     float normFeatureVal = (featureVal - featureMin) / (featureMax - featureMin);
-    gOutputColor = getColorRamp(normFeatureVal);
+    if (hideOutOfRange && (normFeatureVal < 0.0 || normFeatureVal > 1.0)) {
+      gOutputColor = vec4(backgroundColor, 1.0);
+    } else {
+      gOutputColor = getColorRamp(normFeatureVal);
+    }
   }
 }

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -88,14 +88,15 @@ void main() {
   // Data buffer starts at 0, non-background segmentation IDs start at 1
   float featureVal = getFeatureVal(int(id) - 1);
   uint outlierVal = getOutlierVal(int(id) - 1);
+  float normFeatureVal = (featureVal - featureMin) / (featureMax - featureMin);
 
-  if (isinf(featureVal) || outlierVal != 0u) {
-    // outlier
-    gOutputColor = vec4(outlierColor, 1.0);
+  // Mask all values, including outliers, that are outside the range.
+  if (hideOutOfRange && (normFeatureVal < 0.0 || normFeatureVal > 1.0)) {
+    gOutputColor = vec4(backgroundColor, 1.0);
   } else {
-    float normFeatureVal = (featureVal - featureMin) / (featureMax - featureMin);
-    if (hideOutOfRange && (normFeatureVal < 0.0 || normFeatureVal > 1.0)) {
-      gOutputColor = vec4(backgroundColor, 1.0);
+    if (isinf(featureVal) || outlierVal != 0u) {
+      // outlier
+      gOutputColor = vec4(outlierColor, 1.0);
     } else {
       gOutputColor = getColorRamp(normFeatureVal);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,31 +312,32 @@ function updateFeature(newFeatureName: string): void {
   if (selectedTrack) {
     plot.plot(selectedTrack, featureName, timeControls.getCurrentFrame());
   }
-  updateColorRampRangeUI()
+  updateColorRampRangeUI();
 }
 
 function handleHideOutOfRangeCheckboxChange(): void {
   canv.setHideValuesOutOfRange(hideOutOfRangeCheckbox.checked);
+  drawLoop();  // force a render update in case elements should disappear.
 }
 
 function handleLockRangeCheckboxChange(): void {
   canv.setColorMapRangeLock(lockRangeCheckbox.checked);
-  updateColorRampRangeUI()
+  updateColorRampRangeUI();
 }
 
 function handleColorRampMinChanged(): void {
   canv.setColorMapRangeMin(colorRampMinEl.valueAsNumber);
   drawLoop();
-  updateColorRampRangeUI()
+  updateColorRampRangeUI();
 }
 
 function handleColorRampMaxChanged(): void {
   canv.setColorMapRangeMax(colorRampMaxEl.valueAsNumber);
   drawLoop();
-  updateColorRampRangeUI()
+  updateColorRampRangeUI();
 }
 
-function updateColorRampRangeUI() {
+function updateColorRampRangeUI(): void {
   colorRampMinEl.value = `${canv.getColorMapRangeMin()}`;
   colorRampMaxEl.value = `${canv.getColorMapRangeMax()}`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ const datasetSelectEl: HTMLSelectElement = document.querySelector("#dataset")!;
 const featureSelectEl: HTMLSelectElement = document.querySelector("#feature")!;
 const colorRampSelectEl: HTMLSelectElement = document.querySelector("#color_ramp")!;
 const colorRampContainerEl: HTMLDivElement = document.querySelector("#color_ramp_container")!;
-const colorRampMinEl: HTMLLabelElement = document.querySelector("#color_ramp_min")!;
-const colorRampMaxEl: HTMLLabelElement = document.querySelector("#color_ramp_max")!;
+const colorRampMinEl: HTMLInputElement = document.querySelector("#color_ramp_min")!;
+const colorRampMaxEl: HTMLInputElement = document.querySelector("#color_ramp_max")!;
 const trackInput: HTMLInputElement = document.querySelector("#trackValue")!;
 const findTrackBtn: HTMLButtonElement = document.querySelector("#findTrackBtn")!;
 const lockRangeCheckbox: HTMLInputElement = document.querySelector("#lock_range_checkbox")!;
@@ -311,14 +311,29 @@ function updateFeature(newFeatureName: string): void {
   if (selectedTrack) {
     plot.plot(selectedTrack, featureName, timeControls.getCurrentFrame());
   }
-  colorRampMinEl.innerText = `${canv.getColorMapRangeMin()}`;
-  colorRampMaxEl.innerText = `${canv.getColorMapRangeMax()}`;
+  updateColorRampRangeUI()
 }
 
 function handleLockRangeCheckboxChange(): void {
   canv.setColorMapRangeLock(lockRangeCheckbox.checked);
-  colorRampMinEl.innerText = `${canv.getColorMapRangeMin()}`;
-  colorRampMaxEl.innerText = `${canv.getColorMapRangeMax()}`;
+  updateColorRampRangeUI()
+}
+
+function handleColorRampMinChanged(): void {
+  canv.setColorMapRangeMin(colorRampMinEl.valueAsNumber);
+  drawLoop();
+  updateColorRampRangeUI()
+}
+
+function handleColorRampMaxChanged(): void {
+  canv.setColorMapRangeMax(colorRampMaxEl.valueAsNumber);
+  drawLoop();
+  updateColorRampRangeUI()
+}
+
+function updateColorRampRangeUI() {
+  colorRampMinEl.value = `${canv.getColorMapRangeMin()}`;
+  colorRampMaxEl.value = `${canv.getColorMapRangeMax()}`;
 }
 
 function handleCanvasClick(event: MouseEvent): void {
@@ -398,6 +413,8 @@ async function drawLoop(): Promise<void> {
     plot.setTime(timeControls.getCurrentFrame());
     await drawFrame(timeControls.getCurrentFrame());
   }
+
+  lockRangeCheckbox.checked = canv.isColorMapRangeLocked();
 }
 
 async function start(): Promise<void> {
@@ -413,6 +430,8 @@ async function start(): Promise<void> {
   canv.domElement.addEventListener("click", handleCanvasClick);
   findTrackBtn.addEventListener("click", () => handleFindTrack());
   trackInput.addEventListener("change", () => handleFindTrack());
+  colorRampMinEl.addEventListener("change", () => handleColorRampMinChanged());
+  colorRampMaxEl.addEventListener("change", () => handleColorRampMaxChanged());
   lockRangeCheckbox.addEventListener("change", () => handleLockRangeCheckboxChange());
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ const colorRampMaxEl: HTMLInputElement = document.querySelector("#color_ramp_max
 const trackInput: HTMLInputElement = document.querySelector("#trackValue")!;
 const findTrackBtn: HTMLButtonElement = document.querySelector("#findTrackBtn")!;
 const lockRangeCheckbox: HTMLInputElement = document.querySelector("#lock_range_checkbox")!;
+const hideOutOfRangeCheckbox: HTMLInputElement = document.querySelector("#mask_range_checkbox")!;
 
 // time / playback controls
 class TimeControls {
@@ -314,6 +315,10 @@ function updateFeature(newFeatureName: string): void {
   updateColorRampRangeUI()
 }
 
+function handleHideOutOfRangeCheckboxChange(): void {
+  canv.setHideValuesOutOfRange(hideOutOfRangeCheckbox.checked);
+}
+
 function handleLockRangeCheckboxChange(): void {
   canv.setColorMapRangeLock(lockRangeCheckbox.checked);
   updateColorRampRangeUI()
@@ -433,6 +438,7 @@ async function start(): Promise<void> {
   colorRampMinEl.addEventListener("change", () => handleColorRampMinChanged());
   colorRampMaxEl.addEventListener("change", () => handleColorRampMaxChanged());
   lockRangeCheckbox.addEventListener("change", () => handleLockRangeCheckboxChange());
+  hideOutOfRangeCheckbox.addEventListener("change", () => handleHideOutOfRangeCheckboxChange());
 }
 
 window.addEventListener("beforeunload", () => {


### PR DESCRIPTION
Problem
=======
Resolves issue #17, filtering out feature values.

Solution
========
- Adds editable inputs for the min and max fields of the color ramp display, which controls the endpoints of the gradient.
- When either input is modified, the lock range checkbox is checked, preventing the range endpoints from changing when the feature/dataset does.
- Unchecking the lock range checkbox resets the inputs to the default.
- A separate checkbox ("Hide values outside range") masks values (outliers included) that are outside the range.
## Type of change
* New feature (non-breaking change which adds functionality)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/74a2ad4a-2279-42ee-a79f-a5ae5431a923)


