### PR TITLE
feat: Color Map reversing, URL saving

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,8 +107,10 @@ function App(): ReactElement {
       feature: featureName,
       track: selectedTrack?.trackId,
       time: currentFrame,
+      colorRamp: colorRampKey,
+      colorRampReversed: colorRampReversed,
     });
-  }, [collection, datasetKey, dataset, featureName, selectedTrack, currentFrame]);
+  }, [collection, datasetKey, dataset, featureName, selectedTrack, currentFrame, colorRampKey, colorRampReversed]);
 
   // Update url whenever the viewer settings change
   // (but not while playing/recording for performance reasons)
@@ -152,6 +154,17 @@ function App(): ReactElement {
   const initialUrlParams = useConstructor(() => {
     return urlUtils.loadParamsFromUrl();
   });
+
+  // Load URL parameters into the state that don't require a dataset to be loaded.
+  // This reduces flicker on initial load.
+  useEffect(() => {
+    if (initialUrlParams.colorRamp) {
+      setColorRampKey(initialUrlParams.colorRamp);
+    }
+    if (initialUrlParams.colorRampReversed) {
+      setColorRampReversed(initialUrlParams.colorRampReversed);
+    }
+  }, []);
 
   // Attempt to load database and collections data from the URL.
   // This is memoized so that it only runs one time on startup.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -414,6 +414,10 @@ function App(): ReactElement {
   const disableUi: boolean = isRecording || !datasetOpen;
   const disableTimeControlsUi = disableUi;
 
+  let colorRamp = colorRampData.get(colorRampKey)?.colorRamp;
+  if (colorRampReversed && colorRamp) {
+    colorRamp = colorRamp.reverse();
+  }
   const featureUnits = dataset?.getFeatureUnits(featureName) || "";
 
   return (
@@ -530,7 +534,7 @@ function App(): ReactElement {
                 showTrackPath={showTrackPath}
                 outOfRangeDrawSettings={outOfRangeDrawSettings}
                 outlierDrawSettings={outlierDrawSettings}
-                colorRamp={colorRampData.get(colorRampKey)?.colorRamp!}
+                colorRamp={colorRamp!}
                 colorRampMin={colorRampMin}
                 colorRampMax={colorRampMax}
                 selectedTrack={selectedTrack}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ import PlotWrapper from "./components/PlotWrapper";
 import SpinBox from "./components/SpinBox";
 import { DEFAULT_COLLECTION_PATH, DEFAULT_COLOR_RAMPS, DEFAULT_COLOR_RAMP_ID, DEFAULT_PLAYBACK_FPS } from "./constants";
 import FeatureThresholdPanel from "./components/FeatureThresholdPanel";
-import { thresholdMatchFinder } from "./colorizer/utils/data_utils";
+import { getColorMap, thresholdMatchFinder } from "./colorizer/utils/data_utils";
 
 function App(): ReactElement {
   // STATE INITIALIZATION /////////////////////////////////////////////////////////
@@ -188,7 +188,8 @@ function App(): ReactElement {
   // Load URL parameters into the state that don't require a dataset to be loaded.
   // This reduces flicker on initial load.
   useEffect(() => {
-    if (initialUrlParams.colorRampKey) {
+    // Load the currently selected color ramp info from the URL, if it exists.
+    if (initialUrlParams.colorRampKey && colorRampData.has(initialUrlParams.colorRampKey)) {
       setColorRampKey(initialUrlParams.colorRampKey);
     }
     if (initialUrlParams.colorRampReversed) {
@@ -467,10 +468,6 @@ function App(): ReactElement {
   const disableUi: boolean = isRecording || !datasetOpen;
   const disableTimeControlsUi = disableUi;
 
-  let colorRamp = colorRampData.get(colorRampKey)?.colorRamp;
-  if (colorRampReversed && colorRamp) {
-    colorRamp = colorRamp.reverse();
-  }
   // Show min + max marks on the color ramp slider if a feature is selected and
   // is currently being thresholded/filtered on.
   const getColorMapSliderMarks = (): undefined | number[] => {
@@ -602,7 +599,7 @@ function App(): ReactElement {
                 showTrackPath={showTrackPath}
                 outOfRangeDrawSettings={outOfRangeDrawSettings}
                 outlierDrawSettings={outlierDrawSettings}
-                colorRamp={colorRamp!}
+                colorRamp={getColorMap(colorRampData, colorRampKey, colorRampReversed)}
                 colorRampMin={colorRampMin}
                 colorRampMax={colorRampMax}
                 selectedTrack={selectedTrack}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ function App(): ReactElement {
       feature: featureName,
       track: selectedTrack?.trackId,
       time: currentFrame,
-      colorRamp: colorRampKey,
+      colorRampKey: colorRampKey,
       colorRampReversed: colorRampReversed,
     });
   }, [collection, datasetKey, dataset, featureName, selectedTrack, currentFrame, colorRampKey, colorRampReversed]);
@@ -188,8 +188,8 @@ function App(): ReactElement {
   // Load URL parameters into the state that don't require a dataset to be loaded.
   // This reduces flicker on initial load.
   useEffect(() => {
-    if (initialUrlParams.colorRamp) {
-      setColorRampKey(initialUrlParams.colorRamp);
+    if (initialUrlParams.colorRampKey) {
+      setColorRampKey(initialUrlParams.colorRampKey);
     }
     if (initialUrlParams.colorRampReversed) {
       setColorRampReversed(initialUrlParams.colorRampReversed);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ function App(): ReactElement {
 
   const colorRampData = DEFAULT_COLOR_RAMPS;
   const [colorRampKey, setColorRampKey] = useState(DEFAULT_COLOR_RAMP_ID);
+  const [colorRampReversed, setColorRampReversed] = useState(false);
   const [colorRampMin, setColorRampMin] = useState(0);
   const [colorRampMax, setColorRampMax] = useState(0);
   const [outOfRangeDrawSettings, setoutOfRangeDrawSettings] = useState({
@@ -446,7 +447,15 @@ function App(): ReactElement {
             }}
           />
 
-          <ColorRampDropdown selected={colorRampKey} onChange={(name) => setColorRampKey(name)} disabled={disableUi} />
+          <ColorRampDropdown
+            selected={colorRampKey}
+            reversed={colorRampReversed}
+            onChange={(name, reversed) => {
+              setColorRampKey(name);
+              setColorRampReversed(reversed);
+            }}
+            disabled={disableUi}
+          />
         </div>
         <div className={styles.headerRight}>
           <Button type="link" className={styles.copyUrlButton} onClick={openCopyNotification}>

--- a/src/colorizer/ColorRamp.ts
+++ b/src/colorizer/ColorRamp.ts
@@ -67,4 +67,12 @@ export default class ColorRamp {
     const maxColor = new Color(this.colorStops[maxIndex]);
     return minColor.lerp(maxColor, tNormalized);
   }
+
+  /**
+   * Returns a new ColorRamp object with a reversed gradient.
+   */
+  public reverse(): ColorRamp {
+    const newColorStops = [...this.colorStops].reverse();
+    return new ColorRamp(newColorStops);
+  }
 }

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -1,3 +1,5 @@
+import { ColorRampData } from "../../constants";
+import ColorRamp from "../ColorRamp";
 import { FeatureThreshold } from "../ColorizeCanvas";
 
 /**
@@ -16,4 +18,15 @@ export function thresholdMatchFinder(
   unit: string | undefined
 ): (threshold: FeatureThreshold) => boolean {
   return (threshold: FeatureThreshold) => threshold.featureName === featureName && threshold.unit === unit;
+}
+
+/**
+ * Convenience method for getting a single ramp from a map of strings to ramps, optionally reversing it.
+ */
+export function getColorMap(colorRampData: Map<string, ColorRampData>, key: string, reversed = false): ColorRamp {
+  const colorRamp = colorRampData.get(key)?.colorRamp;
+  if (!colorRamp) {
+    throw new Error("Could not find data for color ramp '" + key + "'");
+  }
+  return colorRamp && reversed ? colorRamp.reverse() : colorRamp;
 }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -93,7 +93,7 @@ export function stateToUrlParamString(state: Partial<UrlParams>): string {
   }
   if (colorRamp) {
     if (colorRampReversed) {
-      includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent("!" + colorRamp)}`);
+      includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp + "!")}`);
     } else {
       includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp)}`);
     }
@@ -177,10 +177,10 @@ export function loadParamsFromUrl(): UrlParams {
   const colorRampRawParam = safeDecodeString(urlParams.get(URL_PARAM_COLOR_RAMP));
   let colorRampParam: string | null = colorRampRawParam;
   let colorRampReversedParam: boolean = false;
-  //  Color ramps are marked as reversed by adding ! to the start of the key
-  if (colorRampRawParam && colorRampRawParam.charAt(0) === "!") {
+  //  Color ramps are marked as reversed by adding ! to the end of the key
+  if (colorRampRawParam && colorRampRawParam.charAt(colorRampRawParam.length - 1) === "!") {
     colorRampReversedParam = true;
-    colorRampParam = colorRampRawParam.slice(1);
+    colorRampParam = colorRampRawParam.slice(0, -1);
   }
 
   return {

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -9,6 +9,7 @@ const URL_PARAM_FEATURE = "feature";
 const URL_PARAM_TIME = "t";
 const URL_PARAM_COLLECTION = "collection";
 const URL_PARAM_COLOR_RAMP = "color";
+const URL_COLOR_RAMP_REVERSED_SUFFIX = "!";
 
 export type UrlParams = {
   collection: string | null;
@@ -93,7 +94,9 @@ export function stateToUrlParamString(state: Partial<UrlParams>): string {
   }
   if (colorRamp) {
     if (colorRampReversed) {
-      includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp + "!")}`);
+      includedParameters.push(
+        `${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp + URL_COLOR_RAMP_REVERSED_SUFFIX)}`
+      );
     } else {
       includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp)}`);
     }
@@ -178,7 +181,7 @@ export function loadParamsFromUrl(): UrlParams {
   let colorRampParam: string | null = colorRampRawParam;
   let colorRampReversedParam: boolean = false;
   //  Color ramps are marked as reversed by adding ! to the end of the key
-  if (colorRampRawParam && colorRampRawParam.charAt(colorRampRawParam.length - 1) === "!") {
+  if (colorRampRawParam && colorRampRawParam.charAt(colorRampRawParam.length - 1) === URL_COLOR_RAMP_REVERSED_SUFFIX) {
     colorRampReversedParam = true;
     colorRampParam = colorRampRawParam.slice(0, -1);
   }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -17,7 +17,7 @@ export type UrlParams = {
   feature: string | null;
   track: number;
   time: number;
-  colorRamp: string | null;
+  colorRampKey: string | null;
   colorRampReversed: boolean | null;
 };
 
@@ -69,7 +69,7 @@ export function stateToUrlParamString(state: Partial<UrlParams>): string {
 
   // Get parameters, ignoring null/empty values
   const includedParameters: string[] = [];
-  const { collection, dataset, feature, track, time, colorRamp, colorRampReversed } = state;
+  const { collection, dataset, feature, track, time, colorRampKey, colorRampReversed } = state;
 
   // Don't include collection parameter in URL if it matches the default.
   if (
@@ -92,13 +92,13 @@ export function stateToUrlParamString(state: Partial<UrlParams>): string {
     // time = 0 is ignored because it's the default frame.
     includedParameters.push(`${URL_PARAM_TIME}=${time}`);
   }
-  if (colorRamp) {
+  if (colorRampKey) {
     if (colorRampReversed) {
       includedParameters.push(
-        `${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp + URL_COLOR_RAMP_REVERSED_SUFFIX)}`
+        `${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRampKey + URL_COLOR_RAMP_REVERSED_SUFFIX)}`
       );
     } else {
-      includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRamp)}`);
+      includedParameters.push(`${URL_PARAM_COLOR_RAMP}=${encodeURIComponent(colorRampKey)}`);
     }
   }
 
@@ -192,7 +192,7 @@ export function loadParamsFromUrl(): UrlParams {
     feature: featureParam,
     track: trackParam,
     time: timeParam,
-    colorRamp: colorRampParam,
+    colorRampKey: colorRampParam,
     colorRampReversed: colorRampReversedParam,
   };
 }

--- a/src/components/ColorRampDropdown.module.css
+++ b/src/components/ColorRampDropdown.module.css
@@ -3,7 +3,6 @@
   --height: var(--button-height);
   height: var(--height);
   flex-direction: row;
-  gap: 6px;
   align-items: center;
 }
 

--- a/src/components/ColorRampDropdown.tsx
+++ b/src/components/ColorRampDropdown.tsx
@@ -3,12 +3,15 @@ import styles from "./ColorRampDropdown.module.css";
 import { DEFAULT_COLOR_RAMPS } from "../constants/color_ramps";
 import { Button, Tooltip } from "antd";
 import { AppThemeContext } from "./AppStyle";
+import IconButton from "./IconButton";
+import { RetweetOutlined } from "@ant-design/icons";
 
 type ColorRampSelectorProps = {
   selected: string;
-  onChange: (colorRampKey: string) => void;
+  onChange: (colorRampKey: string, reversed: boolean) => void;
   colorRamps?: typeof DEFAULT_COLOR_RAMPS;
   disabled?: boolean;
+  reversed?: boolean;
 };
 
 const defaultProps: Partial<ColorRampSelectorProps> = {
@@ -66,7 +69,7 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
   const selectedRamp = selectedRampData.colorRamp;
   const selectedRampColorUrl = useMemo(() => {
     return selectedRamp.createGradientCanvas(120, theme.controls.height).toDataURL();
-  }, [props.selected]);
+  }, [props.selected, props.reversed]);
 
   // Memoize to avoid recalculating dropdown contents
   const dropdownContents: ReactElement[] = useMemo(() => {
@@ -78,7 +81,7 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
       const [key, colorRampData] = colorRampEntries[i];
       contents.push(
         <Tooltip title={colorRampData.name} placement="right" key={key} trigger={["hover", "focus"]}>
-          <Button key={key} onClick={() => props.onChange(key)} rootClassName={styles.dropdownButton}>
+          <Button key={key} onClick={() => props.onChange(key, props.reversed)} rootClassName={styles.dropdownButton}>
             <img src={colorRampData.colorRamp.createGradientCanvas(120, theme.controls.height).toDataURL()} />
           </Button>
         </Tooltip>
@@ -95,7 +98,7 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
   return (
     <div className={styles.colorRampSelector} ref={componentContainerRef}>
       <h3>Color map</h3>
-      <div className={buttonDivClassName}>
+      <div className={buttonDivClassName} style={{ marginLeft: "6px" }}>
         <Tooltip
           // Force the tooltip to be hidden (open=false) when disabled
           open={props.disabled ? false : undefined}
@@ -109,6 +112,16 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
         </Tooltip>
         <div className={dropdownContainerClassName}>{dropdownContents}</div>
       </div>
+      <IconButton
+        style={{ marginLeft: "2px" }}
+        type="link"
+        disabled={props.disabled}
+        onClick={() => {
+          props.onChange(props.selected, !props.reversed);
+        }}
+      >
+        <RetweetOutlined />
+      </IconButton>
     </div>
   );
 };

--- a/src/components/ColorRampDropdown.tsx
+++ b/src/components/ColorRampDropdown.tsx
@@ -66,7 +66,10 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
   ///////// Generate dropdown contents
 
   // Only regenerate the gradient canvas URL if the selected ramp changes!
-  const selectedRamp = selectedRampData.colorRamp;
+  let selectedRamp = selectedRampData.colorRamp;
+  if (props.reversed) {
+    selectedRamp = selectedRamp.reverse();
+  }
   const selectedRampColorUrl = useMemo(() => {
     return selectedRamp.createGradientCanvas(120, theme.controls.height).toDataURL();
   }, [props.selected, props.reversed]);
@@ -81,7 +84,7 @@ const ColorRampSelector: React.FC<ColorRampSelectorProps> = (propsInput): ReactE
       const [key, colorRampData] = colorRampEntries[i];
       contents.push(
         <Tooltip title={colorRampData.name} placement="right" key={key} trigger={["hover", "focus"]}>
-          <Button key={key} onClick={() => props.onChange(key, props.reversed)} rootClassName={styles.dropdownButton}>
+          <Button key={key} onClick={() => props.onChange(key, false)} rootClassName={styles.dropdownButton}>
             <img src={colorRampData.colorRamp.createGradientCanvas(120, theme.controls.height).toDataURL()} />
           </Button>
         </Tooltip>

--- a/src/components/ColorRampDropdown.tsx
+++ b/src/components/ColorRampDropdown.tsx
@@ -1,10 +1,11 @@
 import React, { ReactElement, useContext, useEffect, useMemo, useState } from "react";
+import { Button, Tooltip } from "antd";
+import { RetweetOutlined } from "@ant-design/icons";
+
 import styles from "./ColorRampDropdown.module.css";
 import { DEFAULT_COLOR_RAMPS } from "../constants/color_ramps";
-import { Button, Tooltip } from "antd";
 import { AppThemeContext } from "./AppStyle";
 import IconButton from "./IconButton";
-import { RetweetOutlined } from "@ant-design/icons";
 
 type ColorRampSelectorProps = {
   selected: string;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -6,7 +6,8 @@ import styled, { css } from "styled-components";
 type IconButtonProps = {
   onClick?: () => void;
   disabled?: boolean;
-  type?: "outlined" | "primary";
+  style?: React.CSSProperties;
+  type?: "outlined" | "primary" | "link";
 };
 
 // Button styling varies based on the type (outlined vs. primary)
@@ -32,6 +33,20 @@ const StyledButton = styled(Button)<{ $type: IconButtonProps["type"] }>`
           &:disabled {
             border: 1px solid var(--color-borders);
             background-color: var(--color-button-disabled);
+            color: var(--color-text-disabled);
+            fill: var(--color-text-disabled);
+          }
+        `;
+      case "link":
+        return css`
+          border: 0;
+          background-color: transparent;
+          color: var(--color-button);
+          fill: var(--color-button);
+
+          &:disabled {
+            border: 0;
+            background-color: transparent;
             color: var(--color-text-disabled);
             fill: var(--color-text-disabled);
           }
@@ -86,7 +101,13 @@ export default function IconButton(props: PropsWithChildren<IconButtonProps>): R
 
   return (
     <ConfigProvider theme={{ components: { Button: { colorPrimaryActive: themeContext.color.button.hover } } }}>
-      <StyledButton type="primary" $type={props.type || "primary"} disabled={props.disabled} onClick={props.onClick}>
+      <StyledButton
+        type="primary"
+        $type={props.type || "primary"}
+        disabled={props.disabled}
+        onClick={props.onClick}
+        style={props.style}
+      >
         {props.children}
       </StyledButton>
     </ConfigProvider>

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,7 +1,8 @@
 import React, { PropsWithChildren, ReactElement, useContext } from "react";
 import { Button, ConfigProvider } from "antd";
-import { AppThemeContext } from "./AppStyle";
 import styled, { css } from "styled-components";
+
+import { AppThemeContext } from "./AppStyle";
 
 type IconButtonProps = {
   onClick?: () => void;

--- a/tests/ColorRampDropdown.test.tsx
+++ b/tests/ColorRampDropdown.test.tsx
@@ -34,14 +34,19 @@ describe("ColorRampDropdown", () => {
     const elements = screen.getAllByRole("button");
 
     // Expect maps to be ordered according to the color ramp, and skip the first button which is the main selector.
-    for (let i = 1; i < elements.length; i++) {
+    for (let i = 1; i < elements.length - 1; i++) {
+      // Ignore the last button, which is for reversing
       const buttonElement = elements[i];
       fireEvent.click(buttonElement);
     }
 
     // Should be called three times, in order, one time for each element.
     expect(mockCallback.mock.calls.length).to.equal(3);
-    expect(mockCallback.mock.calls).deep.equals([["map1"], ["map2"], ["map3"]]);
+    expect(mockCallback.mock.calls).deep.equals([
+      ["map1", false],
+      ["map2", false],
+      ["map3", false],
+    ]);
   });
 
   it("throws an error when the selected key is invalid", () => {


### PR DESCRIPTION
Problem
=======
Closes #84 and #82! 

Solution
========
Adds the UI and plumbing to support reversing the color map, as well as saving to and loading the color map from the URL (and whether it's reversed).

Note that if you switch color map, the new map will not be reversed (e.g. resets when swapping maps).


## Type of change
* New feature (non-breaking change which adds functionality)

## Testing
- Open the link, change to a different color map, and then hit the reversal button next to the map.
- Copy the URL and paste it into a new tab. The same color map should be applied.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/c33ac0ab-505f-4934-946e-a5d75db2f058)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/b29e2812-412c-4320-81f2-38c3a98ad8e4)

