### PR TITLE
feat: Show recent datasets in load dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.0.0",
       "dependencies": {
         "@ant-design/icons": "^5.2.5",
-        "antd": "5.9.x",
+        "antd": "^5.9.4",
         "mp4-muxer": "^2.2.2",
         "plotly.js-dist-min": "^2.22.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "styled-components": "^6.0.8",
-        "three": "^0.151.3"
+        "three": "^0.151.3",
+        "usehooks-ts": "^2.9.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.3",
@@ -11893,6 +11894,19 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+      "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+      "engines": {
+        "node": ">=16.15.0",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/userhome": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5.2.5",
-    "mp4-muxer": "^2.2.2",
     "antd": "^5.9.4",
+    "mp4-muxer": "^2.2.2",
     "plotly.js-dist-min": "^2.22.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^6.0.8",
-    "three": "^0.151.3"
+    "three": "^0.151.3",
+    "usehooks-ts": "^2.9.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -375,7 +375,7 @@ function App(): ReactElement {
   const handleLoadRequest = useCallback(
     async (url: string): Promise<string> => {
       console.log("Loading '" + url + "'.");
-      const newCollection = await Collection.loadFromAmbiguousUrl(url, urlUtils.fetchWithTimeout);
+      const newCollection = await Collection.loadFromAmbiguousUrl(url);
       const newDatasetKey = newCollection.getDefaultDatasetKey();
       const loadResult = await newCollection.tryLoadDataset(newDatasetKey);
       if (!loadResult.loaded) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -367,10 +367,8 @@ function App(): ReactElement {
   );
 
   /**
-   * Attempt to load an ambiguous URL as either a dataset or a collection.
-   * @param url the url to load.
-   * @returns the resource URL if it was loaded correctly, either an absolute collection
-   * path or an absolute dataset path.
+   * Attempt to load a URL provided in the Load button/modal.
+   * The URL may either be a collection or a dataset, so handle it as an ambiguous URL.
    */
   const handleLoadRequest = useCallback(
     async (url: string): Promise<string> => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -587,7 +587,7 @@ function App(): ReactElement {
             disabled={dataset === null}
             setIsRecording={setIsRecording}
           />
-          <LoadDatasetButton onRequestLoad={handleLoadRequest} />
+          <LoadDatasetButton onRequestLoad={handleLoadRequest} currentResourceUrl={collection?.url || datasetKey} />
         </div>
       </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -369,13 +369,13 @@ function App(): ReactElement {
   /**
    * Attempt to load an ambiguous URL as either a dataset or a collection.
    * @param url the url to load.
-   * @returns a LoadResult, which includes a `result` boolean flag (true if successful, false if not)
-   * and an optional `errorMessage`.
+   * @returns the resource URL if it was loaded correctly, either an absolute collection
+   * path or an absolute dataset path.
    */
   const handleLoadRequest = useCallback(
-    async (url: string): Promise<void> => {
+    async (url: string): Promise<string> => {
       console.log("Loading '" + url + "'.");
-      const newCollection = await Collection.loadFromAmbiguousUrl(url);
+      const newCollection = await Collection.loadFromAmbiguousUrl(url, urlUtils.fetchWithTimeout);
       const newDatasetKey = newCollection.getDefaultDatasetKey();
       const loadResult = await newCollection.tryLoadDataset(newDatasetKey);
       if (!loadResult.loaded) {
@@ -395,6 +395,7 @@ function App(): ReactElement {
       setCollection(newCollection);
       setFeatureThresholds([]); // Clear when switching collections
       await replaceDataset(loadResult.dataset, newDatasetKey);
+      return newCollection.url || newCollection.getDefaultDatasetKey();
     },
     [replaceDataset]
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -367,8 +367,10 @@ function App(): ReactElement {
   );
 
   /**
-   * Attempt to load a URL provided in the Load button/modal.
+   * Attempt to load a URL provided in the Load menu.
    * The URL may either be a collection or a dataset, so handle it as an ambiguous URL.
+   * @throws an error if the URL could not be loaded.
+   * @returns the absolute path of the URL resource that was loaded.
    */
   const handleLoadRequest = useCallback(
     async (url: string): Promise<string> => {

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -1,0 +1,3 @@
+import DropdownSVGAsset from "../assets/dropdown-arrow.svg?react";
+
+export const DropdownSVG = DropdownSVGAsset;

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -284,7 +284,7 @@ export default class Collection {
       console.log("URL resource could not be parsed as a collection; attempting to make a single-database collection.");
     }
 
-    // Could not load as a collection, attempt to load as a daataset.
+    // Could not load as a collection, attempt to load as a dataset.
     return await Collection.makeCollectionFromSingleDataset(url);
   }
 }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -40,18 +40,12 @@ export function fetchWithTimeout(
   timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
   options?: RequestInit
 ): Promise<Response> {
-  const controller = new AbortController();
-  const signal = controller.signal;
   // If the fetch finishes before the timeout completes, clear the timeout.
   // Note: It's ok even if the timeout still triggers, because the fetch promise is already resolved (settled) and
   // won't change even if the AbortController signals for a promise rejection.
-  const timeoutId = setTimeout(() => controller.abort, timeoutMs);
-  const fetchPromise = fetch(url, { signal: signal, ...options });
-  fetchPromise.then(
-    // clear timeout if resolved or rejected
-    () => clearTimeout(timeoutId),
-    () => clearTimeout(timeoutId)
-  );
+
+  const fetchPromise = fetch(url, { signal: AbortSignal.timeout(timeoutMs), ...options });
+
   return fetchPromise;
 }
 

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -40,12 +40,7 @@ export function fetchWithTimeout(
   timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
   options?: RequestInit
 ): Promise<Response> {
-  // If the fetch finishes before the timeout completes, clear the timeout.
-  // Note: It's ok even if the timeout still triggers, because the fetch promise is already resolved (settled) and
-  // won't change even if the AbortController signals for a promise rejection.
-
   const fetchPromise = fetch(url, { signal: AbortSignal.timeout(timeoutMs), ...options });
-
   return fetchPromise;
 }
 

--- a/src/components/LabeledDropdown.tsx
+++ b/src/components/LabeledDropdown.tsx
@@ -8,8 +8,6 @@ import { DropdownSVG } from "../assets";
 type LabeledDropdownProps = {
   /** Text label to include with the dropdown. If null or undefined, hides the label. */
   label?: string | null;
-  /** Text label inside the dropdown button. If null, uses the currently selected item. */
-  placeholder?: string | null;
   /** The key of the item that is currently selected. */
   selected: string;
   /** An array of ItemType that describes the item properties (`{key, label}`),
@@ -30,7 +28,6 @@ type LabeledDropdownProps = {
 
 const defaultProps = {
   label: null,
-  placeholder: null,
   disabled: false,
   buttonType: "default",
   showTooltip: true,
@@ -111,7 +108,7 @@ export default function LabeledDropdown(inputProps: LabeledDropdownProps): React
       onClick={() => setForceOpen(!forceOpen)}
     >
       <div className={styles.buttonContents}>
-        <div className={styles.buttonText}>{props.placeholder ? props.placeholder : selectedLabel}</div>
+        <div className={styles.buttonText}>{selectedLabel}</div>
         <DropdownSVG className={`${styles.buttonIcon} ${styles[props.buttonType || "default"]}`} />
       </div>
     </Button>

--- a/src/components/LabeledDropdown.tsx
+++ b/src/components/LabeledDropdown.tsx
@@ -2,12 +2,14 @@ import React, { ReactElement, ReactNode, useEffect, useMemo, useRef, useState } 
 import styles from "./LabeledDropdown.module.css";
 import { Dropdown, Button, Tooltip } from "antd";
 import { ItemType, MenuItemType } from "antd/es/menu/hooks/useItems";
-import DropdownSVG from "../assets/dropdown-arrow.svg?react";
 import useToken from "antd/es/theme/useToken";
+import { DropdownSVG } from "../assets";
 
 type LabeledDropdownProps = {
   /** Text label to include with the dropdown. If null or undefined, hides the label. */
   label?: string | null;
+  /** Text label inside the dropdown button. If null, uses the currently selected item. */
+  placeholder?: string | null;
   /** The key of the item that is currently selected. */
   selected: string;
   /** An array of ItemType that describes the item properties (`{key, label}`),
@@ -28,6 +30,7 @@ type LabeledDropdownProps = {
 
 const defaultProps = {
   label: null,
+  placeholder: null,
   disabled: false,
   buttonType: "default",
   showTooltip: true,
@@ -108,7 +111,7 @@ export default function LabeledDropdown(inputProps: LabeledDropdownProps): React
       onClick={() => setForceOpen(!forceOpen)}
     >
       <div className={styles.buttonContents}>
-        <div className={styles.buttonText}>{selectedLabel}</div>
+        <div className={styles.buttonText}>{props.placeholder ? props.placeholder : selectedLabel}</div>
         <DropdownSVG className={`${styles.buttonIcon} ${styles[props.buttonType || "default"]}`} />
       </div>
     </Button>

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement, ReactNode, useCallback, useContext, useRef, useState } from "react";
-import { Button, Dropdown, Input, InputRef, MenuProps, Modal } from "antd";
+import { Button, Dropdown, Input, InputRef, MenuProps, Modal, Space } from "antd";
 import { AppThemeContext } from "./AppStyle";
-import { useLocalStorage } from "usehooks-ts";
+import { useClickAnyWhere, useLocalStorage } from "usehooks-ts";
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_COLLECTION_PATH } from "../constants";
 import { DropdownSVG } from "../assets";
 import LabeledDropdown from "./LabeledDropdown";
 
 /** Key for local storage to read/write recently opened datasets */
 const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
-const MAX_RECENT_DATASETS = 5;
+const MAX_RECENT_DATASETS = 10;
 
 type LoadDatasetButtonProps = {
   /**
@@ -32,12 +32,24 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
   const modalContextRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<InputRef>(null);
-  const [urlInput, setUrlInput] = useState("");
+
+  const [urlInput, _setUrlInput] = useState("");
+  const setUrlInput = useCallback((newUrl: string) => {
+    if (newUrl === "") {
+      setForceHideModal(false);
+    } else {
+      // Hide if any input is given
+      setForceHideModal(true);
+    }
+    _setUrlInput(newUrl);
+  }, []);
+
   const [isLoading, setIsLoading] = useState(false);
   const [errorText, setErrorText] = useState<string>("");
   const [recentDatasets, setRecentDatasets] = useLocalStorage<string[]>(RECENT_DATASETS_STORAGE_KEY, [
     DEFAULT_COLLECTION_PATH + "/" + DEFAULT_COLLECTION_FILENAME,
   ]);
+  const [forceHideRecentDropdown, setForceHideModal] = useState(false);
 
   const handleLoadClicked = useCallback(async (): Promise<void> => {
     if (urlInput === "") {
@@ -57,29 +69,34 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     props.onRequestLoad(urlInput).then(
       () => {
         // success
-        setErrorText("");
-        setUrlInput("");
-        setIsLoadModalOpen(false);
-        setIsLoading(false);
-        // Add to recent datasets
-        // Note: Use the url input rather than the absolute resource path here. This makes it
-        // easier for users to find previous inputs, rather than obfuscating it with the full path.
-        const datasetIndex = recentDatasets.indexOf(urlInput);
-        if (datasetIndex === -1) {
-          // New dataset, add to front while maintaining max length
-          setRecentDatasets([urlInput, ...recentDatasets.slice(0, MAX_RECENT_DATASETS - 1)]);
-        } else {
-          // Move to front
-          setRecentDatasets([
-            urlInput,
-            ...recentDatasets.slice(0, datasetIndex),
-            ...recentDatasets.slice(datasetIndex + 1),
-          ]);
-        }
+        // Add a slight delay before closing and resetting the modal for a smoother experience
+        setTimeout(() => {
+          setIsLoadModalOpen(false);
+          setIsLoading(false);
+          // Add to recent datasets
+          const datasetIndex = recentDatasets.indexOf(urlInput);
+          if (datasetIndex === -1) {
+            // New dataset, add to front while maintaining max length
+            setRecentDatasets([urlInput, ...recentDatasets.slice(0, MAX_RECENT_DATASETS - 1)]);
+          } else {
+            // Move to front
+            setRecentDatasets([
+              urlInput,
+              ...recentDatasets.slice(0, datasetIndex),
+              ...recentDatasets.slice(datasetIndex + 1),
+            ]);
+          }
+          setErrorText("");
+          setUrlInput("");
+        }, 500);
         return;
       },
       (reason) => {
         // failed
+        if (reason && reason.toString().includes("AbortError")) {
+          setErrorText("Timeout: The dataset(s) took too long to load. Please try again.");
+          return;
+        }
         setErrorText(
           reason.toString() ||
             "The dataset(s) could not be loaded with the URL provided. Please check it and try again."
@@ -110,6 +127,18 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     items: datasetsDropdownItems,
   };
 
+  // Requested dropdown behavior:
+  // - Dropdown should open whenever you click on the input field, even if there is currently content inside it.
+  // - If the user starts typing or pastes in content, the dropdown should disappear.
+  // - If the user clicks on an option in the dropdown, the dropdown should disappear and the text
+  //   of the clicked option should appear in the input box.
+  // - The dropdown should disappear if Load is clicked.
+
+  // Implementation notes: We need to add a click listener and close the Dropdown if something other than it is clicked.
+  useClickAnyWhere(() => {
+    setForceHideModal(false);
+  });
+
   return (
     <div ref={modalContextRef}>
       <Button type="primary" onClick={() => setIsLoadModalOpen(true)}>
@@ -118,32 +147,46 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       <Modal
         title={"Load a single dataset or collection"}
         open={isLoadModalOpen}
-        okText={"Load"}
-        onOk={handleLoadClicked}
-        okButtonProps={{ loading: isLoading }}
         onCancel={handleCancel}
-        cancelButtonProps={{ hidden: true }}
         getContainer={modalContextRef.current || undefined}
         afterOpenChange={(open) => open && inputRef.current?.focus({ cursor: "all" })}
+        footer={<Button onClick={handleCancel}>Cancel</Button>}
       >
-        <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
-          <p>Load a collection of datasets or a single dataset by providing its URL.</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          <p style={{ marginBottom: "10px" }}>
+            Load a collection of datasets or a single dataset by providing its URL.
+          </p>
           <div>
-            <Dropdown trigger={["click"]} menu={datasetsDropdownProps} placement="bottomLeft">
-              <Input
-                placeholder="https://example.com/collection.json"
-                value={urlInput}
-                ref={inputRef}
-                onChange={(event) => setUrlInput(event.target.value)}
-                allowClear
-              />
-            </Dropdown>
+            <div style={{ display: "flex", flexDirection: "row", gap: "6px" }}>
+              <Space.Compact style={{ width: "100%" }}>
+                <Dropdown
+                  trigger={["click"]}
+                  menu={datasetsDropdownProps}
+                  placement="bottomLeft"
+                  // Force the dropdown to be hidden (open=false) if disabled; otherwise allow default behavior.
+                  open={forceHideRecentDropdown ? false : undefined}
+                >
+                  <Input
+                    placeholder="https://example.com/collection.json"
+                    value={urlInput}
+                    ref={inputRef}
+                    onChange={(event) => setUrlInput(event.target.value)}
+                    allowClear
+                    disabled={isLoading}
+                  />
+                </Dropdown>
+                <Button type="primary" onClick={handleLoadClicked} loading={isLoading}>
+                  Load
+                </Button>
+              </Space.Compact>
+            </div>
             <p>
               <i>
                 <span style={{ color: theme.color.text.hint }}>Click for recent datasets</span>
               </i>
             </p>
           </div>
+
           {/** TODO: Mount the popups here */}
           {errorText && (
             <p>

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Input, InputRef, MenuItemProps, MenuProps, Modal, Space } from "antd";
+import { Button, Dropdown, Input, InputRef, MenuProps, Modal, Space } from "antd";
 import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useClickAnyWhere, useLocalStorage } from "usehooks-ts";

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -1,10 +1,12 @@
-import { Button, Dropdown, Input, InputRef, MenuProps, Modal, Space } from "antd";
+import { Button, Dropdown, Input, InputRef, MenuItemProps, MenuProps, Modal, Space } from "antd";
 import React, { ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { useClickAnyWhere, useLocalStorage } from "usehooks-ts";
 
 import { AppThemeContext } from "./AppStyle";
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_COLLECTION_PATH } from "../constants";
+import { MenuItemType } from "antd/es/menu/hooks/useItems";
+import { FolderOpenOutlined } from "@ant-design/icons";
 
 /** Key for local storage to read/write recently opened datasets */
 const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
@@ -22,6 +24,8 @@ type LoadDatasetButtonProps = {
    * @returns a Promise object resolving to the absolute path of the resource.
    */
   onRequestLoad: (url: string) => Promise<string>;
+  /** The URL of the currently loaded resource, used to indicate it on the recent datasets dropdown. */
+  currentResourceUrl: string;
 };
 
 const defaultProps: Partial<LoadDatasetButtonProps> = {};
@@ -32,6 +36,8 @@ const defaultProps: Partial<LoadDatasetButtonProps> = {};
  */
 const DropdownContentContainer = styled.div`
   position: absolute;
+  width: max-content;
+  max-width: 80vw;
   background-color: var(--color-background);
   border-radius: var(--radius-control-small);
   box-shadow: 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 9px 28px 8px rgba(0, 0, 0, 0.05);
@@ -42,6 +48,17 @@ const DropdownContentContainer = styled.div`
     // Disable the real dropdown's styling
     box-shadow: transparent 0 0 !important;
     background-color: transparent;
+  }
+
+  & .ant-dropdown-menu-item {
+    width: 100%;
+    overflow: hidden;
+
+    overflow-wrap: break-word;
+  }
+
+  & .ant-dropdown-menu-item:not(:last-child) {
+    margin-bottom: 4px;
   }
 `;
 
@@ -173,10 +190,14 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
 
   // RENDERING ////////////////////////////////////////////////////////
 
-  const datasetsDropdownItems = recentDatasets.map(({ url, label }) => {
+  const datasetsDropdownItems: MenuItemType[] = recentDatasets.map(({ url, label }) => {
+    const isCurrentUrl = props.currentResourceUrl === url;
     return {
       key: url,
       label: label,
+      // Disable if dataset is currently open
+      disabled: isCurrentUrl,
+      icon: isCurrentUrl ? <FolderOpenOutlined /> : undefined,
     };
   });
 
@@ -193,6 +214,8 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       setUrlInput(info.key);
     },
     items: datasetsDropdownItems,
+    selectable: true,
+    selectedKeys: [urlInput],
   };
 
   return (

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -53,8 +53,6 @@ const DropdownContentContainer = styled.div`
   & .ant-dropdown-menu-item {
     width: 100%;
     overflow: hidden;
-
-    overflow-wrap: break-word;
   }
 
   & .ant-dropdown-menu-item:not(:last-child) {
@@ -202,6 +200,21 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     };
   });
 
+  // Get the URLs (keys) of any recent datasets that match the currently selected urlInput.
+  const matchingKeys = recentDatasets.filter(({ label }) => label === urlInput).map(({ url }) => url);
+  const datasetsDropdownProps: MenuProps = {
+    onClick: (info) => {
+      // Set the URL input to the label of the selected dataset
+      const dataset = recentDatasets.find(({ url }) => url === info.key);
+      if (dataset) {
+        setUrlInput(dataset.label);
+      }
+    },
+    items: datasetsDropdownItems,
+    selectable: true,
+    selectedKeys: matchingKeys,
+  };
+
   const renderDropdown = (menu: ReactNode): React.JSX.Element => (
     // Add a fake container around this so we can include a text label ("Recent datasets")
     <DropdownContentContainer>
@@ -209,15 +222,6 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       {menu}
     </DropdownContentContainer>
   );
-
-  const datasetsDropdownProps: MenuProps = {
-    onClick: (info) => {
-      setUrlInput(info.key);
-    },
-    items: datasetsDropdownItems,
-    selectable: true,
-    selectedKeys: [urlInput],
-  };
 
   return (
     <div ref={modalContextRef}>

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -13,7 +13,9 @@ const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
 const MAX_RECENT_DATASETS = 10;
 
 type RecentDataset = {
+  /** The absolute URL path of the dataset resource. */
   url: string;
+  /** The user input for the dataset resource. */
   label: string;
 };
 

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -31,6 +31,7 @@ const defaultProps: Partial<LoadDatasetButtonProps> = {};
  * like a single dropdown.
  */
 const DropdownContentContainer = styled.div`
+  position: absolute;
   background-color: var(--color-background);
   border-radius: var(--radius-control-small);
   box-shadow: 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 9px 28px 8px rgba(0, 0, 0, 0.05);
@@ -49,6 +50,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
 
   const theme = useContext(AppThemeContext);
   const modalContextRef = useRef<HTMLDivElement>(null);
+  const dropdownContextRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<InputRef>(null);
 
   // STATE ////////////////////////////////////////////////////////////
@@ -166,6 +168,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     setIsLoading(false);
     setErrorText("");
     setIsLoadModalOpen(false);
+    setShowRecentDropdown(false);
   }, []);
 
   // RENDERING ////////////////////////////////////////////////////////
@@ -210,7 +213,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
             Load a collection of datasets or a single dataset by providing its URL.
           </p>
 
-          <div>
+          <div ref={dropdownContextRef} style={{ position: "relative" }}>
             <div style={{ display: "flex", flexDirection: "row", gap: "6px" }}>
               <Space.Compact style={{ width: "100%" }}>
                 <Dropdown
@@ -218,7 +221,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
                   menu={datasetsDropdownProps}
                   placement="bottomLeft"
                   open={showRecentDropdown}
-                  getPopupContainer={modalContextRef.current ? () => modalContextRef.current! : undefined}
+                  getPopupContainer={dropdownContextRef.current ? () => dropdownContextRef.current! : undefined}
                   dropdownRender={renderDropdown}
                 >
                   <Input

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -244,6 +244,11 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
           </p>
 
           <div ref={dropdownContextRef} style={{ position: "relative" }}>
+            <p>
+              <i>
+                <span style={{ color: theme.color.text.hint }}> Click below to show recent datasets</span>
+              </i>
+            </p>
             <div style={{ display: "flex", flexDirection: "row", gap: "6px" }}>
               <Space.Compact style={{ width: "100%" }}>
                 <Dropdown
@@ -268,11 +273,6 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
                 </Button>
               </Space.Compact>
             </div>
-            <p>
-              <i>
-                <span style={{ color: theme.color.text.hint }}>Click for recent datasets</span>
-              </i>
-            </p>
           </div>
 
           {errorText && (

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -77,7 +77,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   // suddenly) if trying to temporarily disable visibility.
   const [showRecentDropdown, setShowRecentDropdown] = useState(false);
   const [urlInput, _setUrlInput] = useState("");
-  // Clear the dropdown when user starts typing
+  // Wrap `setUrlInput` so we clear the dropdown when user starts typing
   const setUrlInput = useCallback((newUrl: string) => {
     setShowRecentDropdown(false);
     _setUrlInput(newUrl);
@@ -109,7 +109,8 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   }, [isLoadModalOpen]);
 
   // The dropdown should be shown whenever the user clicks on the input field, and hidden if the user starts
-  // typing or clicks off of the input (including clicking options).
+  // typing or clicks off of the input (including selecting options in the dropdown).
+  // TODO: It's not currently possible to open the dropdown with tab navigation. Pending further discussion with UX team.
   useClickAnyWhere((event) => {
     if (event.target === inputRef.current?.input) {
       setShowRecentDropdown(true);
@@ -202,7 +203,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   });
 
   const renderDropdown = (menu: ReactNode): React.JSX.Element => (
-    // Add a fake container around this so we can include a text label
+    // Add a fake container around this so we can include a text label ("Recent datasets")
     <DropdownContentContainer>
       <span style={{ paddingLeft: "16px", color: theme.color.text.hint }}>Recent datasets:</span>
       {menu}


### PR DESCRIPTION
Problem
=======
Closes #122!

Solution
========
- Clicking on the input field in the Load menu will show a list of the 10 most recently opened datasets, with the most recent datasets at the top.
- Successfully opened datasets are saved to local storage (using the new `usehooks-ts` library), so they persist between browser sessions.

Misc:
- Adds `assets/index.ts` to start isolating some weird import syntax to a single location, specifically for SVG icon used in `LabeledDropdown`.
- Caught some typos in documentation elsewhere in the project.
- Fixes a bug where `fetchWithTimeout` would not actually time out (was able to catch this due to today's Vast outage 😋)
  - Made a new issue for adding unit tests for this (#142)


## Type of change
* New feature (non-breaking change which adds functionality)


Change summary:
---------------
* Shows a list of the 10 most recently opened datasets in the Load modal, adding open/close behavior.
* Tweaks/improvements to Load modal UI.
* Adds the `usehooks-ts` library.
* Fixes issue with `fetchWithTimeout` where it would not time out.

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-141/
1. Go to the Load menu, and load in a dataset (https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test)
1. Open the load menu again. There should now be two options in the recent datasets dropdown.
1. Clicking an option in the dropdown will populate it in the input.
1. Open another dataset (https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/EMT/collection.json).
1. Test switching between datasets and loading each one. The list should be ordered by most recent still.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/85326520-028a-4284-bfa6-e7efcf1a4888)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/1cb220f2-9f80-48c9-a3b8-cda00d3b2aec)

🔉 (Turn on audio for walkthrough!)

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/5cfcd484-e63f-4e26-8b83-a28baaf2fa6c


Keyfiles (delete if not relevant):
-----------------------
1. `LoadDatasetButton.tsx`

Thanks for contributing!
