### PR TITLE
feat: Show hovered feature values

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,18 +78,26 @@ p {
       </div>
     </div>
     <div id="app"></div>
-    <div>Time (use arrow keys)
-      <p style="margin:2px;">
-        <button id="playBtn">Play</button>
-        <button id="pauseBtn">Pause</button>
-        <button id="backBtn">Back</button>
-        <button id="forwardBtn">Forward</button>
-        <input id="timeSlider" type="range" min="0" max="0" step="1" value="0"/><input type="number" id="timeValue" min="0" max="0" value="0"/>
-      </p>
-    </div>
-    <div>Find by track:
-      <input id="trackValue" type="number" value=""/>
-      <button id="findTrackBtn">Find</button>
+    <div style="display: flex; flex-direction: row; gap: 10px;">
+      <div>
+        <div>Time (use arrow keys)
+          <p style="margin:2px;">
+            <button id="playBtn">Play</button>
+            <button id="pauseBtn">Pause</button>
+            <button id="backBtn">Back</button>
+            <button id="forwardBtn">Forward</button>
+            <input id="timeSlider" type="range" min="0" max="0" step="1" value="0"/><input type="number" id="timeValue" min="0" max="0" value="0"/>
+          </p>
+        </div>
+        <div>Find by track:
+          <input id="trackValue" type="number" value=""/>
+          <button id="findTrackBtn">Find</button>
+        </div>
+      </div>
+      <div>
+        <p id="mouse_track_id">Track ID:</p>
+        <p id="mouse_feature_value">Feature:</p>
+      </div>
     </div>
     <div id="plot" style="width:600px;height:250px;"></div>
     <div id="recording_controls_container">

--- a/index.html
+++ b/index.html
@@ -95,8 +95,8 @@ p {
         </div>
       </div>
       <div>
-        <p id="mouse_track_id">Track ID:</p>
-        <p id="mouse_feature_value">Feature:</p>
+        <p id="mouseTrackId">Track ID:</p>
+        <p id="mouseFeatureValue">Feature:</p>
       </div>
     </div>
     <div id="plot" style="width:600px;height:250px;"></div>

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -314,4 +314,12 @@ export default class ColorizeCanvas {
     // offset by 1 since 0 is background.
     return value - 1;
   }
+
+  getFeatureValue(id: number): number {
+    if (!this.featureName || !this.dataset) {
+      return -1;
+    }
+    // Look up feature value from id
+    return this.dataset.getFeatureData(this.featureName)?.data[id] || -1;
+  }
 }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -314,12 +314,4 @@ export default class ColorizeCanvas {
     // offset by 1 since 0 is background.
     return value - 1;
   }
-
-  getFeatureValue(id: number): number {
-    if (!this.featureName || !this.dataset) {
-      return -1;
-    }
-    // Look up feature value from id
-    return this.dataset.getFeatureData(this.featureName)?.data[id] || -1;
-  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,16 +250,24 @@ function handleColorRampClick({ target }: MouseEvent): void {
   canv.render();
 }
 
+function getFeatureValue(id: number): number {
+  if (!featureName || !dataset) {
+    return -1;
+  }
+  // Look up feature value from id
+  return dataset.getFeatureData(featureName)?.data[id] || -1;
+}
+
 function onMouseMove(event: MouseEvent): void {
   if (!dataset) {
     return;
   }
   const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
   if (id === -1) {
-    // Keep last known good value
+    // Ignore background pixels
     return;
   }
-  const value = canv.getFeatureValue(id);
+  const value = getFeatureValue(id);
   const trackId = dataset.getTrackId(id);
   mouseTrackIdLabel.textContent = `Track ID: ${trackId}`;
   mouseFeatureValueLabel.textContent = `Feature: ${value}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -265,7 +265,7 @@ function onMouseMove(event: MouseEvent): void {
   mouseFeatureValueLabel.textContent = `Feature: ${value}`;
 }
 
-function onMouseLeave(event: MouseEvent): void {
+function onMouseLeave(_event: MouseEvent): void {
   // Clear
   mouseTrackIdLabel.textContent = `Track ID:`;
   mouseFeatureValueLabel.textContent = `Feature:`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,8 @@ const findTrackBtn: HTMLButtonElement = document.querySelector("#findTrackBtn")!
 const lockRangeCheckbox: HTMLInputElement = document.querySelector("#lock_range_checkbox")!;
 const hideOutOfRangeCheckbox: HTMLInputElement = document.querySelector("#mask_range_checkbox")!;
 const resetRangeBtn: HTMLButtonElement = document.querySelector("#reset_range_btn")!;
-const mouseTrackIdLabel: HTMLParagraphElement = document.querySelector("#mouse_track_id")!;
-const mouseFeatureValueLabel: HTMLParagraphElement = document.querySelector("#mouse_feature_value")!;
+const mouseTrackIdLabel: HTMLParagraphElement = document.querySelector("#mouseTrackId")!;
+const mouseFeatureValueLabel: HTMLParagraphElement = document.querySelector("#mouseFeatureValue")!;
 
 const timeControls = new TimeControls(canv, drawLoop);
 const recordingControls = new RecordingControls(canv, drawLoop);

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ const findTrackBtn: HTMLButtonElement = document.querySelector("#findTrackBtn")!
 const lockRangeCheckbox: HTMLInputElement = document.querySelector("#lock_range_checkbox")!;
 const hideOutOfRangeCheckbox: HTMLInputElement = document.querySelector("#mask_range_checkbox")!;
 const resetRangeBtn: HTMLButtonElement = document.querySelector("#reset_range_btn")!;
+const mouseTrackIdLabel: HTMLParagraphElement = document.querySelector("#mouse_track_id")!;
+const mouseFeatureValueLabel: HTMLParagraphElement = document.querySelector("#mouse_feature_value")!;
 
 const timeControls = new TimeControls(canv, drawLoop);
 const recordingControls = new RecordingControls(canv, drawLoop);
@@ -222,7 +224,6 @@ function updateColorRampRangeUI(): void {
 
 async function handleCanvasClick(event: MouseEvent): Promise<void> {
   const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
-  console.log("clicked id " + id);
   // Reset track input
   resetTrackUI();
   if (id < 0) {
@@ -247,6 +248,27 @@ function handleColorRampClick({ target }: MouseEvent): void {
     }
   });
   canv.render();
+}
+
+function onMouseMove(event: MouseEvent): void {
+  if (!dataset) {
+    return;
+  }
+  const id = canv.getIdAtPixel(event.offsetX, event.offsetY);
+  if (id === -1) {
+    // Keep last known good value
+    return;
+  }
+  const value = canv.getFeatureValue(id);
+  const trackId = dataset.getTrackId(id);
+  mouseTrackIdLabel.textContent = `Track ID: ${trackId}`;
+  mouseFeatureValueLabel.textContent = `Feature: ${value}`;
+}
+
+function onMouseLeave(event: MouseEvent): void {
+  // Clear
+  mouseTrackIdLabel.textContent = `Track ID:`;
+  mouseFeatureValueLabel.textContent = `Feature:`;
 }
 
 // SCRUBBING CONTROLS ////////////////////////////////////////////////////
@@ -376,6 +398,8 @@ async function start(): Promise<void> {
   resetRangeBtn.addEventListener("click", handleResetRangeClick);
   recordingControls.setCanvas(canv);
   timeControls.addPauseListener(updateURL);
+  canv.domElement.addEventListener("mousemove", onMouseMove);
+  canv.domElement.addEventListener("mouseleave", onMouseLeave);
 }
 
 window.addEventListener("beforeunload", () => {


### PR DESCRIPTION
Problem
=======
Resolves [#22, Show currently hovered cell value](https://github.com/allen-cell-animated/nucmorph-colorizer/issues/22)!

Solution
========
- Adds UI text that shows the currently hovered track and feature values.
- Adds a mouse movement listener that checks the current XY of the mouse when over the canvas.
  - The feature and track boxes show the value of the last hovered cell, ignoring non-cell pixels (background).
  - Upon exiting the canvas, the track and feature value box resets.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/0fd7cc8a-51a6-46db-a0a3-f79ec60e0368)

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/1b7ffade-8426-4b5b-8b21-a6d7663e537a

Questions:
-----------------------
- Should there be a responsive element to hovering? (should cells be highlighted? Is this too many redraws?)
- Should I remove the track information, or reorder it?