### PR TITLE
feature/load metadata from URL

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -157,7 +157,7 @@ export default class ColorizeCanvas {
     } else {
       this.setUniform("outlierData", packDataTexture([0], FeatureDataType.U8));
     }
-  
+
     // Force load of frame data (clear cached frame data)
     const frame = await this.dataset?.loadFrame(this.currentFrame);
     if (!frame) {
@@ -189,7 +189,7 @@ export default class ColorizeCanvas {
   }
 
   setFeature(name: string): void {
-    if(!this.dataset?.hasFeature(name)) {
+    if (!this.dataset?.hasFeature(name)) {
       return;
     }
     const featureData = this.dataset.getFeatureData(name)!;
@@ -203,7 +203,7 @@ export default class ColorizeCanvas {
     }
     this.setUniform("featureMin", this.colorMapRangeMin);
     this.setUniform("featureMax", this.colorMapRangeMax);
-    this.render();  // re-render necessary because map range may have changed
+    this.render(); // re-render necessary because map range may have changed
   }
 
   setColorMapRangeLock(locked: boolean): void {
@@ -241,7 +241,7 @@ export default class ColorizeCanvas {
       this.setUniform("featureMax", this.colorMapRangeMax);
     }
   }
-  
+
   getColorMapRangeMin(): number {
     return this.colorMapRangeMin;
   }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -25,6 +25,7 @@ import pickFragmentShader from "./shaders/cellId_RGBA8U.frag";
 
 const BACKGROUND_COLOR_DEFAULT = 0xf7f7f7;
 const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;
+export const BACKGROUND_ID = -1;
 
 type ColorizeUniformTypes = {
   aspect: number;

--- a/src/colorizer/TimeControls.ts
+++ b/src/colorizer/TimeControls.ts
@@ -16,11 +16,14 @@ export default class TimeControls {
   private canvas: ColorizeCanvas;
   private isDisabled: boolean;
 
+  private pauseCallbacks: (() => void)[];
+
   constructor(canvas: ColorizeCanvas, redrawfn: () => void) {
     this.redrawfn = redrawfn;
     this.canvas = canvas;
     this.timerId = DEFAULT_TIMER_ID;
     this.isDisabled = false;
+    this.pauseCallbacks = [];
 
     this.playBtn = document.querySelector("#playBtn")!;
     this.pauseBtn = document.querySelector("#pauseBtn")!;
@@ -78,6 +81,7 @@ export default class TimeControls {
   private handlePauseButtonClick(): void {
     clearInterval(this.timerId);
     this.timerId = DEFAULT_TIMER_ID;
+    this.pauseCallbacks.every((callback) => callback());
   }
 
   public async handleFrameAdvance(delta: number = 1): Promise<void> {
@@ -112,6 +116,10 @@ export default class TimeControls {
 
   public isPlaying(): boolean {
     return this.timerId !== -1;
+  }
+
+  public addPauseListener(callback: () => void): void {
+    this.pauseCallbacks.push(callback);
   }
 
   public updateUI(): void {

--- a/src/colorizer/TimeControls.ts
+++ b/src/colorizer/TimeControls.ts
@@ -1,6 +1,7 @@
 import ColorizeCanvas from "./ColorizeCanvas";
 
 // time / playback controls
+const DEFAULT_TIMER_ID = -1;
 export default class TimeControls {
   private playBtn: HTMLButtonElement;
   private pauseBtn: HTMLButtonElement;
@@ -18,7 +19,7 @@ export default class TimeControls {
   constructor(canvas: ColorizeCanvas, redrawfn: () => void) {
     this.redrawfn = redrawfn;
     this.canvas = canvas;
-    this.timerId = 0;
+    this.timerId = DEFAULT_TIMER_ID;
     this.isDisabled = false;
 
     this.playBtn = document.querySelector("#playBtn")!;
@@ -40,7 +41,7 @@ export default class TimeControls {
     const totalFrames = this.canvas.getTotalFrames();
     return (index + totalFrames) % totalFrames;
   }
-  
+
   private clampFrame(index: number): number {
     return Math.min(Math.max(index, 0), this.canvas.getTotalFrames() - 1);
   }
@@ -76,6 +77,7 @@ export default class TimeControls {
 
   private handlePauseButtonClick(): void {
     clearInterval(this.timerId);
+    this.timerId = DEFAULT_TIMER_ID;
   }
 
   public async handleFrameAdvance(delta: number = 1): Promise<void> {
@@ -84,11 +86,11 @@ export default class TimeControls {
   }
 
   private async handleTimeSliderChange(): Promise<void> {
-      if (this.canvas.isValidFrame(this.timeSlider.valueAsNumber)) {
-        await this.canvas.setFrame(this.timeSlider.valueAsNumber);
-        this.timeInput.value = this.timeSlider.value;
-        this.redrawfn();
-      }
+    if (this.canvas.isValidFrame(this.timeSlider.valueAsNumber)) {
+      await this.canvas.setFrame(this.timeSlider.valueAsNumber);
+      this.timeInput.value = this.timeSlider.value;
+      this.redrawfn();
+    }
   }
   private async handleTimeInputChange(): Promise<void> {
     const newFrame = this.clampFrame(this.timeInput.valueAsNumber);
@@ -104,7 +106,12 @@ export default class TimeControls {
     // Disable and clean up playback interval timer
     if (disabled) {
       clearInterval(this.timerId);
+      this.timerId = DEFAULT_TIMER_ID;
     }
+  }
+
+  public isPlaying(): boolean {
+    return this.timerId !== -1;
   }
 
   public updateUI(): void {

--- a/src/colorizer/UrlUtility.ts
+++ b/src/colorizer/UrlUtility.ts
@@ -5,12 +5,12 @@ const URL_PARAM_TIME = "t";
 
 export default class UrlUtility {
   /**
-   * Updates the current URL path of the webpage. If any parameter value is falsy (null), it will not be
+   * Updates the current URL path of the webpage. If any parameter value is null, it will not be
    * included.
-   * @param dataset
-   * @param feature
-   * @param track
-   * @param time
+   * @param dataset string name of the dataset. Null values will be ignored.
+   * @param feature string name of the feature. Null values will be ignored.
+   * @param track integer track number.
+   * @param time integer frame number. Ignores values where `time <= 0`.
    */
   public static updateURL(
     dataset: string | null,
@@ -29,7 +29,7 @@ export default class UrlUtility {
     if (track || track === 0) {
       params.push(`${URL_PARAM_TRACK}=${track}`);
     }
-    if (time) {
+    if (time && time > 0) {
       // time = 0 is ignored because it's the default frame.
       params.push(`${URL_PARAM_TIME}=${time}`);
     }

--- a/src/colorizer/UrlUtility.ts
+++ b/src/colorizer/UrlUtility.ts
@@ -1,0 +1,68 @@
+const URL_PARAM_TRACK = "track";
+const URL_PARAM_DATASET = "dataset";
+const URL_PARAM_FEATURE = "feature";
+const URL_PARAM_TIME = "t";
+
+export default class UrlUtility {
+  /**
+   * Updates the current URL path of the webpage. If any parameter value is falsy (null), it will not be
+   * included.
+   * @param dataset
+   * @param feature
+   * @param track
+   * @param time
+   */
+  public static updateURL(
+    dataset: string | null,
+    feature: string | null,
+    track: number | null,
+    time: number | null
+  ): void {
+    const params: string[] = [];
+    // Get parameters, ignoring null/empty values
+    if (dataset) {
+      params.push(`${URL_PARAM_DATASET}=${dataset}`);
+    }
+    if (feature) {
+      params.push(`${URL_PARAM_FEATURE}=${feature}`);
+    }
+    if (track) {
+      params.push(`${URL_PARAM_TRACK}=${track}`);
+    }
+    if (time) {
+      params.push(`${URL_PARAM_TIME}=${time}`);
+    }
+
+    // If parameters present, join with URL syntax and push into the URL
+    const paramString = params.length > 0 ? "?" + params.join("&") : "";
+    // Use replaceState rather than pushState, because otherwise every frame will be a unique
+    // URL in the browser history
+    window.history.replaceState(null, document.title, paramString);
+  }
+
+  /**
+   * Loads parameters from the current window URL.
+   * @returns An object with a dataset, feature, track, and time parameters.
+   * The dataset and feature parameters are null if no parameter was found in the URL, and the
+   * track and time will have negative values (-1) if no parameter (or an invalid parameter) was found.
+   */
+  public static loadParamsFromUrl(): { dataset: string | null; feature: string | null; track: number; time: number } {
+    // Get params from URL and load, with default fallbacks.
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+
+    const base10Radix = 10; // required for parseInt
+    const datasetParam = urlParams.get(URL_PARAM_DATASET);
+    const featureParam = urlParams.get(URL_PARAM_FEATURE);
+    const trackParam = parseInt(urlParams.get(URL_PARAM_TRACK) || "-1", base10Radix);
+    // This assumes there are no negative timestamps in the dataset
+    const timeParam = parseInt(urlParams.get(URL_PARAM_TIME) || "-1", base10Radix);
+
+    return {
+      dataset: datasetParam,
+      feature: featureParam,
+      track: trackParam,
+      time: timeParam,
+    };
+  }
+}

--- a/src/colorizer/UrlUtility.ts
+++ b/src/colorizer/UrlUtility.ts
@@ -26,10 +26,11 @@ export default class UrlUtility {
     if (feature) {
       params.push(`${URL_PARAM_FEATURE}=${feature}`);
     }
-    if (track) {
+    if (track || track === 0) {
       params.push(`${URL_PARAM_TRACK}=${track}`);
     }
     if (time) {
+      // time = 0 is ignored because it's the default frame.
       params.push(`${URL_PARAM_TIME}=${time}`);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,7 +224,6 @@ async function handleCanvasClick(event: MouseEvent): Promise<void> {
   // Reset track input
   resetTrackUI();
   if (id < 0) {
-    selectedTrack = null;
     plot.removePlot();
     selectedTrack = null; // clear selected track when clicking off of cells
     return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,7 @@ let datasetName = "";
 let datasetOpen = false;
 let featureName = "";
 let selectedTrack: Track | null = null;
+// TODO: Get the first dataset in a manifest JSON?
 const DEFAULT_DATASET = "mama_bear";
 
 async function loadDataset(name: string): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -303,7 +303,9 @@ function updateURL(): void {
 
   // If parameters present, join with URL syntax and push into the URL
   const paramString = params.length > 0 ? "?" + params.join("&") : "";
-  window.history.pushState(null, document.title, paramString);
+  // Use replaceState rather than pushState, because otherwise every frame will be a unique
+  // URL in the browser history
+  window.history.replaceState(null, document.title, paramString);
 }
 
 // SETUP & DRAWING ///////////////////////////////////////////////////////
@@ -383,8 +385,8 @@ async function start(): Promise<void> {
   if (timeParam >= 0) {
     await canv.setFrame(timeParam);
     timeControls.updateUI();
-    await drawLoop(); // Force redraw to show the new frame
   }
+  await drawLoop(); // Force redraw to show the new frame
 
   window.addEventListener("keydown", handleKeyDown);
   datasetSelectEl.addEventListener("change", handleDatasetChange);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { ColorizeCanvas, ColorRamp, Dataset, Track, Plotting } from "./colorizer
 import RecordingControls from "./colorizer/RecordingControls";
 import TimeControls from "./colorizer/TimeControls";
 import UrlUtility from "./colorizer/UrlUtility";
+import { BACKGROUND_ID } from "./colorizer/ColorizeCanvas";
 
 const baseUrl = "http://dev-aics-dtp-001.corp.alleninstitute.org/dan-data/colorizer/data";
 
@@ -222,7 +223,6 @@ function updateColorRampRangeUI(): void {
 async function handleCanvasClick(event: MouseEvent): Promise<void> {
   const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
   console.log("clicked id " + id);
-  canv.setHighlightedId(id - 1);
   // Reset track input
   resetTrackUI();
   if (id < 0) {
@@ -285,7 +285,9 @@ function resetTrackUI(): void {
 
 // URL STATE /////////////////////////////////////////////////////////////
 function updateURL(): void {
-  UrlUtility.updateURL(datasetName, featureName, selectedTrack?.trackId || null, canv.getCurrentFrame());
+  console.log("selectedTrack is :");
+  console.log(selectedTrack);
+  UrlUtility.updateURL(datasetName, featureName, selectedTrack ? selectedTrack.trackId : null, canv.getCurrentFrame());
 }
 
 // SETUP & DRAWING ///////////////////////////////////////////////////////
@@ -298,6 +300,8 @@ async function drawLoop(): Promise<void> {
     if (selectedTrack) {
       const id = selectedTrack.getIdAtTime(canv.getCurrentFrame());
       canv.setHighlightedId(id - 1);
+    } else {
+      canv.setHighlightedId(BACKGROUND_ID); // clear selection
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ async function loadDataset(name: string): Promise<void> {
   featureSelectEl.disabled = false;
 
   await drawLoop();
-
+  updateURL();
   console.timeEnd("loadDataset");
 }
 
@@ -181,6 +181,7 @@ async function updateFeature(newFeatureName: string): Promise<void> {
   }
   updateColorRampRangeUI();
   featureSelectEl.value = featureName;
+  updateURL();
 }
 
 function handleHideOutOfRangeCheckboxChange(): void {
@@ -233,6 +234,7 @@ async function handleCanvasClick(event: MouseEvent): Promise<void> {
     plot.plot(selectedTrack, featureName, canv.getCurrentFrame());
   }
   await drawLoop();
+  updateURL();
 }
 
 function handleColorRampClick({ target }: MouseEvent): void {
@@ -274,6 +276,7 @@ async function findTrack(trackId: number): Promise<void> {
   plot.plot(selectedTrack, featureName, canv.getCurrentFrame());
   await drawLoop();
   trackInput.value = "" + trackId;
+  updateURL();
 }
 
 function resetTrackUI(): void {
@@ -370,6 +373,7 @@ async function start(): Promise<void> {
   hideOutOfRangeCheckbox.addEventListener("change", () => handleHideOutOfRangeCheckboxChange());
   resetRangeBtn.addEventListener("click", handleResetRangeClick);
   recordingControls.setCanvas(canv);
+  timeControls.addPauseListener(updateURL);
 }
 
 window.addEventListener("beforeunload", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,11 +140,9 @@ async function loadDataset(name: string): Promise<void> {
   plot.setDataset(dataset);
   plot.removePlot();
   await canv.setFrame(0);
-
   featureSelectEl.innerHTML = "";
   dataset.featureNames.forEach((feature) => addOptionTo(featureSelectEl, feature));
   featureSelectEl.value = featureName;
-
   datasetOpen = true;
   datasetSelectEl.disabled = false;
   featureSelectEl.disabled = false;
@@ -228,7 +226,7 @@ async function handleCanvasClick(event: MouseEvent): Promise<void> {
   if (id < 0) {
     selectedTrack = null;
     plot.removePlot();
-    selectedTrack = null;
+    selectedTrack = null; // clear selected track when clicking off of cells
     return;
   }
   const trackId = dataset!.getTrackId(id);
@@ -290,9 +288,8 @@ const URL_PARAM_FEATURE = "feature";
 const URL_PARAM_TIME = "t";
 
 function updateURL(): void {
-  // Firs time should push onto state rather than replacing it, so that users can go back to the original page when doing forward/backwards
-  // navigation?
   const params: string[] = [];
+  // Get parameters, ignoring null/empty values
   if (datasetName) {
     params.push(`${URL_PARAM_DATASET}=${datasetName}`);
   }
@@ -304,6 +301,7 @@ function updateURL(): void {
   }
   params.push(`${URL_PARAM_TIME}=${canv.getCurrentFrame()}`);
 
+  // If parameters present, join with URL syntax and push into the URL
   const paramString = params.length > 0 ? "?" + params.join("&") : "";
   window.history.pushState(null, document.title, paramString);
 }
@@ -322,7 +320,6 @@ async function drawLoop(): Promise<void> {
   }
 
   await canv.render();
-
   // Update UI Elements
   timeControls.setIsDisabled(recordingControls.isRecording());
   timeControls.updateUI();
@@ -342,7 +339,7 @@ async function drawLoop(): Promise<void> {
   // update current time in plot
   plot.setTime(canv.getCurrentFrame());
 
-  updateURL();
+  updateURL(); // Update as part of drawloop so that it reflects visual changes to canvas
 }
 
 async function start(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -264,7 +264,7 @@ async function handleFindTrack(): Promise<void> {
   await findTrack(trackInput.valueAsNumber);
 }
 
-async function findTrack(trackId: number) {
+async function findTrack(trackId: number): Promise<void> {
   const newTrack = dataset!.buildTrack(trackId);
 
   if (newTrack.length() < 1) {
@@ -289,10 +289,10 @@ const URL_PARAM_DATASET = "dataset";
 const URL_PARAM_FEATURE = "feature";
 const URL_PARAM_TIME = "t";
 
-function updateURL() {
+function updateURL(): void {
   // Firs time should push onto state rather than replacing it, so that users can go back to the original page when doing forward/backwards
   // navigation?
-  let params: string[] = [];
+  const params: string[] = [];
   if (datasetName) {
     params.push(`${URL_PARAM_DATASET}=${datasetName}`);
   }
@@ -304,7 +304,7 @@ function updateURL() {
   }
   params.push(`${URL_PARAM_TIME}=${canv.getCurrentFrame()}`);
 
-  let paramString = params.length > 0 ? "?" + params.join("&") : "";
+  const paramString = params.length > 0 ? "?" + params.join("&") : "";
   window.history.pushState(null, document.title, paramString);
 }
 
@@ -350,11 +350,12 @@ async function start(): Promise<void> {
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
 
+  const base10Radix = 10;
   const datasetParam = urlParams.get(URL_PARAM_DATASET) || DEFAULT_DATASET;
-  const trackParam = parseInt(urlParams.get(URL_PARAM_TRACK) || "-1");
+  const trackParam = parseInt(urlParams.get(URL_PARAM_TRACK) || "-1", base10Radix);
   const featureParam = urlParams.get(URL_PARAM_FEATURE);
   // Assumes a minimum time of t=0 for the dataset
-  const timeParam = parseInt(urlParams.get(URL_PARAM_TIME) || "-1");
+  const timeParam = parseInt(urlParams.get(URL_PARAM_TIME) || "-1", base10Radix);
 
   setSize();
   populateColorRampSelect();

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,7 +284,7 @@ function resetTrackUI(): void {
 }
 
 // URL STATE /////////////////////////////////////////////////////////////
-function updateURL() {
+function updateURL(): void {
   UrlUtility.updateURL(datasetName, featureName, selectedTrack?.trackId || null, canv.getCurrentFrame());
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -285,8 +285,6 @@ function resetTrackUI(): void {
 
 // URL STATE /////////////////////////////////////////////////////////////
 function updateURL(): void {
-  console.log("selectedTrack is :");
-  console.log(selectedTrack);
   UrlUtility.updateURL(datasetName, featureName, selectedTrack ? selectedTrack.trackId : null, canv.getCurrentFrame());
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -345,15 +345,15 @@ async function drawLoop(): Promise<void> {
 }
 
 async function start(): Promise<void> {
-  // Get params from URL and load instead of defaults
+  // Get params from URL and load, with default fallbacks.
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
 
-  const base10Radix = 10;
+  const base10Radix = 10; // required for parseInt
   const datasetParam = urlParams.get(URL_PARAM_DATASET) || DEFAULT_DATASET;
   const trackParam = parseInt(urlParams.get(URL_PARAM_TRACK) || "-1", base10Radix);
   const featureParam = urlParams.get(URL_PARAM_FEATURE);
-  // Assumes a minimum time of t=0 for the dataset
+  // This assumes there are no negative timestamps in the dataset
   const timeParam = parseInt(urlParams.get(URL_PARAM_TIME) || "-1", base10Radix);
 
   setSize();


### PR DESCRIPTION
Problem
=======
Resolves https://github.com/allen-cell-animated/nucmorph-colorizer/issues/23!

Solution
========
- The URL of nucmorph colorizer now updates with the selected dataset, feature, frame #, and track ID.
- On initial load of the webpage, these same parameters can be pulled from the URL and used to seek to the right dataset/feature/frame/track.
- Some formatting fixes on `ColorizeCanvas.ts` are also included.

Note: There's a possible bug where approximately 25% of the time when loading invalid track IDs, the canvas will freeze on the first render and not update when clicked (even though the rest of the interface will show selected/deselected tracks and the correct timestamp). The canvas resets correctly if the time slider is changed, however. I have not been able to reproduce this since discovering it yesterday.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/cbb4ebf2-14c0-4823-8f19-ab5401c1bfcd)
Example URL: `http://localhost:5173/?dataset=mama_bear&feature=NUC_shape_volume_lcc&track=11018&t=346`
