### PR TITLE
Feature/centroids

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "aicsimageio",
+    "aicspylibczi",
     "numpy",
     "pillow",
     "scikit-image",

--- a/scripts/timelapse-colorizer-data/generate_data.py
+++ b/scripts/timelapse-colorizer-data/generate_data.py
@@ -120,10 +120,10 @@ def make_frames(grouped_frames, output_dir, dataset):
         img = Image.fromarray(seg_rgba)  # new("RGBA", (xres, yres), seg2d)
         img.save(outpath + "/frame_" + str(frame_number) + ".png")
 
-        # Save bounding box to JSON
-        bbox_json = {"data": np.ravel(bbox_data).tolist()}  # flatten to 2D
-        with open(outpath + "/bounds.json", "w") as f:
-            json.dump(bbox_json, f)
+    # Save bounding box to JSON
+    bbox_json = {"data": np.ravel(bbox_data).tolist()}  # flatten to 2D
+    with open(outpath + "/bounds.json", "w") as f:
+        json.dump(bbox_json, f)
 
 
 def make_features(a, features, output_dir, dataset):

--- a/scripts/timelapse-colorizer-data/generate_data.py
+++ b/scripts/timelapse-colorizer-data/generate_data.py
@@ -1,4 +1,3 @@
-import time
 from aicsimageio import AICSImage
 from PIL import Image
 import argparse
@@ -8,6 +7,7 @@ import numpy as np
 import os
 import platform
 import skimage
+import time
 
 from nuc_morph_analysis.utilities.create_base_directories import create_base_directories
 from nuc_morph_analysis.preprocessing.load_data import (


### PR DESCRIPTION
Problem
=======
Closes Issue #13, which requested centroid and bounding box data to be added to the nucmorph-colorizer data format.

Solution
========
- Calculates bounds for each track and saves it to a new `bounds.json` as a 1D array.
- Copies dataset centroids data to a new `centroids.json` as a 1D array.
- The `baby_bear`, `goldilocks`, and `mama_bear` datasets have been updated with the new data.
- Adds improved logging (to stdout and `debug.log`) 
