### PR TITLE
feat: Loading feature thresholds from URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,13 +40,7 @@ import LoadDatasetButton from "./components/LoadDatasetButton";
 import PlaybackSpeedControl from "./components/PlaybackSpeedControl";
 import PlotWrapper from "./components/PlotWrapper";
 import SpinBox from "./components/SpinBox";
-import {
-  DEFAULT_COLLECTION_FILENAME,
-  DEFAULT_COLLECTION_PATH,
-  DEFAULT_COLOR_RAMPS,
-  DEFAULT_COLOR_RAMP_ID,
-  DEFAULT_PLAYBACK_FPS,
-} from "./constants";
+import { DEFAULT_COLLECTION_PATH, DEFAULT_COLOR_RAMPS, DEFAULT_COLOR_RAMP_ID, DEFAULT_PLAYBACK_FPS } from "./constants";
 import FeatureThresholdPanel from "./components/FeatureThresholdPanel";
 
 function App(): ReactElement {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,8 +134,9 @@ function App(): ReactElement {
       feature: featureName,
       track: selectedTrack?.trackId,
       time: currentFrame,
+      thresholds: featureThresholds,
     });
-  }, [collection, datasetKey, dataset, featureName, selectedTrack, currentFrame]);
+  }, [collection, datasetKey, dataset, featureName, selectedTrack, currentFrame, featureThresholds]);
 
   // Update url whenever the viewer settings change
   // (but not while playing/recording for performance reasons)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,13 +16,8 @@ import { Color } from "three";
 import styles from "./App.module.css";
 import { ColorizeCanvas, Dataset, Track } from "./colorizer";
 import Collection from "./colorizer/Collection";
-import {
-  BACKGROUND_ID,
-  DrawMode,
-  FeatureThreshold,
-  OUTLIER_COLOR_DEFAULT,
-  OUT_OF_RANGE_COLOR_DEFAULT,
-} from "./colorizer/ColorizeCanvas";
+import { BACKGROUND_ID, DrawMode, OUTLIER_COLOR_DEFAULT, OUT_OF_RANGE_COLOR_DEFAULT } from "./colorizer/ColorizeCanvas";
+import { FeatureThreshold } from "./constants/types";
 import TimeControls from "./colorizer/TimeControls";
 import { numberToStringDecimal } from "./colorizer/utils/math_utils";
 import { useConstructor, useDebounce } from "./colorizer/utils/react_utils";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,14 +137,6 @@ function App(): ReactElement {
       datasetParam = dataset?.manifestUrl;
       collectionParam = undefined;
     }
-    // If the collection is the default collection path, don't include it in the URL.
-    if (
-      collectionParam &&
-      (collectionParam === DEFAULT_COLLECTION_PATH ||
-        collectionParam === DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME)
-    ) {
-      collectionParam = undefined;
-    }
     // check if current color map range matches the default feature range; if so, don't include
     // it in the URL parameter to reduce clutter.
     let rangeIsDefault = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -269,7 +269,7 @@ function App(): ReactElement {
       }
       if (initialUrlParams.track && initialUrlParams.track >= 0) {
         // Highlight the track. Seek to start of frame only if time is not defined.
-        findTrack(initialUrlParams.track, (initialUrlParams.time ?? 0) < 0);
+        findTrack(initialUrlParams.track, initialUrlParams.time !== undefined);
       }
       let newTime = currentFrame;
       if (initialUrlParams.time && initialUrlParams.time >= 0) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,8 +140,8 @@ function App(): ReactElement {
     // If the collection is the default collection path, don't include it in the URL.
     if (
       collectionParam &&
-      collectionParam !== DEFAULT_COLLECTION_PATH &&
-      collectionParam !== DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME
+      (collectionParam === DEFAULT_COLLECTION_PATH ||
+        collectionParam === DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME)
     ) {
       collectionParam = undefined;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ function App(): ReactElement {
     if (featureData) {
       rangeIsDefault = featureData.min === colorRampMin && featureData.max === colorRampMax;
     }
-    return urlUtils.stateToUrlQueryString({
+    return urlUtils.paramsToUrlQueryString({
       collection: collectionParam,
       dataset: datasetParam,
       feature: featureName,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,12 +135,13 @@ function App(): ReactElement {
     if (dataset && featureData) {
       rangeIsDefault = featureData.min === colorRampMin && featureData.max === colorRampMax;
     }
-    return urlUtils.stateToUrlParamString({
-      collection: collection?.url,
+    return urlUtils.stateToUrlQueryString({
+      collection: collection?.url ?? undefined,
       dataset: datasetParam,
       feature: featureName,
       track: selectedTrack?.trackId,
-      time: currentFrame,
+      // Ignore time=0
+      time: currentFrame !== 0 ? currentFrame : undefined,
       thresholds: featureThresholds,
       range: rangeIsDefault ? undefined : [colorRampMin, colorRampMax],
     });
@@ -249,12 +250,12 @@ function App(): ReactElement {
         setColorRampMin(initialUrlParams.range[0]);
         setColorRampMax(initialUrlParams.range[1]);
       }
-      if (initialUrlParams.track >= 0) {
+      if (initialUrlParams.track && initialUrlParams.track >= 0) {
         // Highlight the track. Seek to start of frame only if time is not defined.
-        findTrack(initialUrlParams.track, initialUrlParams.time < 0);
+        findTrack(initialUrlParams.track, (initialUrlParams.time ?? 0) < 0);
       }
       let newTime = currentFrame;
-      if (initialUrlParams.time >= 0) {
+      if (initialUrlParams.time && initialUrlParams.time >= 0) {
         // Load time (if unset, defaults to track time or default t=0)
         newTime = initialUrlParams.time;
         await canv.setFrame(newTime);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,9 @@ function App(): ReactElement {
    * and frame information.
    */
   const getUrlParams = useCallback((): string => {
+    if (!dataset) {
+      return "";
+    }
     let datasetParam: string | undefined = datasetKey;
     let collectionParam = collection?.url;
     // If there is no collection loaded (e.g. a single dataset URL was loaded),
@@ -133,11 +136,10 @@ function App(): ReactElement {
       datasetParam = dataset?.manifestUrl;
       collectionParam = undefined;
     }
-    // check if current color map range matches the default feature range; if so, don't include
-    // it in the URL parameter to reduce clutter.
+    // check if current selected feature range matches the default feature range; if so, don't include.
     let rangeIsDefault = false;
-    const featureData = dataset?.getFeatureData(featureName);
-    if (dataset && featureData) {
+    const featureData = dataset.getFeatureData(featureName);
+    if (featureData) {
       rangeIsDefault = featureData.min === colorRampMin && featureData.max === colorRampMax;
     }
     return urlUtils.stateToUrlQueryString({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,6 +219,9 @@ function App(): ReactElement {
       return;
     }
     const setupInitialParameters = async (): Promise<void> => {
+      if (initialUrlParams.thresholds) {
+        setFeatureThresholds(initialUrlParams.thresholds);
+      }
       if (initialUrlParams.feature && dataset) {
         // Load feature (if unset, do nothing because replaceDataset already loads a default)
         await updateFeature(dataset, initialUrlParams.feature);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import styles from "./App.module.css";
 import { ColorizeCanvas, Dataset, Track } from "./colorizer";
 import Collection from "./colorizer/Collection";
 import { BACKGROUND_ID, DrawMode, OUTLIER_COLOR_DEFAULT, OUT_OF_RANGE_COLOR_DEFAULT } from "./colorizer/ColorizeCanvas";
-import { FeatureThreshold } from "./constants/types";
+import { FeatureThreshold } from "./colorizer/types";
 import TimeControls from "./colorizer/TimeControls";
 import { numberToStringDecimal } from "./colorizer/utils/math_utils";
 import { useConstructor, useDebounce } from "./colorizer/utils/react_utils";

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -29,6 +29,7 @@ import vertexShader from "./shaders/colorize.vert";
 import fragmentShader from "./shaders/colorize_RGBA8U.frag";
 import pickFragmentShader from "./shaders/cellId_RGBA8U.frag";
 import Track from "./Track";
+import { FeatureThreshold } from "../constants/types";
 
 const BACKGROUND_COLOR_DEFAULT = 0xf7f7f7;
 export const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;
@@ -92,13 +93,6 @@ const getDefaultUniforms = (): ColorizeUniforms => {
     outlierDrawMode: new Uniform(DrawMode.USE_COLOR),
     outOfRangeDrawMode: new Uniform(DrawMode.USE_COLOR),
   };
-};
-
-export type FeatureThreshold = {
-  featureName: string;
-  units: string;
-  min: number;
-  max: number;
 };
 
 // TODO: Change into a component?

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -96,7 +96,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
 
 export type FeatureThreshold = {
   featureName: string;
-  unit: string | undefined;
+  units: string;
   min: number;
   max: number;
 };
@@ -400,7 +400,7 @@ export default class ColorizeCanvas {
     for (const threshold of thresholds) {
       const featureData = this.dataset.getFeatureData(threshold.featureName);
       // Ignore thresholds with features that don't exist in this dataset or whose units don't match
-      if (!featureData || featureData.units !== threshold.unit) {
+      if (!featureData || featureData.units !== threshold.units) {
         continue;
       }
       for (let i = 0, n = inRangeIds.length; i < n; i++) {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -29,7 +29,7 @@ import vertexShader from "./shaders/colorize.vert";
 import fragmentShader from "./shaders/colorize_RGBA8U.frag";
 import pickFragmentShader from "./shaders/cellId_RGBA8U.frag";
 import Track from "./Track";
-import { FeatureThreshold } from "../constants/types";
+import { FeatureThreshold } from "./types";
 
 const BACKGROUND_COLOR_DEFAULT = 0xf7f7f7;
 export const OUTLIER_COLOR_DEFAULT = 0xc0c0c0;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -30,7 +30,8 @@ export type FeatureData = {
   tex: Texture;
   min: number;
   max: number;
-  units?: string;
+  /** Defaults to empty string ("") if no units are provided. */
+  units: string;
 };
 
 const MAX_CACHED_FRAMES = 60;
@@ -100,10 +101,8 @@ export default class Dataset {
       data: source.getBuffer(FeatureDataType.F32),
       min: source.getMin(),
       max: source.getMax(),
+      units: metadata?.units || "",
     };
-    if (metadata && metadata.units !== undefined && metadata.units !== null) {
-      this.features[name].units = metadata.units;
-    }
   }
 
   public hasFeature(name: string): boolean {
@@ -127,8 +126,8 @@ export default class Dataset {
     }
   }
 
-  public getFeatureUnits(name: string): string | undefined {
-    return this.features[name]?.units;
+  public getFeatureUnits(name: string): string {
+    return this.features[name].units;
   }
 
   /**

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -73,3 +73,10 @@ export const featureTypeSpecs: { [T in FeatureDataType]: FeatureTypeSpec<T> } = 
     internalFormat: "R8UI",
   },
 };
+
+export type FeatureThreshold = {
+  featureName: string;
+  units: string;
+  min: number;
+  max: number;
+};

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -13,7 +13,7 @@ import { FeatureThreshold } from "../ColorizeCanvas";
  */
 export function thresholdMatchFinder(
   featureName: string,
-  unit: string | undefined
+  units: string | undefined
 ): (threshold: FeatureThreshold) => boolean {
-  return (threshold: FeatureThreshold) => threshold.featureName === featureName && threshold.unit === unit;
+  return (threshold: FeatureThreshold) => threshold.featureName === featureName && threshold.units === units;
 }

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -3,7 +3,7 @@ import { FeatureThreshold } from "../ColorizeCanvas";
 /**
  * Generates a find function for a FeatureThreshold, matching on feature name and unit.
  * @param featureName String feature name to match on.
- * @param unit String unit to match on. If undefined, will match on thresholds with undefined units only.
+ * @param unit String unit to match on.
  * @returns a lambda function that can be passed into `Array.find` for an array of FeatureThreshold.
  * @example
  * ```
@@ -11,9 +11,6 @@ import { FeatureThreshold } from "../ColorizeCanvas";
  * const matchThreshold = featureThresholds.find(thresholdMatchFinder("Temperature", "°C"));
  * ```
  */
-export function thresholdMatchFinder(
-  featureName: string,
-  units: string | undefined
-): (threshold: FeatureThreshold) => boolean {
+export function thresholdMatchFinder(featureName: string, units: string): (threshold: FeatureThreshold) => boolean {
   return (threshold: FeatureThreshold) => threshold.featureName === featureName && threshold.units === units;
 }

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -1,4 +1,4 @@
-import { FeatureThreshold } from "../../constants/types";
+import { FeatureThreshold } from "../types";
 
 /**
  * Generates a find function for a FeatureThreshold, matching on feature name and unit.

--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -1,4 +1,4 @@
-import { FeatureThreshold } from "../ColorizeCanvas";
+import { FeatureThreshold } from "../../constants/types";
 
 /**
  * Generates a find function for a FeatureThreshold, matching on feature name and unit.

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -258,8 +258,8 @@ export function loadParamsFromUrlQueryString(queryString: string): Partial<UrlPa
   }
 
   const colorRampRawParam = urlParams.get(URL_PARAM_COLOR_RAMP);
-  let colorRampParam: string | null = colorRampRawParam;
-  let colorRampReversedParam: boolean = false;
+  let colorRampParam: string | undefined = colorRampRawParam || undefined;
+  let colorRampReversedParam: boolean | undefined = undefined;
   //  Color ramps are marked as reversed by adding ! to the end of the key
   if (colorRampRawParam && colorRampRawParam.charAt(colorRampRawParam.length - 1) === URL_COLOR_RAMP_REVERSED_SUFFIX) {
     colorRampReversedParam = true;

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -10,7 +10,7 @@ const URL_PARAM_FEATURE = "feature";
 const URL_PARAM_TIME = "t";
 const URL_PARAM_COLLECTION = "collection";
 // TODO: Make thresholds/filters language consistent. Requires talking with users/UX!
-const URL_PARAM_THRESHOLDS = "thresholds";
+const URL_PARAM_THRESHOLDS = "filters";
 const URL_PARAM_RANGE = "range";
 
 export type UrlParams = {

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -1,7 +1,7 @@
 // Typescript doesn't recognize RequestInit
 /* global RequestInit */
 
-import { FeatureThreshold } from "../../constants/types";
+import { FeatureThreshold } from "../types";
 import { numberToStringDecimal } from "./math_utils";
 
 const URL_PARAM_TRACK = "track";

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -97,8 +97,10 @@ export function stateToUrlQueryString(state: Partial<UrlParams>): string {
     includedParameters.push(`${URL_PARAM_TIME}=${state.time}`);
   }
   if (state.thresholds && state.thresholds.length > 0) {
+    // Thresholds are saved as a comma-separated list of featureName:min:max.
     // featureName is encoded in case it contains special characters (":" or ",")
-    // TODO: Is there a better character separator I can use here? ":" and "," are reserved characters in URLs.
+    // TODO: Are there better characters I can be using here? ":" and "," take up
+    // more space in the URL.
     const thresholdsString = state.thresholds
       .map((threshold) => {
         const featureName = encodeURIComponent(threshold.featureName);
@@ -110,7 +112,7 @@ export function stateToUrlQueryString(state: Partial<UrlParams>): string {
     includedParameters.push(`${URL_PARAM_THRESHOLDS}=${encodeURIComponent(thresholdsString)}`);
   }
   if (state.range && state.range.length === 2) {
-    const rangeString = numberToStringDecimal(state.range[0], 3) + "," + numberToStringDecimal(state.range[1], 3);
+    const rangeString = `${numberToStringDecimal(state.range[0], 3)},${numberToStringDecimal(state.range[1], 3)}`;
     includedParameters.push(`${URL_PARAM_RANGE}=${encodeURIComponent(rangeString)}`);
   }
 
@@ -172,7 +174,7 @@ export function formatPath(input: string): string {
 /**
  * Loads parameters from the current window URL.
  * @returns An object with a dataset, feature, track, and time parameters.
- * The parameters are undefined if no parameter was found in the URL, or if
+ * A parameter is `undefined` if it was not found in the URL, or if
  * it could not be parsed.
  */
 export function loadParamsFromUrl(): Partial<UrlParams> {
@@ -181,6 +183,10 @@ export function loadParamsFromUrl(): Partial<UrlParams> {
   return loadParamsFromUrlQueryString(queryString);
 }
 
+/**
+ * Returns a copy of an object where any properties with a value of `undefined`
+ * are not included.
+ */
 function removeUndefinedProperties<T>(object: T): Partial<T> {
   const ret: Partial<T> = {};
   for (const key in object) {
@@ -191,6 +197,11 @@ function removeUndefinedProperties<T>(object: T): Partial<T> {
   return ret;
 }
 
+/**
+ * Loads parameters from the query string of a URL.
+ * @param queryString A URL query string, as from `window.location.search`.
+ * @returns A partial UrlParams object with values loaded from the queryString.
+ */
 export function loadParamsFromUrlQueryString(queryString: string): Partial<UrlParams> {
   // NOTE: URLSearchParams automatically applies one level of URI decoding.
   const urlParams = new URLSearchParams(queryString);
@@ -227,9 +238,9 @@ export function loadParamsFromUrlQueryString(queryString: string): Partial<UrlPa
 
   // Remove undefined entries from the object for a cleaner return value
   return removeUndefinedProperties({
-    collection: collectionParam ?? undefined,
-    dataset: datasetParam ?? undefined,
-    feature: featureParam ?? undefined,
+    collection: collectionParam,
+    dataset: datasetParam,
+    feature: featureParam,
     track: trackParam,
     time: timeParam,
     thresholds: thresholdsParam.length > 0 ? thresholdsParam : undefined,

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -12,8 +12,6 @@ const URL_PARAM_COLLECTION = "collection";
 const URL_PARAM_THRESHOLDS = "filters";
 const URL_PARAM_RANGE = "range";
 
-const THRESHOLD_UNIT_UNDEFINED = "!";
-
 export type UrlParams = {
   collection: string;
   dataset: string;
@@ -100,8 +98,7 @@ export function stateToUrlQueryString(state: Partial<UrlParams>): string {
         const featureName = encodeURIComponent(threshold.featureName);
         // Note that THRESHOLD_UNIT_UNDEFINED (="!") is not encoded here, so that it won't conflict
         // with normal feature units names. (Users should not be using "!" as a unit anyway, but just in case.)
-        const featureUnit =
-          threshold.unit !== undefined ? encodeURIComponent(threshold.unit) : THRESHOLD_UNIT_UNDEFINED;
+        const featureUnit = encodeURIComponent(threshold.units);
         const min = numberToStringDecimal(threshold.min, 3);
         const max = numberToStringDecimal(threshold.max, 3);
         return `${featureName}:${featureUnit}:${min}:${max}`;
@@ -226,7 +223,7 @@ export function loadParamsFromUrlQueryString(queryString: string): Partial<UrlPa
       const [rawFeatureName, rawFeatureUnit, min, max] = rawThreshold.split(":");
       let threshold = {
         featureName: decodeURIComponent(rawFeatureName),
-        unit: rawFeatureUnit !== THRESHOLD_UNIT_UNDEFINED ? decodeURIComponent(rawFeatureUnit) : undefined,
+        units: decodeURIComponent(rawFeatureUnit),
         min: parseFloat(min),
         max: parseFloat(max),
       };

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -52,7 +52,7 @@ export function fetchWithTimeout(
 }
 
 /**
- * Creates a string of parameters that can be appended onto the base URL as metadata.
+ * Creates a url query string from parameters that can be appended onto the base URL.
  *
  * @param state: An object matching any of the properties of `UrlParams`.
  * - `collection`: string path to the collection. Ignores paths matching the default collection address.
@@ -67,9 +67,7 @@ export function fetchWithTimeout(
  * - If no parameters are present or valid, returns an empty string.
  * - Else, returns a string of URL parameters that can be appended to the URL directly (ex: `?collection=<some_url>&time=23`).
  */
-export function stateToUrlQueryString(state: Partial<UrlParams>): string {
-  // arguments as more data gets stored to the URL.
-
+export function paramsToUrlQueryString(state: Partial<UrlParams>): string {
   // Get parameters, ignoring null/empty values
   const includedParameters: string[] = [];
 

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -1,7 +1,6 @@
 // Typescript doesn't recognize RequestInit
 /* global RequestInit */
 
-import { DEFAULT_COLLECTION_FILENAME, DEFAULT_COLLECTION_PATH } from "../../constants";
 import { FeatureThreshold } from "../ColorizeCanvas";
 import { numberToStringDecimal } from "./math_utils";
 
@@ -20,7 +19,6 @@ export type UrlParams = {
   feature: string;
   track: number;
   time: number;
-  // TODO: bad code smell for url params to be aware of this type
   thresholds: FeatureThreshold[];
   range: [number, number];
 };
@@ -77,11 +75,7 @@ export function stateToUrlQueryString(state: Partial<UrlParams>): string {
   const includedParameters: string[] = [];
 
   // Don't include collection parameter in URL if it matches the default.
-  if (
-    state.collection &&
-    state.collection !== DEFAULT_COLLECTION_PATH &&
-    state.collection !== DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME
-  ) {
+  if (state.collection) {
     includedParameters.push(`${URL_PARAM_COLLECTION}=${encodeURIComponent(state.collection)}`);
   }
   if (state.dataset) {

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -9,7 +9,6 @@ const URL_PARAM_DATASET = "dataset";
 const URL_PARAM_FEATURE = "feature";
 const URL_PARAM_TIME = "t";
 const URL_PARAM_COLLECTION = "collection";
-// TODO: Make thresholds/filters language consistent. Requires talking with users/UX!
 const URL_PARAM_THRESHOLDS = "filters";
 const URL_PARAM_RANGE = "range";
 
@@ -74,7 +73,6 @@ export function stateToUrlQueryString(state: Partial<UrlParams>): string {
   // Get parameters, ignoring null/empty values
   const includedParameters: string[] = [];
 
-  // Don't include collection parameter in URL if it matches the default.
   if (state.collection) {
     includedParameters.push(`${URL_PARAM_COLLECTION}=${encodeURIComponent(state.collection)}`);
   }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -1,7 +1,7 @@
 // Typescript doesn't recognize RequestInit
 /* global RequestInit */
 
-import { FeatureThreshold } from "../ColorizeCanvas";
+import { FeatureThreshold } from "../../constants/types";
 import { numberToStringDecimal } from "./math_utils";
 
 const URL_PARAM_TRACK = "track";

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -3,7 +3,7 @@ import { Color } from "three";
 
 import { ColorRamp, ColorizeCanvas, Dataset, Track } from "../colorizer";
 import { DrawMode } from "../colorizer/ColorizeCanvas";
-import { FeatureThreshold } from "../constants/types";
+import { FeatureThreshold } from "../colorizer/types";
 
 export type DrawSettings = {
   mode: DrawMode;

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -2,7 +2,8 @@ import React, { ReactElement, useCallback, useEffect, useMemo, useRef } from "re
 import { Color } from "three";
 
 import { ColorRamp, ColorizeCanvas, Dataset, Track } from "../colorizer";
-import { DrawMode, FeatureThreshold } from "../colorizer/ColorizeCanvas";
+import { DrawMode } from "../colorizer/ColorizeCanvas";
+import { FeatureThreshold } from "../constants/types";
 
 export type DrawSettings = {
   mode: DrawMode;

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -94,7 +94,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
 
   /** Converts a threshold to a unique key that can be used to look up its information later. Matches on feature name and unit. */
   const thresholdToKey = (threshold: FeatureThreshold): string => {
-    return `${encodeURIComponent(threshold.featureName)}:${threshold.unit ? encodeURIComponent(threshold.unit) : ""}`;
+    return `${encodeURIComponent(threshold.featureName)}:${threshold.units ? encodeURIComponent(threshold.units) : ""}`;
   };
   // Save the FEATURE min/max bounds (not the selected range of the threshold) for each threshold. We do
   // this in case the user switches to a dataset that no longer has the threshold's feature
@@ -110,7 +110,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     // reflect the last known good values.
     for (const threshold of props.featureThresholds) {
       const featureData = props.dataset?.features[threshold.featureName];
-      if (featureData && featureData.units === threshold.unit) {
+      if (featureData && featureData.units === threshold.units) {
         featureMinMaxBoundsFallback.current.set(thresholdToKey(threshold), [featureData.min, featureData.max]);
       }
     }
@@ -126,7 +126,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
       // Add a new threshold for the selected value if valid
       newThresholds.push({
         featureName: featureName,
-        unit: props.dataset?.getFeatureUnits(featureName),
+        units: props.dataset!.getFeatureUnits(featureName),
         min: featureData.min,
         max: featureData.max,
       });
@@ -179,7 +179,7 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
   // show selections that are actually valid.
   const thresholdsInDataset = props.featureThresholds.filter((t) => {
     const featureData = props.dataset?.features[t.featureName];
-    return featureData && featureData.units === t.unit;
+    return featureData && featureData.units === t.units;
   });
   const selectedFeatures = thresholdsInDataset.map((t) => t.featureName);
 
@@ -187,13 +187,13 @@ export default function FeatureThresholdPanel(inputProps: FeatureThresholdPanelP
     // Thresholds are matched on both feature names and units; a threshold must match
     // both in the current dataset to be valid.
     const featureData = props.dataset?.features[item.featureName];
-    const disabled = featureData === undefined || featureData.units !== item.unit;
+    const disabled = featureData === undefined || featureData.units !== item.units;
     // If the feature is no longer in the dataset, use the saved min/max bounds.
     const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [0, 1];
     const sliderMin = disabled ? savedMinMax[0] : featureData.min;
     const sliderMax = disabled ? savedMinMax[1] : featureData.max;
 
-    const featureLabel = item.unit ? `${item.featureName} (${item.unit})` : item.featureName;
+    const featureLabel = item.units ? `${item.featureName} (${item.units})` : item.featureName;
 
     return (
       <List.Item style={{ position: "relative" }}>

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -5,7 +5,7 @@ import styled, { css } from "styled-components";
 
 import DropdownSVG from "../assets/dropdown-arrow.svg?react";
 
-import { FeatureThreshold } from "../constants/types";
+import { FeatureThreshold } from "../colorizer/types";
 import LabeledRangeSlider from "./LabeledRangeSlider";
 import { Dataset } from "../colorizer";
 import IconButton from "./IconButton";

--- a/src/components/FeatureThresholdPanel.tsx
+++ b/src/components/FeatureThresholdPanel.tsx
@@ -5,7 +5,7 @@ import styled, { css } from "styled-components";
 
 import DropdownSVG from "../assets/dropdown-arrow.svg?react";
 
-import { FeatureThreshold } from "../colorizer/ColorizeCanvas";
+import { FeatureThreshold } from "../constants/types";
 import LabeledRangeSlider from "./LabeledRangeSlider";
 import { Dataset } from "../colorizer";
 import IconButton from "./IconButton";

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,0 +1,6 @@
+export type FeatureThreshold = {
+  featureName: string;
+  units: string;
+  min: number;
+  max: number;
+};

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,6 +1,0 @@
-export type FeatureThreshold = {
-  featureName: string;
-  units: string;
-  min: number;
-  max: number;
-};

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -62,6 +62,6 @@ describe("Dataset", () => {
     expect(dataset.getFeatureUnits("feature1")).to.equal("meters");
     expect(dataset.getFeatureUnits("feature2")).to.equal("(m)");
     expect(dataset.getFeatureUnits("feature3")).to.equal("μm/s");
-    expect(dataset.getFeatureUnits("feature4")).to.be.undefined;
+    expect(dataset.getFeatureUnits("feature4")).to.equal("");
   });
 });

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -67,17 +67,13 @@ describe("Loading + saving from URL query strings", () => {
       feature: "Привет, мир", // %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80
     };
     const queryString = stateToUrlQueryString(originalParams);
-    // The dataset and feature say "Hello World" in Mandarin and Russian in case you're curious.
-    expect(queryString).to.equal(
-      "?collection=https%3A%2F%2Fsome-url.com%2Fcollection.json" +
-        "&dataset=%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C" +
-        "&feature=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80"
-    );
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
   });
 
   it("Saves and retrieves URL params correctly", () => {
+    // This will need to be updated for any new URL params.
+    // The use of `Required` makes sure that we don't forget to update this test :)
     const originalParams: Required<UrlParams> = {
       collection: "collection",
       dataset: "dataset",

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -81,10 +81,10 @@ describe("Loading + saving from URL query strings", () => {
       track: 25,
       time: 14,
       thresholds: [
-        { featureName: "f1", unit: "m", min: 0, max: 0 },
-        { featureName: "f2", unit: "um", min: NaN, max: NaN },
-        { featureName: "f3", unit: "km", min: 0, max: 1 },
-        { featureName: "f4", unit: "mm", min: 0.501, max: 1000.485 },
+        { featureName: "f1", units: "m", min: 0, max: 0 },
+        { featureName: "f2", units: "um", min: NaN, max: NaN },
+        { featureName: "f3", units: "km", min: 0, max: 1 },
+        { featureName: "f4", units: "mm", min: 0.501, max: 1000.485 },
       ],
       range: [21.433, 89.4],
     };
@@ -96,10 +96,10 @@ describe("Loading + saving from URL query strings", () => {
   it("Handles feature threshold names with potentially illegal characters", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [
-        { featureName: "feature,,,", unit: "", min: 0, max: 1 },
-        { featureName: "(feature)", unit: "", min: 0, max: 1 },
-        { featureName: "feat:ure", unit: "", min: 0, max: 1 },
-        { featureName: "0.0%", unit: "", min: 0.0, max: 1 },
+        { featureName: "feature,,,", units: ",m,", min: 0, max: 1 },
+        { featureName: "(feature)", units: "(m)", min: 0, max: 1 },
+        { featureName: "feat:ure", units: ":m", min: 0, max: 1 },
+        { featureName: "0.0%", units: "m&m's", min: 0.0, max: 1 },
       ],
     };
     const queryString = stateToUrlQueryString(originalParams);
@@ -110,9 +110,9 @@ describe("Loading + saving from URL query strings", () => {
   it("Enforces min/max on range and thresholds", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [
-        { featureName: "feature1", unit: "", min: 1, max: 0 },
-        { featureName: "feature2", unit: "", min: 12, max: -34 },
-        { featureName: "feature3", unit: "", min: 0.5, max: 0.25 },
+        { featureName: "feature1", units: "m", min: 1, max: 0 },
+        { featureName: "feature2", units: "m", min: 12, max: -34 },
+        { featureName: "feature3", units: "m", min: 0.5, max: 0.25 },
       ],
       range: [1, 0],
     };
@@ -120,16 +120,16 @@ describe("Loading + saving from URL query strings", () => {
     const parsedParams = loadParamsFromUrlQueryString(queryString);
 
     expect(parsedParams.thresholds).deep.equals([
-      { featureName: "feature1", unit: "", min: 0, max: 1 },
-      { featureName: "feature2", unit: "", min: -34, max: 12 },
-      { featureName: "feature3", unit: "", min: 0.25, max: 0.5 },
+      { featureName: "feature1", units: "m", min: 0, max: 1 },
+      { featureName: "feature2", units: "m", min: -34, max: 12 },
+      { featureName: "feature3", units: "m", min: 0.25, max: 0.5 },
     ]);
     expect(parsedParams.range).deep.equals([0, 1]);
   });
 
-  it("Handles undefined feature thresholds", () => {
+  it("Handles empty feature thresholds", () => {
     const originalParams: Partial<UrlParams> = {
-      thresholds: [{ featureName: "feature1", unit: undefined, min: 0, max: 1 }],
+      thresholds: [{ featureName: "feature1", units: "", min: 0, max: 1 }],
     };
     const queryString = stateToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
@@ -141,7 +141,7 @@ describe("Loading + saving from URL query strings", () => {
       time: 0,
       track: 0,
       range: [0, 0],
-      thresholds: [{ featureName: "feature", unit: "", min: 0, max: 0 }],
+      thresholds: [{ featureName: "feature", units: "", min: 0, max: 0 }],
     };
     const queryString = stateToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -38,16 +38,6 @@ describe("stateToUrlQueryString", () => {
     expect(result).to.be.empty;
   });
 
-  it("Ignores default collections", () => {
-    let result = stateToUrlQueryString({ collection: DEFAULT_COLLECTION_PATH });
-    expect(result).to.be.empty;
-
-    result = stateToUrlQueryString({
-      collection: DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME,
-    });
-    expect(result).to.be.empty;
-  });
-
   it("Encodes URI components", () => {
     const result = stateToUrlQueryString({
       collection: "https://some-url.com/collection.json", // https%3A%2F%2Fsome-url.com%2Fcollection.json

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -87,6 +87,8 @@ describe("Loading + saving from URL query strings", () => {
         { featureName: "f4", units: "mm", min: 0.501, max: 1000.485 },
       ],
       range: [21.433, 89.4],
+      colorRampKey: "myMap-1",
+      colorRampReversed: true,
     };
     const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isUrl,
   isJson,
-  stateToUrlQueryString,
+  paramsToUrlQueryString,
   loadParamsFromUrlQueryString,
   UrlParams,
 } from "../src/colorizer/utils/url_utils";
@@ -43,14 +43,14 @@ describe("isJson", () => {
   });
 });
 
-describe("stateToUrlQueryString", () => {
+describe("paramsToUrlQueryString", () => {
   it("Handles null/undefined values", () => {
-    const result = stateToUrlQueryString({});
+    const result = paramsToUrlQueryString({});
     expect(result).to.be.empty;
   });
 
   it("Encodes URI components", () => {
-    const result = stateToUrlQueryString(stateWithNonLatinCharacters[0]);
+    const result = paramsToUrlQueryString(stateWithNonLatinCharacters[0]);
     // The dataset and feature say "Hello World" in Mandarin and Russian in case you're curious.
     expect(result).to.equal(stateWithNonLatinCharacters[1]);
   });
@@ -66,7 +66,7 @@ describe("loadParamsFromUrlQueryString", () => {
 describe("Loading + saving from URL query strings", () => {
   it("Encodes + Decodes URL strings", () => {
     const originalParams = stateWithNonLatinCharacters[0];
-    const queryString = stateToUrlQueryString(originalParams);
+    const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
   });
@@ -88,7 +88,7 @@ describe("Loading + saving from URL query strings", () => {
       ],
       range: [21.433, 89.4],
     };
-    const queryString = stateToUrlQueryString(originalParams);
+    const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
   });
@@ -102,7 +102,7 @@ describe("Loading + saving from URL query strings", () => {
         { featureName: "0.0%", units: "m&m's", min: 0.0, max: 1 },
       ],
     };
-    const queryString = stateToUrlQueryString(originalParams);
+    const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
   });
@@ -116,7 +116,7 @@ describe("Loading + saving from URL query strings", () => {
       ],
       range: [1, 0],
     };
-    const queryString = stateToUrlQueryString(originalParams);
+    const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
 
     expect(parsedParams.thresholds).deep.equals([
@@ -131,7 +131,7 @@ describe("Loading + saving from URL query strings", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [{ featureName: "feature1", units: "", min: 0, max: 1 }],
     };
-    const queryString = stateToUrlQueryString(originalParams);
+    const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams.thresholds).deep.equals(originalParams.thresholds);
   });
@@ -143,7 +143,7 @@ describe("Loading + saving from URL query strings", () => {
       range: [0, 0],
       thresholds: [{ featureName: "feature", units: "", min: 0, max: 0 }],
     };
-    const queryString = stateToUrlQueryString(originalParams);
+    const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
   });

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -7,6 +7,7 @@ import {
   loadParamsFromUrlQueryString,
   UrlParams,
 } from "../src/colorizer/utils/url_utils";
+import { DEFAULT_COLOR_RAMPS } from "../src/constants";
 
 const stateWithNonLatinCharacters: [Partial<UrlParams>, string] = [
   {
@@ -148,5 +149,19 @@ describe("Loading + saving from URL query strings", () => {
     const queryString = paramsToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
+  });
+
+  it("Handles all color map names", () => {
+    // Test all color ramp names to make sure they can be safely sent through the URL.
+    for (const key of DEFAULT_COLOR_RAMPS.keys()) {
+      const params: Partial<UrlParams> = { colorRampKey: key };
+      let parsedParams = loadParamsFromUrlQueryString(paramsToUrlQueryString(params));
+      expect(parsedParams).deep.equals(params);
+
+      // Reversed
+      params.colorRampReversed = true;
+      parsedParams = loadParamsFromUrlQueryString(paramsToUrlQueryString(params));
+      expect(parsedParams).deep.equals(params);
+    }
   });
 });

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -8,6 +8,18 @@ import {
   UrlParams,
 } from "../src/colorizer/utils/url_utils";
 
+const stateWithNonLatinCharacters: [Partial<UrlParams>, string] = [
+  {
+    collection: "https://some-url.com/collection.json", // https%3A%2F%2Fsome-url.com%2Fcollection.json
+    dataset: "你好世界", // %E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C
+    feature: "Привет, мир", // %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80
+  },
+  // Expected query string:
+  "?collection=https%3A%2F%2Fsome-url.com%2Fcollection.json" +
+    "&dataset=%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C" +
+    "&feature=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80",
+];
+
 describe("isUrl", () => {
   it("Can differentiate URLs", () => {
     expect(isUrl("http://some-url.com/")).to.be.true;
@@ -38,17 +50,9 @@ describe("stateToUrlQueryString", () => {
   });
 
   it("Encodes URI components", () => {
-    const result = stateToUrlQueryString({
-      collection: "https://some-url.com/collection.json", // https%3A%2F%2Fsome-url.com%2Fcollection.json
-      dataset: "你好世界", // %E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C
-      feature: "Привет, мир", // %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80
-    });
+    const result = stateToUrlQueryString(stateWithNonLatinCharacters[0]);
     // The dataset and feature say "Hello World" in Mandarin and Russian in case you're curious.
-    expect(result).to.equal(
-      "?collection=https%3A%2F%2Fsome-url.com%2Fcollection.json" +
-        "&dataset=%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C" +
-        "&feature=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80"
-    );
+    expect(result).to.equal(stateWithNonLatinCharacters[1]);
   });
 });
 
@@ -61,11 +65,7 @@ describe("loadParamsFromUrlQueryString", () => {
 
 describe("Loading + saving from URL query strings", () => {
   it("Encodes + Decodes URL strings", () => {
-    const originalParams = {
-      collection: "https://some-url.com/collection.json", // https%3A%2F%2Fsome-url.com%2Fcollection.json
-      dataset: "你好世界", // %E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C
-      feature: "Привет, мир", // %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80
-    };
+    const originalParams = stateWithNonLatinCharacters[0];
     const queryString = stateToUrlQueryString(originalParams);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
@@ -103,9 +103,28 @@ describe("Loading + saving from URL query strings", () => {
       ],
     };
     const queryString = stateToUrlQueryString(originalParams);
-    console.log(queryString);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
+  });
+
+  it("Enforces min/max on range and thresholds", () => {
+    const originalParams: Partial<UrlParams> = {
+      thresholds: [
+        { featureName: "feature1", min: 1, max: 0 },
+        { featureName: "feature2", min: 12, max: -34 },
+        { featureName: "feature3", min: 0.5, max: 0.25 },
+      ],
+      range: [1, 0],
+    };
+    const queryString = stateToUrlQueryString(originalParams);
+    const parsedParams = loadParamsFromUrlQueryString(queryString);
+
+    expect(parsedParams.thresholds).deep.equals([
+      { featureName: "feature1", min: 0, max: 1 },
+      { featureName: "feature2", min: -34, max: 12 },
+      { featureName: "feature3", min: 0.25, max: 0.5 },
+    ]);
+    expect(parsedParams.range).deep.equals([0, 1]);
   });
 
   it("Handles zero values for numeric parameters", () => {

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -144,7 +144,6 @@ describe("Loading + saving from URL query strings", () => {
       thresholds: [{ featureName: "feature", unit: "", min: 0, max: 0 }],
     };
     const queryString = stateToUrlQueryString(originalParams);
-    console.log(queryString);
     const parsedParams = loadParamsFromUrlQueryString(queryString);
     expect(parsedParams).deep.equals(originalParams);
   });

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { isUrl, isJson, stateToUrlParamString } from "../src/colorizer/utils/url_utils";
+import {
+  isUrl,
+  isJson,
+  stateToUrlQueryString,
+  loadParamsFromUrlQueryString,
+  UrlParams,
+} from "../src/colorizer/utils/url_utils";
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_COLLECTION_PATH } from "../src/constants/url";
 
 describe("isUrl", () => {
@@ -26,29 +32,24 @@ describe("isJson", () => {
   });
 });
 
-describe("stateToUrlParamString", () => {
-  it("Handles null values", () => {
-    const result = stateToUrlParamString({});
+describe("stateToUrlQueryString", () => {
+  it("Handles null/undefined values", () => {
+    const result = stateToUrlQueryString({});
     expect(result).to.be.empty;
   });
 
   it("Ignores default collections", () => {
-    let result = stateToUrlParamString({ collection: DEFAULT_COLLECTION_PATH });
+    let result = stateToUrlQueryString({ collection: DEFAULT_COLLECTION_PATH });
     expect(result).to.be.empty;
 
-    result = stateToUrlParamString({
+    result = stateToUrlQueryString({
       collection: DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME,
     });
     expect(result).to.be.empty;
   });
 
-  it("Ignores bad time values", () => {
-    const result = stateToUrlParamString({ time: -56 });
-    expect(result).to.be.empty;
-  });
-
   it("Encodes URI components", () => {
-    const result = stateToUrlParamString({
+    const result = stateToUrlQueryString({
       collection: "https://some-url.com/collection.json", // https%3A%2F%2Fsome-url.com%2Fcollection.json
       dataset: "你好世界", // %E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C
       feature: "Привет, мир", // %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80
@@ -60,20 +61,78 @@ describe("stateToUrlParamString", () => {
         "&feature=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80"
     );
   });
+});
 
-  it("Ignores bad track values", () => {
-    const result = stateToUrlParamString({ time: -56 });
-    expect(result).to.be.empty;
+describe("loadParamsFromUrlQueryString", () => {
+  it("Handles empty query strings", () => {
+    const result = loadParamsFromUrlQueryString("");
+    expect(result).to.deep.equal({});
+  });
+});
+
+describe("Loading + saving from URL query strings", () => {
+  it("Encodes + Decodes URL strings", () => {
+    const originalParams = {
+      collection: "https://some-url.com/collection.json", // https%3A%2F%2Fsome-url.com%2Fcollection.json
+      dataset: "你好世界", // %E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C
+      feature: "Привет, мир", // %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80
+    };
+    const queryString = stateToUrlQueryString(originalParams);
+    // The dataset and feature say "Hello World" in Mandarin and Russian in case you're curious.
+    expect(queryString).to.equal(
+      "?collection=https%3A%2F%2Fsome-url.com%2Fcollection.json" +
+        "&dataset=%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C" +
+        "&feature=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%2C%20%D0%BC%D0%B8%D1%80"
+    );
+    const parsedParams = loadParamsFromUrlQueryString(queryString);
+    expect(parsedParams).deep.equals(originalParams);
   });
 
-  it("Gets URL parameters", () => {
-    const result = stateToUrlParamString({
+  it("Saves and retrieves URL params correctly", () => {
+    const originalParams: Required<UrlParams> = {
       collection: "collection",
       dataset: "dataset",
       feature: "feature",
       track: 25,
       time: 14,
-    });
-    expect(result).to.equal("?collection=collection&dataset=dataset&feature=feature&track=25&t=14");
+      thresholds: [
+        { featureName: "f1", min: 0, max: 0 },
+        { featureName: "f2", min: NaN, max: NaN },
+        { featureName: "f3", min: 0, max: 1 },
+        { featureName: "f4", min: 0.501, max: 1000.485 },
+      ],
+      range: [21.433, 89.4],
+    };
+    const queryString = stateToUrlQueryString(originalParams);
+    const parsedParams = loadParamsFromUrlQueryString(queryString);
+    expect(parsedParams).deep.equals(originalParams);
+  });
+
+  it("Handles feature threshold names with potentially illegal characters", () => {
+    const originalParams: Partial<UrlParams> = {
+      thresholds: [
+        { featureName: "feature,,,", min: 0, max: 1 },
+        { featureName: "(feature)", min: 0, max: 1 },
+        { featureName: "feat:ure", min: 0, max: 1 },
+        { featureName: "0.0%", min: 0.0, max: 1 },
+      ],
+    };
+    const queryString = stateToUrlQueryString(originalParams);
+    console.log(queryString);
+    const parsedParams = loadParamsFromUrlQueryString(queryString);
+    expect(parsedParams).deep.equals(originalParams);
+  });
+
+  it("Handles zero values for numeric parameters", () => {
+    const originalParams: Partial<UrlParams> = {
+      time: 0,
+      track: 0,
+      range: [0, 0],
+      thresholds: [{ featureName: "feature", min: 0, max: 0 }],
+    };
+    const queryString = stateToUrlQueryString(originalParams);
+    console.log(queryString);
+    const parsedParams = loadParamsFromUrlQueryString(queryString);
+    expect(parsedParams).deep.equals(originalParams);
   });
 });

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -81,10 +81,10 @@ describe("Loading + saving from URL query strings", () => {
       track: 25,
       time: 14,
       thresholds: [
-        { featureName: "f1", min: 0, max: 0 },
-        { featureName: "f2", min: NaN, max: NaN },
-        { featureName: "f3", min: 0, max: 1 },
-        { featureName: "f4", min: 0.501, max: 1000.485 },
+        { featureName: "f1", unit: "m", min: 0, max: 0 },
+        { featureName: "f2", unit: "um", min: NaN, max: NaN },
+        { featureName: "f3", unit: "km", min: 0, max: 1 },
+        { featureName: "f4", unit: "mm", min: 0.501, max: 1000.485 },
       ],
       range: [21.433, 89.4],
     };
@@ -96,10 +96,10 @@ describe("Loading + saving from URL query strings", () => {
   it("Handles feature threshold names with potentially illegal characters", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [
-        { featureName: "feature,,,", min: 0, max: 1 },
-        { featureName: "(feature)", min: 0, max: 1 },
-        { featureName: "feat:ure", min: 0, max: 1 },
-        { featureName: "0.0%", min: 0.0, max: 1 },
+        { featureName: "feature,,,", unit: "", min: 0, max: 1 },
+        { featureName: "(feature)", unit: "", min: 0, max: 1 },
+        { featureName: "feat:ure", unit: "", min: 0, max: 1 },
+        { featureName: "0.0%", unit: "", min: 0.0, max: 1 },
       ],
     };
     const queryString = stateToUrlQueryString(originalParams);
@@ -110,9 +110,9 @@ describe("Loading + saving from URL query strings", () => {
   it("Enforces min/max on range and thresholds", () => {
     const originalParams: Partial<UrlParams> = {
       thresholds: [
-        { featureName: "feature1", min: 1, max: 0 },
-        { featureName: "feature2", min: 12, max: -34 },
-        { featureName: "feature3", min: 0.5, max: 0.25 },
+        { featureName: "feature1", unit: "", min: 1, max: 0 },
+        { featureName: "feature2", unit: "", min: 12, max: -34 },
+        { featureName: "feature3", unit: "", min: 0.5, max: 0.25 },
       ],
       range: [1, 0],
     };
@@ -120,11 +120,20 @@ describe("Loading + saving from URL query strings", () => {
     const parsedParams = loadParamsFromUrlQueryString(queryString);
 
     expect(parsedParams.thresholds).deep.equals([
-      { featureName: "feature1", min: 0, max: 1 },
-      { featureName: "feature2", min: -34, max: 12 },
-      { featureName: "feature3", min: 0.25, max: 0.5 },
+      { featureName: "feature1", unit: "", min: 0, max: 1 },
+      { featureName: "feature2", unit: "", min: -34, max: 12 },
+      { featureName: "feature3", unit: "", min: 0.25, max: 0.5 },
     ]);
     expect(parsedParams.range).deep.equals([0, 1]);
+  });
+
+  it("Handles undefined feature thresholds", () => {
+    const originalParams: Partial<UrlParams> = {
+      thresholds: [{ featureName: "feature1", unit: undefined, min: 0, max: 1 }],
+    };
+    const queryString = stateToUrlQueryString(originalParams);
+    const parsedParams = loadParamsFromUrlQueryString(queryString);
+    expect(parsedParams.thresholds).deep.equals(originalParams.thresholds);
   });
 
   it("Handles zero values for numeric parameters", () => {
@@ -132,7 +141,7 @@ describe("Loading + saving from URL query strings", () => {
       time: 0,
       track: 0,
       range: [0, 0],
-      thresholds: [{ featureName: "feature", min: 0, max: 0 }],
+      thresholds: [{ featureName: "feature", unit: "", min: 0, max: 0 }],
     };
     const queryString = stateToUrlQueryString(originalParams);
     console.log(queryString);

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -7,7 +7,6 @@ import {
   loadParamsFromUrlQueryString,
   UrlParams,
 } from "../src/colorizer/utils/url_utils";
-import { DEFAULT_COLLECTION_FILENAME, DEFAULT_COLLECTION_PATH } from "../src/constants/url";
 
 describe("isUrl", () => {
   it("Can differentiate URLs", () => {


### PR DESCRIPTION
Problem
=======
Closes #124!

Solution
========
- Feature thresholds and current color ramp min+max are now saved to the URL if edited from the defaults.
- The app will now load the color ramp and thresholds from the URL on startup!
- Also refactors tests and other URL handling code to reduce assumptions about formatting in the utility scripts.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link.
2. Set the feature color map range. You should see the URL update.
3. Set feature thresholds in the filters pane. You should also see the URL update.
4. Copy the URL and paste it into a new tab or browser window.
5. The thresholds + color map range should persist.