### PR TITLE
feat: Support `/allen` file links

### DIFF
--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -150,7 +150,7 @@ export function isAllenPath(input: string): boolean {
 }
 
 /**
- * Attempst to convert an Allen path to an HTTPS resource path.
+ * Attempts to convert an Allen path to an HTTPS resource path.
  * @returns Returns null if the path was not recognized or could not be converted,
  * otherwise, returns an HTTPS resource path.
  */

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -144,10 +144,23 @@ export function isUrl(input: string | null): boolean {
 }
 
 /**
+ * Normalizes a file path to use only single forward slashes. Replaces
+ * backwards slashes with forward slashes, and removes double slashes.
+ */
+function normalizeFilePathSlashes(input: string): string {
+  // Replace all backslashes with forward slashes
+  input = input.replaceAll("\\", "/");
+  // Replace double slashes with single
+  input = input.replaceAll("//", "/");
+  return input;
+}
+
+/**
  * Returns whether the input string is a path to an Allen file server resource.
+ * Matches any path that starts with `/allen/`, normalizing for backwards and double slashes.
  */
 export function isAllenPath(input: string): boolean {
-  return input.startsWith(ALLEN_FILE_PREFIX);
+  return normalizeFilePathSlashes(input).startsWith(ALLEN_FILE_PREFIX);
 }
 
 /**
@@ -156,6 +169,7 @@ export function isAllenPath(input: string): boolean {
  * otherwise, returns an HTTPS resource path.
  */
 export function convertAllenPathToHttps(input: string): string | null {
+  input = normalizeFilePathSlashes(input);
   for (const prefix of Object.keys(ALLEN_PREFIX_TO_HTTPS)) {
     if (input.startsWith(prefix)) {
       return input.replace(prefix, ALLEN_PREFIX_TO_HTTPS[prefix]);

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -14,6 +14,11 @@ const URL_PARAM_RANGE = "range";
 const URL_PARAM_COLOR_RAMP = "color";
 const URL_COLOR_RAMP_REVERSED_SUFFIX = "!";
 
+const ALLEN_FILE_PREFIX = "/allen/";
+const ALLEN_PREFIX_TO_HTTPS: Record<string, string> = {
+  "/allen/aics/assay-dev": "https://dev-aics-dtp-001.int.allencell.org/assay-dev",
+};
+
 export type UrlParams = {
   collection: string;
   dataset: string;
@@ -135,6 +140,27 @@ export function updateUrl(urlParams: string): void {
 export function isUrl(input: string | null): boolean {
   // Check for strings that start with http(s):// or a double-slash (//).
   return input !== null && (/^http(s)*:\/\//.test(input) || /^\/\//.test(input));
+}
+
+/**
+ * Returns whether the input string is a path to an Allen file server resource.
+ */
+export function isAllenPath(input: string): boolean {
+  return input.startsWith(ALLEN_FILE_PREFIX);
+}
+
+/**
+ * Attempst to convert an Allen path to an HTTPS resource path.
+ * @returns Returns null if the path was not recognized or could not be converted,
+ * otherwise, returns an HTTPS resource path.
+ */
+export function convertAllenPathToHttps(input: string): string | null {
+  for (const prefix of Object.keys(ALLEN_PREFIX_TO_HTTPS)) {
+    if (input.startsWith(prefix)) {
+      return input.replace(prefix, ALLEN_PREFIX_TO_HTTPS[prefix]);
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -17,6 +17,7 @@ const URL_COLOR_RAMP_REVERSED_SUFFIX = "!";
 const ALLEN_FILE_PREFIX = "/allen/";
 const ALLEN_PREFIX_TO_HTTPS: Record<string, string> = {
   "/allen/aics/assay-dev": "https://dev-aics-dtp-001.int.allencell.org/assay-dev",
+  "/allen/aics/microscopy": "https://dev-aics-dtp-001.int.allencell.org/microscopy",
 };
 
 export type UrlParams = {

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -7,6 +7,7 @@ import { AppThemeContext } from "./AppStyle";
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_COLLECTION_PATH } from "../constants";
 import { MenuItemType } from "antd/es/menu/hooks/useItems";
 import { FolderOpenOutlined } from "@ant-design/icons";
+import { convertAllenPathToHttps, isAllenPath } from "../colorizer/utils/url_utils";
 
 /** Key for local storage to read/write recently opened datasets */
 const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
@@ -124,7 +125,20 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       setErrorText("Please enter a URL!");
       return;
     }
-    if (window.location.protocol === "https:" && urlInput.trim().startsWith("http:")) {
+    let formattedUrlInput = urlInput.trim();
+    // Check if the URL is an allen resource. If so, attempt to convert it.
+    if (isAllenPath(formattedUrlInput)) {
+      const convertedUrl = convertAllenPathToHttps(formattedUrlInput);
+      if (!convertedUrl) {
+        setErrorText(
+          "This directory can't be loaded directly. Contact danielt@alleninstitute.org or peyton.lee@alleninstitute.org for more details."
+        );
+        return;
+      }
+      formattedUrlInput = convertedUrl;
+    }
+
+    if (window.location.protocol === "https:" && formattedUrlInput.startsWith("http:")) {
       setErrorText(
         "Cannot load a HTTP resource from an HTTPS site. Please move your dataset so it is served over HTTPS, or install and run this project locally."
       );
@@ -134,7 +148,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       return;
     }
     setIsLoading(true);
-    props.onRequestLoad(urlInput).then(
+    props.onRequestLoad(formattedUrlInput).then(
       (loadedUrl) => {
         // Add a slight delay before closing and resetting the modal for a smoother experience
         setTimeout(() => {
@@ -145,7 +159,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
           // because there is some ambiguity in user input, since we accept both filenames and directories.
           const newRecentDataset: RecentDataset = {
             url: loadedUrl,
-            label: urlInput,
+            label: urlInput, // Use raw url input for the label
           };
           const datasetIndex = recentDatasets.findIndex(({ url }) => url === loadedUrl);
           if (datasetIndex === -1) {

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -131,7 +131,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       const convertedUrl = convertAllenPathToHttps(formattedUrlInput);
       if (!convertedUrl) {
         setErrorText(
-          "This directory can't be loaded directly. Contact danielt@alleninstitute.org or peyton.lee@alleninstitute.org for more details."
+          "The provided filestore path cannot be loaded directly. Please check that the path is correct! Alternatively, move your dataset so it is served over HTTPS."
         );
         return;
       }

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -6,6 +6,7 @@ import {
   paramsToUrlQueryString,
   loadParamsFromUrlQueryString,
   UrlParams,
+  isAllenPath,
 } from "../src/colorizer/utils/url_utils";
 import { DEFAULT_COLOR_RAMPS } from "../src/constants";
 
@@ -61,6 +62,27 @@ describe("loadParamsFromUrlQueryString", () => {
   it("Handles empty query strings", () => {
     const result = loadParamsFromUrlQueryString("");
     expect(result).to.deep.equal({});
+  });
+});
+
+describe("isAllenPath", () => {
+  it("Detects allen paths correctly", () => {
+    expect(isAllenPath("/allen/some/resource")).to.be.true;
+    expect(isAllenPath("/allen/another/resource")).to.be.true;
+    expect(isAllenPath("/not-allen/")).to.be.false;
+    expect(isAllenPath("/some-other-resource/allen/")).to.be.false;
+  });
+
+  it("Ignores URLs", () => {
+    expect(isAllenPath("https://some-website.com/allen/another/resource")).to.be.false;
+    expect(isAllenPath("http://allen/some-website.com")).to.be.false;
+  });
+
+  it("Normalizes slashes", () => {
+    expect(isAllenPath("\\allen\\some-resource\\path.json")).to.be.true;
+    expect(isAllenPath("\\\\allen\\\\some-resource\\\\path.json")).to.be.true;
+    expect(isAllenPath("/allen//some-resource////path.json")).to.be.true;
+    expect(isAllenPath("//allen//some-resource////path.json")).to.be.true;
   });
 });
 


### PR DESCRIPTION
Problem
=======
Closes #133!

Solution
========
- Adds a lookup table for accepted `/allen` directories, with mappings to their HTTPS equivalents.
- Updates the error messages to give more info when loading unsupported allen directories.
- Compatible with the recent datasets dropdown!

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-144/
2. Load this `/allen` directory: `/allen/aics/assay-dev/computational/data/EMT_deliverable_processing/LH_Analysis/Version2_ColorizerTest`
3. The dataset should appear correctly.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/3cee584c-0980-4d4a-be9c-1da99defdc5f)
