### PR TITLE
feat: Disabling feature thresholds

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "arrowParens": "always",
   "jsxBracketSameLine": false,
-  "printWidth": 120,
+  "printWidth": 80,
   "trailingComma": "es5",
   "tabWidth": 2
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "arrowParens": "always",
   "jsxBracketSameLine": false,
-  "printWidth": 80,
+  "printWidth": 100,
   "trailingComma": "es5",
   "tabWidth": 2
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "arrowParens": "always",
   "jsxBracketSameLine": false,
-  "printWidth": 100,
+  "printWidth": 120,
   "trailingComma": "es5",
   "tabWidth": 2
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -329,6 +329,7 @@ function App(): ReactElement {
       }
 
       setCollection(newCollection);
+      setFeatureThresholds([]); // Clear when switching collections
       await replaceDataset(loadResult.dataset, newDatasetKey);
     },
     [replaceDataset]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import PlotWrapper from "./components/PlotWrapper";
 import SpinBox from "./components/SpinBox";
 import { DEFAULT_COLLECTION_PATH, DEFAULT_COLOR_RAMPS, DEFAULT_COLOR_RAMP_ID, DEFAULT_PLAYBACK_FPS } from "./constants";
 import FeatureThresholdPanel from "./components/FeatureThresholdPanel";
+import { thresholdMatchFinder } from "./colorizer/utils/data_utils";
 
 function App(): ReactElement {
   // STATE INITIALIZATION /////////////////////////////////////////////////////////
@@ -79,14 +80,15 @@ function App(): ReactElement {
   const setFeatureThresholds = useCallback(
     // Change the current feature min + max on the color ramp if that feature's threshold moved.
     (newThresholds: FeatureThreshold[]): void => {
-      // Check if the current feature name is being thresholded on, and if that threshold
+      // Check if the current feature is being thresholded on, and if that threshold
       // has changed. If so, snap the current min + max color ramp values so they match the new
       // threshold values.
-      const currThreshold = featureThresholds.find((t) => t.featureName === featureName);
-      const newThreshold = newThresholds.find((t) => t.featureName === featureName);
+      const featureData = dataset?.getFeatureData(featureName);
+      if (featureData) {
+        const oldThreshold = featureThresholds.find(thresholdMatchFinder(featureName, featureData.units));
+        const newThreshold = newThresholds.find(thresholdMatchFinder(featureName, featureData.units));
 
-      if (newThreshold && currThreshold) {
-        if (newThreshold.min !== currThreshold.min || newThreshold.max !== currThreshold.max) {
+        if (newThreshold && oldThreshold) {
           setColorRampMin(newThreshold.min);
           setColorRampMax(newThreshold.max);
         }
@@ -347,7 +349,7 @@ function App(): ReactElement {
       if (!isColorRampRangeLocked && featureData) {
         // Use min/max from threshold if there is a matching one, otherwise use feature min/max
         // TODO: Update this with units later
-        const threshold = featureThresholds.find((t) => t.featureName === newFeatureName);
+        const threshold = featureThresholds.find(thresholdMatchFinder(newFeatureName, featureData.units));
         if (threshold) {
           setColorRampMin(threshold.min);
           setColorRampMax(threshold.max);
@@ -454,10 +456,11 @@ function App(): ReactElement {
   // Show min + max marks on the color ramp slider if a feature is selected and
   // is currently being thresholded/filtered on.
   const getColorMapSliderMarks = (): undefined | number[] => {
-    if (!featureName || featureThresholds.length === 0) {
+    const featureData = dataset?.getFeatureData(featureName);
+    if (!featureData || featureThresholds.length === 0) {
       return undefined;
     }
-    const threshold = featureThresholds.find((value) => value.featureName === featureName);
+    const threshold = featureThresholds.find(thresholdMatchFinder(featureName, featureData.units));
     if (!threshold) {
       return undefined;
     }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -98,6 +98,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
 
 export type FeatureThreshold = {
   featureName: string;
+  unit: string | undefined;
   min: number;
   max: number;
 };

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -401,7 +401,8 @@ export default class ColorizeCanvas {
 
     for (const threshold of thresholds) {
       const featureData = this.dataset.getFeatureData(threshold.featureName);
-      if (!featureData) {
+      // Ignore thresholds with features that don't exist in this dataset or whose units don't match
+      if (!featureData || featureData.units !== threshold.unit) {
         continue;
       }
       for (let i = 0, n = inRangeIds.length; i < n; i++) {

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -1,0 +1,19 @@
+import { FeatureThreshold } from "../ColorizeCanvas";
+
+/**
+ * Generates a find function for a FeatureThreshold, matching on feature name and unit.
+ * @param featureName String feature name to match on.
+ * @param unit String unit to match on. If undefined, will match on thresholds with undefined units only.
+ * @returns a lambda function that can be passed into `Array.find` for an array of FeatureThreshold.
+ * @example
+ * ```
+ * const featureThresholds = [...]
+ * const matchThreshold = featureThresholds.find(thresholdMatchFinder("Temperature", "°C"));
+ * ```
+ */
+export function thresholdMatchFinder(
+  featureName: string,
+  unit: string | undefined
+): (threshold: FeatureThreshold) => boolean {
+  return (threshold: FeatureThreshold) => threshold.featureName === featureName && threshold.unit === unit;
+}

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -192,7 +192,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     // If the feature is no longer in the dataset, use the saved min/max bounds.
     const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [0, 1];
     const sliderMin = disabled ? savedMinMax[0] : featureData.min;
-    const sliderMax = disabled ? savedMinMax[1] : featureData!.max;
+    const sliderMax = disabled ? savedMinMax[1] : featureData.max;
 
     const featureLabel = item.unit ? `${item.featureName} (${item.unit})` : item.featureName;
 

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -117,7 +117,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
       } else {
         const featureData = props.dataset?.features[featureName];
         if (featureData) {
-          newThresholds.push({
+          newThresholds.unshift({
             featureName,
             min: featureData.min,
             max: featureData.max,

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -9,6 +9,7 @@ import { FeatureThreshold } from "../colorizer/ColorizeCanvas";
 import LabeledRangeSlider from "./LabeledRangeSlider";
 import { Dataset } from "../colorizer";
 import IconButton from "./IconButton";
+import { thresholdMatchFinder } from "../colorizer/utils/data_utils";
 
 const PanelContainer = styled.div`
   flex-grow: 1;
@@ -139,9 +140,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     const featureData = props.dataset?.features[featureName];
     const newThresholds = [...props.featureThresholds];
     if (featureData) {
-      const index = props.featureThresholds.findIndex(
-        (t) => t.featureName === featureName && t.unit === featureData.units
-      );
+      const index = props.featureThresholds.findIndex(thresholdMatchFinder(featureName, featureData.units));
       if (index !== -1) {
         // Delete saved min/max bounds for this feature
         const thresholdToRemove = props.featureThresholds[index];

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode, useContext, useMemo, useRef } from "react";
 import { FeatureThreshold } from "../colorizer/ColorizeCanvas";
 import { Dataset } from "../colorizer";
-import { Card, List, Select, Tooltip } from "antd";
+import { Button, Card, List, Select, Tooltip } from "antd";
 import styled from "styled-components";
 import LabeledRangeSlider from "./LabeledRangeSlider";
 import { CloseOutlined, FilterOutlined } from "@ant-design/icons";
@@ -14,6 +14,17 @@ const PanelContainer = styled.div`
   flex-direction: column;
   gap: 6px;
   height: 100%;
+`;
+
+const SelectContainer = styled.div`
+  & .ant-select-selector {
+    padding: 0 2px;
+  }
+
+  & .ant-select-item-option-content {
+    font-weight: normal;
+    color: var(--color-button);
+  }
 `;
 
 const FiltersCard = styled(Card)`
@@ -51,6 +62,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   const props = { ...defaultProps, ...inputProps } as Required<FeatureThresholdPanelProps>;
   const theme = useContext(AppThemeContext);
 
+  const selectContainerRef = useRef<HTMLDivElement>(null);
   // Save the min/max values of each selected feature in case the user switches to a dataset that no longer has
   // that feature. This allows the user to switch back to the original dataset and keep the same thresholds.
   const featureMinMax = useRef<Map<string, [number, number]>>(new Map());
@@ -157,15 +169,20 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
 
   return (
     <PanelContainer>
-      <Select
-        style={{ width: "100%" }}
-        mode="multiple"
-        placeholder="Add features"
-        onChange={onSelectionsChanged}
-        value={selectedFeatures}
-        options={featureOptions}
-        disabled={props.disabled}
-      />
+      <SelectContainer ref={selectContainerRef}>
+        <Select
+          style={{ width: "100%" }}
+          allowClear
+          mode="multiple"
+          placeholder="Add features"
+          onChange={onSelectionsChanged}
+          value={selectedFeatures}
+          options={featureOptions}
+          disabled={props.disabled}
+          onClear={() => props.onChange([])}
+          getPopupContainer={() => selectContainerRef.current!}
+        />
+      </SelectContainer>
       <FiltersCard size="small" style={{ paddingTop: 0 }}>
         <List
           renderItem={renderListItems}

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -131,7 +131,8 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   };
 
   ////// RENDERING ///////////////////
-
+  // TODO: Possible bug where selected features with the same name but different units across datasets will use the same filter values.
+  // This is unlikely to be a problem because collections are expected to have similar datasets.
   const selectedFeatures = props.featureThresholds.map((t) => t.featureName);
   const featureOptions =
     props.dataset?.featureNames.map((name) => ({ label: props.dataset?.getFeatureNameWithUnits(name), value: name })) ||

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -81,7 +81,8 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   const selectContainerRef = useRef<HTMLDivElement>(null);
 
   // Save the min/max values of each selected feature in case the user switches to a dataset that no longer has
-  // that feature. This allows the user to switch back to the original dataset and keep the same thresholds.
+  // that feature. This allows the sliders to be rendered with the same bounds as before until the user switches
+  // back to a dataset that has the feature.
   const featureMinMax = useRef<Map<string, [number, number]>>(new Map());
   useMemo(() => {
     // Update the saved min/max bounds of any selected features.
@@ -138,11 +139,11 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
 
   const renderListItems = (item: FeatureThreshold, index: number): ReactNode => {
     const featureData = props.dataset?.features[item.featureName];
-    const disabled = featureData === undefined;
     const savedMinMax = featureMinMax.current.get(item.featureName) || [0, 1];
     // If the feature is no longer in the dataset, use the saved min/max bounds.
     const sliderMin = featureData ? featureData.min : savedMinMax[0];
     const sliderMax = featureData ? featureData.max : savedMinMax[1];
+    const disabled = featureData === undefined;
 
     return (
       <List.Item style={{ position: "relative" }}>

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -193,6 +193,11 @@ export default function FeatureThresholdPanel(
     );
   };
 
+  // TODO: Using Select here can cause layout issues. If many features are selected (such that the Select bar is full)
+  // and the user is using a narrower window, switching to/from the Plot panel can cause the whole panel to jump because
+  // Select prevents this panel from changing width.
+  // Using a custom dropdown component instead of Select would fix this, but we lose some of the nice functionality
+  // (search, clear all, etc.) that Select provides.
   return (
     <PanelContainer>
       <SelectContainer ref={selectContainerRef}>

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -176,13 +176,10 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     })) || [];
   // Filter out thresholds that no longer match the dataset (feature and/or unit), so we only
   // show selections that are actually valid.
-  const thresholdsInDataset = props.featureThresholds.reduce((acc, t) => {
+  const thresholdsInDataset = props.featureThresholds.filter((t) => {
     const featureData = props.dataset?.features[t.featureName];
-    if (featureData && featureData.units === t.unit) {
-      acc.push(t);
-    }
-    return acc;
-  }, [] as FeatureThreshold[]);
+    return featureData && featureData.units === t.unit;
+  });
   const selectedFeatures = thresholdsInDataset.map((t) => t.featureName);
 
   const renderListItems = (item: FeatureThreshold, index: number): ReactNode => {

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -95,9 +95,10 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   const thresholdToKey = (threshold: FeatureThreshold): string => {
     return `${encodeURIComponent(threshold.featureName)}:${threshold.unit ? encodeURIComponent(threshold.unit) : ""}`;
   };
-  // Save the min/max values of each threshold in case the user switches to a dataset that no longer has the threshold's
-  // feature (no match for name + unit). This allows the sliders to be rendered with the same bounds as before until the user switches
-  // back to a dataset that has the thresholded feature.
+  // Save the FEATURE min/max bounds (not the selected range of the threshold) for each threshold. We do
+  // this in case the user switches to a dataset that no longer has the threshold's feature
+  // (no match for name + unit), which means there would be no way to get the feature's min/max bounds.
+  // Doing this allows the sliders be rendered with the same bounds as before and prevents weird UI behavior.
   const featureMinMax = useRef<Map<string, [number, number]>>(new Map());
 
   useMemo(() => {

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -22,10 +22,15 @@ const SelectContainer = styled.div`
   // Add some padding to the Select component so item tags line up
   & .ant-select-selector {
     padding: 0 2px;
+    font-weight: normal;
+  }
+
+  & .rc-virtual-list-holder-inner {
+    gap: 2px;
   }
 
   // Override what selected items look like
-  & .ant-select-item-option-content {
+  & .ant-select-item-option-selected > .ant-select-item-option-content {
     font-weight: normal;
     color: var(--color-button);
   }
@@ -125,7 +130,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   const onClickedRemove = (index: number): void => {
     const newThresholds = [...props.featureThresholds];
     newThresholds.splice(index, 1);
-    // Delete our saved min/max bounds for this feature when it's removed.
+    // Delete saved min/max bounds for this feature when it's removed.
     featureMinMax.current.delete(props.featureThresholds[index].featureName);
     props.onChange(newThresholds);
   };
@@ -183,6 +188,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
           options={featureOptions}
           disabled={props.disabled}
           onClear={() => props.onChange([])}
+          // Allows the selection dropdown to be selected and styled
           getPopupContainer={() => selectContainerRef.current!}
           suffixIcon={isFocused ? <SearchOutlined /> : <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />}
           onFocus={() => setIsFocused(true)}

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -1,11 +1,15 @@
-import React, { ReactElement, ReactNode, useContext, useMemo, useRef } from "react";
-import { FeatureThreshold } from "../colorizer/ColorizeCanvas";
-import { Dataset } from "../colorizer";
-import { Button, Card, List, Select, Tooltip } from "antd";
+import React, { ReactElement, ReactNode, useContext, useMemo, useRef, useState } from "react";
+import { Card, List, Select } from "antd";
+import { CloseOutlined, FilterOutlined, SearchOutlined } from "@ant-design/icons";
 import styled from "styled-components";
+
+import DropdownSVG from "../assets/dropdown-arrow.svg?react";
+
+import { FeatureThreshold } from "../colorizer/ColorizeCanvas";
 import LabeledRangeSlider from "./LabeledRangeSlider";
-import { CloseOutlined, FilterOutlined } from "@ant-design/icons";
+import { Dataset } from "../colorizer";
 import IconButton from "./IconButton";
+
 import { AppThemeContext } from "./AppStyle";
 
 const PanelContainer = styled.div`
@@ -62,6 +66,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   const props = { ...defaultProps, ...inputProps } as Required<FeatureThresholdPanelProps>;
   const theme = useContext(AppThemeContext);
 
+  const [iconMode, setIconMode] = useState<"default" | "search" | "clear">("default");
   const selectContainerRef = useRef<HTMLDivElement>(null);
   // Save the min/max values of each selected feature in case the user switches to a dataset that no longer has
   // that feature. This allows the user to switch back to the original dataset and keep the same thresholds.
@@ -167,6 +172,13 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     );
   };
 
+  let suffixIcon = <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />;
+  if (iconMode === "search") {
+    suffixIcon = <SearchOutlined />;
+  } else if (iconMode === "clear") {
+    suffixIcon = <></>;
+  }
+
   return (
     <PanelContainer>
       <SelectContainer ref={selectContainerRef}>
@@ -181,6 +193,9 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
           disabled={props.disabled}
           onClear={() => props.onChange([])}
           getPopupContainer={() => selectContainerRef.current!}
+          suffixIcon={suffixIcon}
+          onFocus={() => setIconMode("search")}
+          onBlur={() => setIconMode("default")}
         />
       </SelectContainer>
       <FiltersCard size="small" style={{ paddingTop: 0 }}>

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -193,11 +193,6 @@ export default function FeatureThresholdPanel(
     );
   };
 
-  // TODO: Using Select here can cause layout issues. If many features are selected (such that the Select bar is full)
-  // and the user is using a narrower window, switching to/from the Plot panel can cause the whole panel to jump because
-  // Select prevents this panel from changing width.
-  // Using a custom dropdown component instead of Select would fix this, but we lose some of the nice functionality
-  // (search, clear all, etc.) that Select provides.
   return (
     <PanelContainer>
       <SelectContainer ref={selectContainerRef}>
@@ -213,6 +208,7 @@ export default function FeatureThresholdPanel(
           onClear={() => props.onChange([])}
           // Allows the selection dropdown to be selected and styled
           getPopupContainer={() => selectContainerRef.current!}
+          maxTagCount={"responsive"}
           suffixIcon={
             isFocused ? (
               <SearchOutlined />

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -1,6 +1,16 @@
-import React, { ReactElement, ReactNode, useMemo, useRef, useState } from "react";
+import React, {
+  ReactElement,
+  ReactNode,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Card, List, Select } from "antd";
-import { CloseOutlined, FilterOutlined, SearchOutlined } from "@ant-design/icons";
+import {
+  CloseOutlined,
+  FilterOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
 import styled, { css } from "styled-components";
 
 import DropdownSVG from "../assets/dropdown-arrow.svg?react";
@@ -19,7 +29,8 @@ const PanelContainer = styled.div`
 `;
 
 const SelectContainer = styled.div`
-  // Add some padding to the Select component so item tags line up
+  // Add some padding to the Select component so item tags have even spacing
+  // above/below and left/right
   & .ant-select-selector {
     padding: 0 2px;
     font-weight: normal;
@@ -29,7 +40,8 @@ const SelectContainer = styled.div`
     gap: 2px;
   }
 
-  // Override what selected items look like
+  // Override what selected items look like to match the style of
+  // the dropdowns
   & .ant-select-item-option-selected > .ant-select-item-option-content {
     font-weight: normal;
     color: var(--color-button);
@@ -79,8 +91,13 @@ const defaultProps: Partial<FeatureThresholdPanelProps> = {
 /**
  * A React component for adding, removing, and editing thresholds on features in a dataset.
  */
-export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelProps): ReactElement {
-  const props = { ...defaultProps, ...inputProps } as Required<FeatureThresholdPanelProps>;
+export default function FeatureThresholdPanel(
+  inputProps: FeatureThresholdPanelProps
+): ReactElement {
+  const props = {
+    ...defaultProps,
+    ...inputProps,
+  } as Required<FeatureThresholdPanelProps>;
 
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const selectContainerRef = useRef<HTMLDivElement>(null);
@@ -94,7 +111,10 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     for (const threshold of props.featureThresholds) {
       const featureData = props.dataset?.features[threshold.featureName];
       if (featureData) {
-        featureMinMax.current.set(threshold.featureName, [featureData.min, featureData.max]);
+        featureMinMax.current.set(threshold.featureName, [
+          featureData.min,
+          featureData.max,
+        ]);
       }
     }
   }, [props.dataset, props.featureThresholds]);
@@ -106,13 +126,19 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     const newThresholds: FeatureThreshold[] = [];
     selections.forEach((featureName) => {
       // Set up default values for any new selected features, otherwise keep old thresholds
-      const existingThreshold = props.featureThresholds.find((t) => t.featureName === featureName);
+      const existingThreshold = props.featureThresholds.find(
+        (t) => t.featureName === featureName
+      );
       if (existingThreshold) {
         newThresholds.push(existingThreshold);
       } else {
         const featureData = props.dataset?.features[featureName];
         if (featureData) {
-          newThresholds.push({ featureName, min: featureData.min, max: featureData.max });
+          newThresholds.push({
+            featureName,
+            min: featureData.min,
+            max: featureData.max,
+          });
         }
       }
     });
@@ -120,7 +146,11 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   };
 
   /** Handle the threshold for a feature changing. */
-  const onThresholdChanged = (index: number, min: number, max: number): void => {
+  const onThresholdChanged = (
+    index: number,
+    min: number,
+    max: number
+  ): void => {
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = { ...newThresholds[index], min, max };
     props.onChange(newThresholds);
@@ -136,14 +166,22 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   };
 
   ////// RENDERING ///////////////////
-  // TODO: Possible bug where selected features with the same name but different units across datasets will use the same filter values.
-  // This is unlikely to be a problem because collections are expected to have similar datasets.
+  // TODO: Possible bug where selected features with the same name but different units/scaling across
+  // datasets will use the same filter values.
+  // Might not be a problem if collections have similarly-structured datasets...?
+  // The alternative is to use the feature name + units as the key, but that may cause unexpected behavior
+  // for users (such as if one dataset does not have units for a feature but another does)
   const selectedFeatures = props.featureThresholds.map((t) => t.featureName);
   const featureOptions =
-    props.dataset?.featureNames.map((name) => ({ label: props.dataset?.getFeatureNameWithUnits(name), value: name })) ||
-    [];
+    props.dataset?.featureNames.map((name) => ({
+      label: props.dataset?.getFeatureNameWithUnits(name),
+      value: name,
+    })) || [];
 
-  const renderListItems = (item: FeatureThreshold, index: number): ReactNode => {
+  const renderListItems = (
+    item: FeatureThreshold,
+    index: number
+  ): ReactNode => {
     const featureData = props.dataset?.features[item.featureName];
     const savedMinMax = featureMinMax.current.get(item.featureName) || [0, 1];
     // If the feature is no longer in the dataset, use the saved min/max bounds.
@@ -154,7 +192,9 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     return (
       <List.Item style={{ position: "relative" }}>
         <div style={{ width: "100%" }}>
-          <FeatureLabel $disabled={disabled}>{props.dataset?.getFeatureNameWithUnits(item.featureName)}</FeatureLabel>
+          <FeatureLabel $disabled={disabled}>
+            {props.dataset?.getFeatureNameWithUnits(item.featureName)}
+          </FeatureLabel>
           <div style={{ width: "calc(100% - 10px)" }}>
             <LabeledRangeSlider
               min={item.min}
@@ -190,7 +230,13 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
           onClear={() => props.onChange([])}
           // Allows the selection dropdown to be selected and styled
           getPopupContainer={() => selectContainerRef.current!}
-          suffixIcon={isFocused ? <SearchOutlined /> : <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />}
+          suffixIcon={
+            isFocused ? (
+              <SearchOutlined />
+            ) : (
+              <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />
+            )
+          }
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         />

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -1,16 +1,6 @@
-import React, {
-  ReactElement,
-  ReactNode,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { ReactElement, ReactNode, useMemo, useRef, useState } from "react";
 import { Card, List, Select } from "antd";
-import {
-  CloseOutlined,
-  FilterOutlined,
-  SearchOutlined,
-} from "@ant-design/icons";
+import { CloseOutlined, FilterOutlined, SearchOutlined } from "@ant-design/icons";
 import styled, { css } from "styled-components";
 
 import DropdownSVG from "../assets/dropdown-arrow.svg?react";
@@ -111,10 +101,7 @@ export default function FeatureThresholdPanel(
     for (const threshold of props.featureThresholds) {
       const featureData = props.dataset?.features[threshold.featureName];
       if (featureData) {
-        featureMinMax.current.set(threshold.featureName, [
-          featureData.min,
-          featureData.max,
-        ]);
+        featureMinMax.current.set(threshold.featureName, [featureData.min, featureData.max]);
       }
     }
   }, [props.dataset, props.featureThresholds]);
@@ -126,9 +113,7 @@ export default function FeatureThresholdPanel(
     const newThresholds: FeatureThreshold[] = [];
     selections.forEach((featureName) => {
       // Set up default values for any new selected features, otherwise keep old thresholds
-      const existingThreshold = props.featureThresholds.find(
-        (t) => t.featureName === featureName
-      );
+      const existingThreshold = props.featureThresholds.find((t) => t.featureName === featureName);
       if (existingThreshold) {
         newThresholds.push(existingThreshold);
       } else {
@@ -146,11 +131,7 @@ export default function FeatureThresholdPanel(
   };
 
   /** Handle the threshold for a feature changing. */
-  const onThresholdChanged = (
-    index: number,
-    min: number,
-    max: number
-  ): void => {
+  const onThresholdChanged = (index: number, min: number, max: number): void => {
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = { ...newThresholds[index], min, max };
     props.onChange(newThresholds);
@@ -178,10 +159,7 @@ export default function FeatureThresholdPanel(
       value: name,
     })) || [];
 
-  const renderListItems = (
-    item: FeatureThreshold,
-    index: number
-  ): ReactNode => {
+  const renderListItems = (item: FeatureThreshold, index: number): ReactNode => {
     const featureData = props.dataset?.features[item.featureName];
     const savedMinMax = featureMinMax.current.get(item.featureName) || [0, 1];
     // If the feature is no longer in the dataset, use the saved min/max bounds.

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -81,9 +81,7 @@ const defaultProps: Partial<FeatureThresholdPanelProps> = {
 /**
  * A React component for adding, removing, and editing thresholds on features in a dataset.
  */
-export default function FeatureThresholdPanel(
-  inputProps: FeatureThresholdPanelProps
-): ReactElement {
+export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelProps): ReactElement {
   const props = {
     ...defaultProps,
     ...inputProps,
@@ -170,9 +168,7 @@ export default function FeatureThresholdPanel(
     return (
       <List.Item style={{ position: "relative" }}>
         <div style={{ width: "100%" }}>
-          <FeatureLabel $disabled={disabled}>
-            {props.dataset?.getFeatureNameWithUnits(item.featureName)}
-          </FeatureLabel>
+          <FeatureLabel $disabled={disabled}>{props.dataset?.getFeatureNameWithUnits(item.featureName)}</FeatureLabel>
           <div style={{ width: "calc(100% - 10px)" }}>
             <LabeledRangeSlider
               min={item.min}
@@ -209,13 +205,7 @@ export default function FeatureThresholdPanel(
           // Allows the selection dropdown to be selected and styled
           getPopupContainer={() => selectContainerRef.current!}
           maxTagCount={"responsive"}
-          suffixIcon={
-            isFocused ? (
-              <SearchOutlined />
-            ) : (
-              <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />
-            )
-          }
+          suffixIcon={isFocused ? <SearchOutlined /> : <DropdownSVG style={{ pointerEvents: "none", width: "12px" }} />}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
         />

--- a/src/components/LabeledRangeSlider.tsx
+++ b/src/components/LabeledRangeSlider.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactEventHandler, ReactNode, useRef } from "react";
 import { InputNumber, Slider } from "antd";
 import { clamp } from "three/src/math/MathUtils";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { setMaxDecimalPrecision, numberToStringDecimal } from "../colorizer/utils/math_utils";
 
 type LabeledRangeSliderProps = {
@@ -72,10 +72,19 @@ const SliderContainer = styled.div`
   }
 `;
 
-const SliderLabel = styled.p`
+const SliderLabel = styled.p<{ $disabled?: boolean }>`
   position: absolute;
   bottom: var(--label-position);
   z-index: 0;
+
+  ${(props) => {
+    if (props.$disabled) {
+      return css`
+        color: var(--color-text-disabled);
+      `;
+    }
+    return;
+  }}
 
   &:not(:last-child) {
     // Bit of a hack to override font size by increasing specificity
@@ -175,8 +184,12 @@ export default function LabeledRangeSlider(inputProps: LabeledRangeSliderProps):
           // TODO: Is this better than showing the precise value?
           tooltip={{ formatter: (value) => numberToStringDecimal(value, props.maxDecimalsToDisplay) }}
         />
-        <SliderLabel>{numberToStringDecimal(props.minSliderBound, props.maxDecimalsToDisplay)}</SliderLabel>
-        <SliderLabel>{numberToStringDecimal(props.maxSliderBound, props.maxDecimalsToDisplay)}</SliderLabel>
+        <SliderLabel $disabled={props.disabled}>
+          {numberToStringDecimal(props.minSliderBound, props.maxDecimalsToDisplay)}
+        </SliderLabel>
+        <SliderLabel $disabled={props.disabled}>
+          {numberToStringDecimal(props.maxSliderBound, props.maxDecimalsToDisplay)}
+        </SliderLabel>
       </SliderContainer>
       <InputNumber
         ref={maxInput}

--- a/src/components/LabeledRangeSlider.tsx
+++ b/src/components/LabeledRangeSlider.tsx
@@ -182,7 +182,10 @@ export default function LabeledRangeSlider(inputProps: LabeledRangeSliderProps):
           step={stepSize}
           // Show formatted decimals in tooltip
           // TODO: Is this better than showing the precise value?
-          tooltip={{ formatter: (value) => numberToStringDecimal(value, props.maxDecimalsToDisplay) }}
+          tooltip={{
+            formatter: (value) => numberToStringDecimal(value, props.maxDecimalsToDisplay),
+            open: props.disabled ? false : undefined, // Hide tooltip when disabled
+          }}
         />
         <SliderLabel $disabled={props.disabled}>
           {numberToStringDecimal(props.minSliderBound, props.maxDecimalsToDisplay)}


### PR DESCRIPTION
Problem
=======
Partially resolves action items in #124

Solution
========
- Allows thresholds on features to persist when switching datasets, even if the feature doesn't exist in the new dataset.
  - Features that are not available are greyed out/disabled.
- Various improvements to formatting on the Select component in `FeatureThresholdingPanel.tsx`
  - Fixed a spacing issue for selected feature names
  - Replaced dropdown and search icons to be consistent with the rest of the UI
- Various improvements to Slider formatting in `LabeledRangeSlider.tsx`
  - Greyed out min/max slider bound text labels when disabled. 
  - Removed tooltips when disabled.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link
2. Load this URL: `https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test/`
3. Set a threshold on the feature `feature`.
4. Switch to another dataset (Test 5 or Test 6)
5. See that the original feature threshold is now disabled
6. Add additional feature thresholds.
7. Switch back.  All thresholds should persist

NEW: Verifying that thresholds are differentiated by feature + unit
1. Open the preview link. `Test 1 Default` should have a feature with a unit (`feature (test unit)`). If you don't see the unit label, you may need to clear your cache. 
3. Add a filter for that feature.
4. Switch to dataset `Test 2 Nested`. The original feature (`feature (test unit)`) should be greyed out.
5. You should now be able to add a new filter for the feature `feature`.

Demo Video (turn on sound 🔊)
-----------------------

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/867de740-8d79-42ec-8175-7c0daa43ea99

