### PR TITLE
fix: Z-indexing issues with color ramp dropdown and modals

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -244,6 +244,11 @@ export default function AppStyle(props: PropsWithChildren<AppStyleProps>): React
             Divider: {
               marginLG: 0,
             },
+            Modal: {
+              // Set z-index to 2000 here because Ant sets popups to 1050 by default, and modals to 1000.
+              zIndexBase: 2000,
+              zIndexPopupBase: 2000,
+            },
           },
         }}
       >

--- a/src/components/ColorRampDropdown.module.css
+++ b/src/components/ColorRampDropdown.module.css
@@ -34,7 +34,8 @@
 }
 
 .dropdownContainer {
-  z-index: 10;
+  /* Ant makes all of its dropdowns z-index 1050. */
+  z-index: 1051;
   position: absolute;
   top: calc(--height + 1px);
   display: flex;


### PR DESCRIPTION
Problem
=======
Fixes an issue where the color map dropdown would render behind other popups. (Also fixes an issue where dropdowns would appear above modals.)

Solution
========
- Changed z-index for `ColorRampDropdown.tsx` and `Modal`.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
Before:
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/fa3f64a2-d90b-4302-9987-84538df71b41)

After:
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/7bdccf50-d52e-42b5-9862-7fe1e11d6044)
