### PR TITLE
fix: Hide track path when track completes

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -283,23 +283,19 @@ export default class ColorizeCanvas {
    * frame.
    */
   updateTrackRange(): void {
-    // Do nothing if track doesn't exist or doesn't have centroid data
-    if (!this.track || !this.track.centroids) {
-      return;
-    }
-    if (!this.showTrackPath) {
+    // Show nothing if track doesn't exist or doesn't have centroid data
+    if (!this.track || !this.track.centroids || !this.showTrackPath) {
       this.line.geometry.setDrawRange(0, 0);
       return;
     }
 
     // Show path up to current frame
     const trackFirstFrame = this.track.times[0];
-    const range = this.currentFrame - trackFirstFrame;
+    let range = this.currentFrame - trackFirstFrame;
 
     if (range >= this.track.length() || range < 0) {
       // Hide track if we are outside the track range
-      this.line.geometry.setDrawRange(0, 0);
-      return;
+      range = 0;
     }
 
     this.line.geometry.setDrawRange(0, range);

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -288,13 +288,20 @@ export default class ColorizeCanvas {
       return;
     }
     if (!this.showTrackPath) {
-      // Hide path
       this.line.geometry.setDrawRange(0, 0);
       return;
     }
+
+    // Show path up to current frame
     const trackFirstFrame = this.track.times[0];
-    // Clamp path to track length (don't draw non-existent vertices)
-    const range = Math.min(this.currentFrame - trackFirstFrame, this.track.length());
+    const range = this.currentFrame - trackFirstFrame;
+
+    if (range >= this.track.length()) {
+      // Hide track if we are past the last frame
+      this.line.geometry.setDrawRange(0, 0);
+      return;
+    }
+
     this.line.geometry.setDrawRange(0, range);
   }
 

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -296,8 +296,8 @@ export default class ColorizeCanvas {
     const trackFirstFrame = this.track.times[0];
     const range = this.currentFrame - trackFirstFrame;
 
-    if (range >= this.track.length()) {
-      // Hide track if we are past the last frame
+    if (range >= this.track.length() || range < 0) {
+      // Hide track if we are outside the track range
       this.line.geometry.setDrawRange(0, 0);
       return;
     }


### PR DESCRIPTION
Problem
=======
Request from @toloudis! Track paths are now hidden once the track is completed.

Solution
========
- Adjusted checks in `ColorizeCanvas.ts` for the range of the track that's visible.
