### PR TITLE
feat: Physical time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ function App(): ReactElement {
   const [isColorRampRangeLocked, setIsColorRampRangeLocked] = useState(false);
   const [showTrackPath, setShowTrackPath] = useState(false);
   const [showScaleBar, setShowScaleBar] = useState(true);
+  const [showTimestamp, setShowTimestamp] = useState(true);
 
   // Provides a mounting point for Antd's notification component. Otherwise, the notifications
   // are mounted outside of App and don't receive CSS styling variables.
@@ -673,6 +674,7 @@ function App(): ReactElement {
                 }}
                 onMouseLeave={() => setShowHoveredId(false)}
                 showScaleBar={showScaleBar}
+                showTimestamp={showTimestamp}
               />
             </HoverTooltip>
 
@@ -832,6 +834,15 @@ function App(): ReactElement {
                             }}
                           >
                             Show scale bar
+                          </Checkbox>
+                          <Checkbox
+                            type="checkbox"
+                            checked={showTimestamp}
+                            onChange={() => {
+                              setShowTimestamp(!showTimestamp);
+                            }}
+                          >
+                            Show timestamp
                           </Checkbox>
                         </div>
                       </div>

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -1,3 +1,4 @@
+import { Vector2 } from "three";
 import { numberToSciNotation } from "./utils/math_utils";
 
 export type StyleOptions = {
@@ -205,7 +206,8 @@ export default class CanvasOverlay {
     if (useSeconds) {
       const seconds = this.timestampOptions.currentTimestampSeconds % 60; // Ignore minutes/hours
       if (!useHours && this.timestampOptions.frameDurationSeconds % 1.0 !== 0) {
-        timestampDigits.unshift(seconds.toFixed(2).padStart(5, "0"));
+        // Duration increment is smaller than a second and we're not using hours, so show milliseconds.
+        timestampDigits.unshift(seconds.toFixed(3).padStart(6, "0"));
       } else {
         timestampDigits.unshift(seconds.toFixed(0).padStart(2, "0"));
       }
@@ -221,7 +223,7 @@ export default class CanvasOverlay {
       timestampDigits.unshift(hours.toString().padStart(2, "0"));
       timestampUnits.unshift("h");
     }
-    const timestampFormatted = timestampDigits.join(":") + " " + timestampUnits.join(":");
+    const timestampFormatted = timestampDigits.join(":") + " (" + timestampUnits.join(", ") + ")";
 
     // Render the resulting timestamp in the bottom left corner of the canvas.
     const marginPx = { v: 0, h: 20 };

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -190,22 +190,32 @@ export default class CanvasOverlay {
     // max timestamp parameter.
     // Then, format the resulting timestamp based on that format (Ideally close to HH:mm:ss`s`), with extra
     // precision if only using seconds/minutes (mm:ss.ss`s` or ss.ss`s`).
-    // TODO: Handle timestamps where only hours/minutes are used. This would require the
-    // frame duration to be passed in.
+    // TODO: Cleanup this code.
     const useMinutes = this.timestampOptions.maxTimestampSeconds >= 60;
     const useHours = this.timestampOptions.maxTimestampSeconds >= 60 * 60;
+    const useSeconds =
+      this.timestampOptions.frameDurationSeconds % 60 === 0 && this.timestampOptions.startTimeSeconds % 60 === 0;
     const useHighPrecisionSeconds = !useHours;
 
     const seconds = this.timestampOptions.currentTimestampSeconds % 60; // Ignore minutes/hours
     let timestampFormatted = "";
-    if (useHighPrecisionSeconds) {
-      timestampFormatted = seconds.toFixed(2).padStart(5, "0") + "s";
-    } else {
-      timestampFormatted = seconds.toFixed(0).padStart(2, "0") + "s";
+    if (useSeconds) {
+      if (useHighPrecisionSeconds) {
+        timestampFormatted = seconds.toFixed(2).padStart(5, "0") + "s";
+      } else {
+        timestampFormatted = seconds.toFixed(0).padStart(2, "0") + "s";
+      }
+      if (useMinutes) {
+        timestampFormatted = `:${timestampFormatted}`;
+      }
     }
     if (useMinutes) {
       const minutes = Math.floor(this.timestampOptions.currentTimestampSeconds / 60) % 60;
-      timestampFormatted = `${minutes.toString().padStart(2, "0")}:${timestampFormatted}`;
+      timestampFormatted = `${minutes.toString().padStart(2, "0")}${timestampFormatted}`;
+      // TODO: Is this the best way to label this?
+      if (useMinutes && !useSeconds) {
+        timestampFormatted = `${timestampFormatted} h:m`;
+      }
     }
     if (useHours) {
       const hours = Math.floor(this.timestampOptions.currentTimestampSeconds / (60 * 60));

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -186,6 +186,8 @@ export default class CanvasOverlay {
     // max timestamp parameter.
     // Then, format the resulting timestamp based on that format (Ideally close to HH:mm:ss`s`), with extra
     // precision if only using seconds/minutes (mm:ss.ss`s` or ss.ss`s`).
+    // TODO: Handle timestamps where only hours/minutes are used. This would require the
+    // frame duration to be passed in.
     const useMinutes = this.timestampOptions.maxTimestampSeconds >= 60;
     const useHours = this.timestampOptions.maxTimestampSeconds >= 60 * 60;
     const useHighPrecisionSeconds = !useHours;

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -63,8 +63,10 @@ const defaultBackgroundOptions: BackgroundOptions = {
   radiusPx: 4,
 };
 
-type SizeAndRender = {
-  size: Vector2;
+type RenderInfo = {
+  /** Size of the element, in pixels. */
+  sizePx: Vector2;
+  /** Callback to render the element. */
   render: () => void;
 };
 
@@ -200,9 +202,9 @@ export default class CanvasOverlay {
    *  - `size`: a vector representing the width and height of the rendered scale bar, in pixels.
    *  - `render`: a callback that renders the scale bar to the canvas.
    */
-  private getScaleBarRenderer(ctx: CanvasRenderingContext2D, originPx: Vector2): SizeAndRender {
+  private getScaleBarRenderer(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
     if (!this.scaleBarOptions.unitsPerScreenPixel || !this.scaleBarOptions.visible) {
-      return { size: new Vector2(0, 0), render: () => {} };
+      return { sizePx: new Vector2(0, 0), render: () => {} };
     }
 
     ///////// Get scale bar width and unit label /////////
@@ -238,7 +240,7 @@ export default class CanvasOverlay {
     };
 
     return {
-      size: new Vector2(scaleBarWidthPx, this.scaleBarOptions.fontSizePx + textPaddingPx.y * 2),
+      sizePx: new Vector2(scaleBarWidthPx, this.scaleBarOptions.fontSizePx + textPaddingPx.y * 2),
       render: () => {
         renderScaleBar();
         renderScaleBarText();
@@ -302,9 +304,9 @@ export default class CanvasOverlay {
    *  - `size`: a vector representing the width and height of the rendered scale bar, in pixels.
    *  - `render`: a callback that renders the scale bar to the canvas.
    */
-  private renderTimestamp(ctx: CanvasRenderingContext2D, originPx: Vector2): SizeAndRender {
+  private renderTimestamp(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
     if (!this.timestampOptions.visible || this.timestampOptions.frameDurationSec === 0) {
-      return { size: new Vector2(0, 0), render: () => {} };
+      return { sizePx: new Vector2(0, 0), render: () => {} };
     }
 
     ////////////////// Format timestamp as text //////////////////
@@ -319,7 +321,7 @@ export default class CanvasOverlay {
     };
 
     return {
-      size: new Vector2(
+      sizePx: new Vector2(
         timestampPaddingPx.x * 2 + this.getTextDimensions(ctx, timestampFormatted, this.timestampOptions).x,
         timestampPaddingPx.y * 2 + this.timestampOptions.fontSizePx
       ),
@@ -365,9 +367,9 @@ export default class CanvasOverlay {
     // Get dimensions + render methods for the elements, but don't render yet so we can draw the background
     // behind them.
     const origin = this.backgroundOptions.margin.clone().add(this.backgroundOptions.padding);
-    const { size: scaleBarDimensions, render: renderScaleBar } = this.getScaleBarRenderer(ctx, origin);
+    const { sizePx: scaleBarDimensions, render: renderScaleBar } = this.getScaleBarRenderer(ctx, origin);
     origin.y += scaleBarDimensions.y;
-    const { size: timestampDimensions, render: renderTimestamp } = this.renderTimestamp(ctx, origin);
+    const { sizePx: timestampDimensions, render: renderTimestamp } = this.renderTimestamp(ctx, origin);
 
     // If both elements are invisible, don't render the background.
     if (scaleBarDimensions.equals(new Vector2(0, 0)) && timestampDimensions.equals(new Vector2(0, 0))) {

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -172,13 +172,6 @@ export default class CanvasOverlay {
   }
 
   private renderTimestamp(yOffsetPx: number): number {
-    this.timestampOptions = {
-      ...this.timestampOptions,
-      visible: true,
-      currentTimestampSeconds: 54.344,
-      maxTimestampSeconds: 100,
-    };
-
     if (!this.timestampOptions.visible) {
       return 0;
     }

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -17,6 +17,8 @@ export type TimestampOptions = StyleOptions & {
   visible: boolean;
   maxTimestampSeconds: number;
   currentTimestampSeconds: number;
+  frameDurationSeconds: number;
+  startTimeSeconds: number;
 };
 
 const defaultStyleOptions: StyleOptions = {
@@ -36,6 +38,8 @@ const defaultScaleBarOptions: ScaleBarOptions = {
 const defaultTimestampOptions: TimestampOptions = {
   ...defaultStyleOptions,
   visible: false,
+  frameDurationSeconds: 1,
+  startTimeSeconds: 0,
   maxTimestampSeconds: 1,
   currentTimestampSeconds: 0,
 };

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -8,14 +8,14 @@ type StyleOptions = {
   fontStyle: string;
 };
 
-export type ScaleBarOptions = StyleOptions & {
+type ScaleBarOptions = StyleOptions & {
   minWidthPx: number;
   visible: boolean;
   unitsPerScreenPixel: number;
   units: string;
 };
 
-export type TimestampOptions = StyleOptions & {
+type TimestampOptions = StyleOptions & {
   visible: boolean;
   maxTimeSec: number;
   currTimeSec: number;
@@ -23,7 +23,7 @@ export type TimestampOptions = StyleOptions & {
   startTimeSec: number;
 };
 
-export type BackgroundOptions = {
+type BackgroundOptions = {
   fill: string;
   stroke: string;
   paddingPx: Vector2;

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -1,7 +1,7 @@
 import { Vector2 } from "three";
 import { numberToSciNotation } from "./utils/math_utils";
 
-export type StyleOptions = {
+type StyleOptions = {
   fontSizePx: number;
   fontFamily: string;
   fontColor: string;

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -159,11 +159,6 @@ export default class CanvasOverlay {
     }
   }
 
-  // NOTE: Rendering of the scale bar and timestamp is deferred here, since we need to draw a background behind them
-  // with an appropriate size. These methods return a callback that renders the scale bar or timestamp to the canvas,
-  // and provide the dimensions of the rendered element. The dimensions are used to draw a background
-  // box, and then the elements are rendered on top using the callbacks.
-
   /**
    * Determine a reasonable width for the scale bar, in units, and the corresponding width in pixels.
    * Unit widths will always have values `nx10^m`, where `n` is 1, 2, or 5, and `m` is an integer. Pixel widths
@@ -304,7 +299,7 @@ export default class CanvasOverlay {
    *  - `size`: a vector representing the width and height of the rendered scale bar, in pixels.
    *  - `render`: a callback that renders the scale bar to the canvas.
    */
-  private renderTimestamp(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
+  private getTimestampRenderer(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
     if (!this.timestampOptions.visible) {
       return { sizePx: new Vector2(0, 0), render: () => {} };
     }
@@ -369,7 +364,7 @@ export default class CanvasOverlay {
     const origin = this.backgroundOptions.marginPx.clone().add(this.backgroundOptions.paddingPx);
     const { sizePx: scaleBarDimensions, render: renderScaleBar } = this.getScaleBarRenderer(ctx, origin);
     origin.y += scaleBarDimensions.y;
-    const { sizePx: timestampDimensions, render: renderTimestamp } = this.renderTimestamp(ctx, origin);
+    const { sizePx: timestampDimensions, render: renderTimestamp } = this.getTimestampRenderer(ctx, origin);
 
     // If both elements are invisible, don't render the background.
     if (scaleBarDimensions.equals(new Vector2(0, 0)) && timestampDimensions.equals(new Vector2(0, 0))) {

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -107,7 +107,7 @@ export default class CanvasOverlay {
     this.timestampOptions = { ...this.timestampOptions, ...options };
   }
 
-  updateOverlayOptions(options: Partial<BackgroundOptions>): void {
+  updateBackgroundOptions(options: Partial<BackgroundOptions>): void {
     this.backgroundOptions = { ...this.backgroundOptions, ...options };
   }
 
@@ -135,7 +135,9 @@ export default class CanvasOverlay {
     ctx.font = `${options.fontStyle} ${options.fontSizePx}px ${options.fontFamily}`;
     ctx.fillStyle = options.fontColor;
     const textWidth = ctx.measureText(text).width;
-    ctx.fillText(text, this.canvas.width - textWidth - originPx.x, this.canvas.height - originPx.y);
+    // Throw in a magic number to nudge the text up a bit so it looks vertically centered.
+    const textOffset = Math.round(options.fontSizePx * 0.1);
+    ctx.fillText(text, this.canvas.width - textWidth - originPx.x, this.canvas.height - originPx.y - textOffset);
     return new Vector2(textWidth, options.fontSizePx);
   }
 
@@ -229,7 +231,7 @@ export default class CanvasOverlay {
     // TODO: This looks bad at high magnification. A workaround would be to use CSS2DRenderer to
     // render the text normally and then hotswap it for a regular canvas when recording occurs.
     // (but most likely a non-issue?)
-    const textPaddingPx = new Vector2(6, 6);
+    const textPaddingPx = new Vector2(6, 4);
     const textOriginPx = new Vector2(originPx.x + textPaddingPx.x, originPx.y + textPaddingPx.y);
     const renderScaleBarText = () => {
       this.renderRightAlignedText(ctx, textOriginPx, textContent, this.scaleBarOptions);
@@ -310,9 +312,7 @@ export default class CanvasOverlay {
 
     // TODO: Would be nice to configure top/bottom/left/right padding separately.
     const timestampPaddingPx = new Vector2(6, 2);
-    // Nudge by 2 pixels up due to text rendering alignment weirdness
-    // (Otherwise the vertical padding above the text is larger than below)
-    const timestampOriginPx = new Vector2(originPx.x + timestampPaddingPx.x, originPx.y + timestampPaddingPx.y + 2);
+    const timestampOriginPx = new Vector2(originPx.x + timestampPaddingPx.x, originPx.y + timestampPaddingPx.y);
     // Save the render function for later.
     const render = () => {
       this.renderRightAlignedText(ctx, timestampOriginPx, timestampFormatted, this.scaleBarOptions);

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -121,7 +121,7 @@ export default class CanvasOverlay {
   }
 
   /**
-   * Renders text on the canvas
+   * Renders text on the canvas, using its bottom right corner as the origin.
    * @param ctx the canvas context to render to.
    * @param text the text to render.
    * @param originPx the origin of the text, from the lower right corner, in pixels.
@@ -137,7 +137,7 @@ export default class CanvasOverlay {
     ctx.font = `${options.fontStyle} ${options.fontSizePx}px ${options.fontFamily}`;
     ctx.fillStyle = options.fontColor;
     const textWidth = ctx.measureText(text).width;
-    // Throw in a magic number to nudge the text up a bit so it looks vertically centered.
+    // Magic number to nudge text up a bit so it looks vertically centered.
     const textOffset = Math.round(options.fontSizePx * 0.1);
     ctx.fillText(text, this.canvas.width - textWidth - originPx.x, this.canvas.height - originPx.y - textOffset);
     return new Vector2(textWidth, options.fontSizePx);

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -26,8 +26,8 @@ export type TimestampOptions = StyleOptions & {
 export type BackgroundOptions = {
   fill: string;
   stroke: string;
-  padding: Vector2;
-  margin: Vector2;
+  paddingPx: Vector2;
+  marginPx: Vector2;
   radiusPx: number;
 };
 
@@ -58,8 +58,8 @@ const defaultTimestampOptions: TimestampOptions = {
 const defaultBackgroundOptions: BackgroundOptions = {
   fill: "rgba(255, 255, 255, 0.8)",
   stroke: "rgba(0, 0, 0, 0.2)",
-  padding: new Vector2(10, 10),
-  margin: new Vector2(20, 20),
+  paddingPx: new Vector2(10, 10),
+  marginPx: new Vector2(20, 20),
   radiusPx: 4,
 };
 
@@ -305,7 +305,7 @@ export default class CanvasOverlay {
    *  - `render`: a callback that renders the scale bar to the canvas.
    */
   private renderTimestamp(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
-    if (!this.timestampOptions.visible || this.timestampOptions.frameDurationSec === 0) {
+    if (!this.timestampOptions.visible) {
       return { sizePx: new Vector2(0, 0), render: () => {} };
     }
 
@@ -340,8 +340,8 @@ export default class CanvasOverlay {
     ctx.strokeStyle = options.stroke;
     ctx.beginPath();
     ctx.roundRect(
-      Math.round(ctx.canvas.width - size.x - options.margin.x) + 0.5,
-      Math.round(ctx.canvas.height - size.y - options.margin.y) + 0.5,
+      Math.round(ctx.canvas.width - size.x - options.marginPx.x) + 0.5,
+      Math.round(ctx.canvas.height - size.y - options.marginPx.y) + 0.5,
       Math.round(size.x),
       Math.round(size.y),
       options.radiusPx
@@ -366,7 +366,7 @@ export default class CanvasOverlay {
 
     // Get dimensions + render methods for the elements, but don't render yet so we can draw the background
     // behind them.
-    const origin = this.backgroundOptions.margin.clone().add(this.backgroundOptions.padding);
+    const origin = this.backgroundOptions.marginPx.clone().add(this.backgroundOptions.paddingPx);
     const { sizePx: scaleBarDimensions, render: renderScaleBar } = this.getScaleBarRenderer(ctx, origin);
     origin.y += scaleBarDimensions.y;
     const { sizePx: timestampDimensions, render: renderTimestamp } = this.renderTimestamp(ctx, origin);
@@ -381,7 +381,7 @@ export default class CanvasOverlay {
       Math.max(scaleBarDimensions.x, timestampDimensions.x),
       scaleBarDimensions.y + timestampDimensions.y
     );
-    const boxSize = contentSize.clone().add(this.backgroundOptions.padding.clone().multiplyScalar(2.0));
+    const boxSize = contentSize.clone().add(this.backgroundOptions.paddingPx.clone().multiplyScalar(2.0));
     CanvasOverlay.renderBackground(ctx, boxSize, this.backgroundOptions);
 
     // Draw elements over the background

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -267,27 +267,26 @@ export default class ColorizeCanvas {
     // by the dataset (optionally, hide the timestamp if the frame duration is not provided).
     // Pass along to the overlay as parameters.
     if (this.showTimestamp && this.dataset) {
-      const frameDurationSeconds = this.dataset.metadata.frameDurationSeconds;
-      if (frameDurationSeconds) {
+      const frameDurationSec = this.dataset.metadata.frameDurationSeconds;
+      if (frameDurationSec) {
         const startTimeSec = this.dataset.metadata.startTimeSeconds;
-        const maxTimestampSec = this.dataset.numberOfFrames * frameDurationSeconds + startTimeSec;
-        const currentTimestampSec = this.currentFrame * frameDurationSeconds + startTimeSec;
-        // Note: there's some semi-redundant information here, since the current timestamp and max timestamp
-        // could be calculated from the frame duration if we passed in the current + max frames instead.
-        // For now, we're keeping those calculations here in ColorizeCanvas so the overlay doesn't need to
-        // know frame numbers. The duration + start time are needed for time display calculations though.
+        // Note: there's some semi-redundant information here, since the current timestamp and max
+        // timestamp could be calculated from the frame duration if we passed in the current + max
+        // frames instead. For now, it's ok to keep those calculations here in ColorizeCanvas so the
+        // overlay doesn't need to know frame numbers. The duration + start time are needed for
+        // time display calculations, however.
         this.overlay.updateTimestampOptions({
           visible: true,
-          currTimeSec: currentTimestampSec,
-          maxTimeSec: maxTimestampSec,
-          frameDurationSec: frameDurationSeconds,
-          startTimeSec: startTimeSec,
+          frameDurationSec,
+          startTimeSec,
+          currTimeSec: this.currentFrame * frameDurationSec + startTimeSec,
+          maxTimeSec: this.dataset.numberOfFrames * frameDurationSec + startTimeSec,
         });
         return;
       }
     }
 
-    // Hide the scale bar
+    // Hide the timestamp if configuration is invalid or it's disabled.
     this.overlay.updateTimestampOptions({ visible: false });
   }
 
@@ -540,7 +539,6 @@ export default class ColorizeCanvas {
       return;
     }
     this.setUniform("frame", frame);
-    this.updateTimestamp();
   }
 
   render(): void {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -266,6 +266,8 @@ export default class ColorizeCanvas {
   private updateTimestamp(): void {
     // Calculate the current time stamp based on the current frame and the frame duration provided
     // by the dataset (optionally, hide the timestamp if the frame duration is not provided).
+    // Pass along to the overlay as parameters.
+    // TODO: Call updateTimeStamp everywhere we call updateScaleBar. (or merge them?)
     // TODO: Move calls to overlay.render() so they're not all triggered at once?
   }
 

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -269,10 +269,24 @@ export default class ColorizeCanvas {
     // Pass along to the overlay as parameters.
     // TODO: Call updateTimeStamp everywhere we call updateScaleBar. (or merge them?)
     // TODO: Move calls to overlay.render() so they're not all triggered at once?
+    const frameDurationSeconds = this.dataset?.metadata?.frameDurationSeconds || 60;
+    const numberOfFrames = this.dataset?.numberOfFrames;
+
+    if (this.showTimestamp && frameDurationSeconds && numberOfFrames) {
+      const maxTimestampSeconds = numberOfFrames * frameDurationSeconds;
+      const currentTimestampSeconds = this.currentFrame * frameDurationSeconds;
+      this.overlay.updateTimestampOptions({ visible: true, currentTimestampSeconds, maxTimestampSeconds });
+      this.overlay.render();
+    } else {
+      // Hide the scale bar if the frame duration is not provided.
+      this.overlay.updateScaleBarOptions({ visible: false });
+      this.overlay.render();
+    }
   }
 
-  private setTimestampVisibility(visible: boolean): void {
+  setTimestampVisibility(visible: boolean): void {
     this.showTimestamp = visible;
+    this.updateTimestamp();
   }
 
   updateScaling(frameResolution: Vector2 | null, canvasResolution: Vector2 | null): void {
@@ -518,6 +532,7 @@ export default class ColorizeCanvas {
       return;
     }
     this.setUniform("frame", frame);
+    this.updateTimestamp();
   }
 
   render(): void {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -111,6 +111,7 @@ export default class ColorizeCanvas {
   private line: Line;
   private showTrackPath: boolean;
 
+  private showTimestamp: boolean;
   private showScaleBar: boolean;
   private frameToCanvasScale: Vector4;
 
@@ -187,6 +188,7 @@ export default class ColorizeCanvas {
 
     this.overlay = new CanvasOverlay();
     this.showScaleBar = false;
+    this.showTimestamp = false;
     this.frameToCanvasScale = new Vector4(1, 1, 1, 1);
 
     this.render = this.render.bind(this);
@@ -259,6 +261,16 @@ export default class ColorizeCanvas {
   setScaleBarVisibility(visible: boolean): void {
     this.showScaleBar = visible;
     this.updateScaleBar();
+  }
+
+  private updateTimestamp(): void {
+    // Calculate the current time stamp based on the current frame and the frame duration provided
+    // by the dataset (optionally, hide the timestamp if the frame duration is not provided).
+    // TODO: Move calls to overlay.render() so they're not all triggered at once?
+  }
+
+  private setTimestampVisibility(visible: boolean): void {
+    this.showTimestamp = visible;
   }
 
   updateScaling(frameResolution: Vector2 | null, canvasResolution: Vector2 | null): void {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -266,18 +266,23 @@ export default class ColorizeCanvas {
     // Calculate the current time stamp based on the current frame and the frame duration provided
     // by the dataset (optionally, hide the timestamp if the frame duration is not provided).
     // Pass along to the overlay as parameters.
-    // TODO: Call updateTimeStamp everywhere we call updateScaleBar. (or merge them?)
     if (this.showTimestamp && this.dataset) {
-      const frameDurationSeconds = this.dataset.metadata?.frameDurationSeconds || 1.0;
-      const numberOfFrames = this.dataset.numberOfFrames;
+      // TODO: Remove the || conditional, it's just for testing. Call me out if I forget to remove this >:(
+      const frameDurationSeconds = this.dataset.metadata.frameDurationSeconds || 51.25;
       if (frameDurationSeconds) {
-        const maxTimestampSeconds = numberOfFrames * frameDurationSeconds;
-        const currentTimestampSeconds = this.currentFrame * frameDurationSeconds;
+        const startTimeSec = this.dataset.metadata.startTimeSeconds;
+        const maxTimestampSec = this.dataset.numberOfFrames * frameDurationSeconds + startTimeSec;
+        const currentTimestampSec = this.currentFrame * frameDurationSeconds + startTimeSec;
+        // Note: there's some semi-redundant information here, since the current timestamp and max timestamp
+        // could be calculated from the frame duration if we passed in the current + max frames instead.
+        // For now, we're keeping those calculations here in ColorizeCanvas so the overlay doesn't need to
+        // know frame numbers. The duration + start time are needed for time display calculations though.
         this.overlay.updateTimestampOptions({
           visible: true,
-          currentTimestampSeconds,
-          maxTimestampSeconds,
+          currentTimestampSeconds: currentTimestampSec,
+          maxTimestampSeconds: maxTimestampSec,
           frameDurationSeconds,
+          startTimeSeconds: startTimeSec,
         });
         return;
       }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -266,12 +266,17 @@ export default class ColorizeCanvas {
     // Pass along to the overlay as parameters.
     // TODO: Call updateTimeStamp everywhere we call updateScaleBar. (or merge them?)
     if (this.showTimestamp && this.dataset) {
-      const frameDurationSeconds = this.dataset.metadata?.frameDurationSeconds;
+      const frameDurationSeconds = this.dataset.metadata?.frameDurationSeconds || 1.0;
       const numberOfFrames = this.dataset.numberOfFrames;
       if (frameDurationSeconds) {
         const maxTimestampSeconds = numberOfFrames * frameDurationSeconds;
         const currentTimestampSeconds = this.currentFrame * frameDurationSeconds;
-        this.overlay.updateTimestampOptions({ visible: true, currentTimestampSeconds, maxTimestampSeconds });
+        this.overlay.updateTimestampOptions({
+          visible: true,
+          currentTimestampSeconds,
+          maxTimestampSeconds,
+          frameDurationSeconds,
+        });
         return;
       }
     }

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -267,8 +267,7 @@ export default class ColorizeCanvas {
     // by the dataset (optionally, hide the timestamp if the frame duration is not provided).
     // Pass along to the overlay as parameters.
     if (this.showTimestamp && this.dataset) {
-      // TODO: Remove the || conditional, it's just for testing. Call me out if I forget to remove this >:(
-      const frameDurationSeconds = this.dataset.metadata.frameDurationSeconds || 1;
+      const frameDurationSeconds = this.dataset.metadata.frameDurationSeconds;
       if (frameDurationSeconds) {
         const startTimeSec = this.dataset.metadata.startTimeSeconds;
         const maxTimestampSec = this.dataset.numberOfFrames * frameDurationSeconds + startTimeSec;

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -268,7 +268,7 @@ export default class ColorizeCanvas {
     // Pass along to the overlay as parameters.
     if (this.showTimestamp && this.dataset) {
       // TODO: Remove the || conditional, it's just for testing. Call me out if I forget to remove this >:(
-      const frameDurationSeconds = this.dataset.metadata.frameDurationSeconds || 51.25;
+      const frameDurationSeconds = this.dataset.metadata.frameDurationSeconds || 1;
       if (frameDurationSeconds) {
         const startTimeSec = this.dataset.metadata.startTimeSeconds;
         const maxTimestampSec = this.dataset.numberOfFrames * frameDurationSeconds + startTimeSec;
@@ -279,10 +279,10 @@ export default class ColorizeCanvas {
         // know frame numbers. The duration + start time are needed for time display calculations though.
         this.overlay.updateTimestampOptions({
           visible: true,
-          currentTimestampSeconds: currentTimestampSec,
-          maxTimestampSeconds: maxTimestampSec,
-          frameDurationSeconds,
-          startTimeSeconds: startTimeSec,
+          currTimeSec: currentTimestampSec,
+          maxTimeSec: maxTimestampSec,
+          frameDurationSec: frameDurationSeconds,
+          startTimeSec: startTimeSec,
         });
         return;
       }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -40,6 +40,8 @@ const defaultMetadata: DatasetMetadata = {
     height: 0,
     units: "",
   },
+  frameDurationSeconds: 0,
+  startTimeSeconds: 0,
 };
 
 export type DatasetManifest = {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -29,6 +29,7 @@ export type DatasetMetadata = {
     height: number;
     units: string;
   };
+  frameDurationSeconds: number;
 };
 
 export type DatasetManifest = {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -30,6 +30,8 @@ export type DatasetMetadata = {
     units: string;
   };
   frameDurationSeconds: number;
+  /* Optional offset for the timestamp. */
+  startTimeSeconds: number;
 };
 
 export type DatasetManifest = {

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -85,6 +85,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     };
     canv.overlay.updateScaleBarOptions(defaultTheme);
     canv.overlay.updateTimestampOptions(defaultTheme);
+    canv.overlay.updateBackgroundOptions({ stroke: theme.color.layout.borders });
   }, [theme]);
 
   // Update canvas color ramp

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -20,6 +20,7 @@ type CanvasWrapperProps = {
   dataset: Dataset | null;
   showTrackPath: boolean;
   showScaleBar: boolean;
+  showTimestamp: boolean;
   outOfRangeDrawSettings: DrawSettings;
   outlierDrawSettings: DrawSettings;
   colorRamp: ColorRamp;

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -78,11 +78,13 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   // Update the theming of the canvas overlay.
   useMemo(() => {
-    canv.overlay.updateScaleBarOptions({
+    const defaultTheme = {
       fontSizePx: theme.font.size.label,
       fontColor: theme.color.text.primary,
       fontFamily: theme.font.family,
-    });
+    };
+    canv.overlay.updateScaleBarOptions(defaultTheme);
+    canv.overlay.updateTimestampOptions(defaultTheme);
   }, [theme]);
 
   // Update canvas color ramp
@@ -120,6 +122,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   useMemo(() => {
     canv.setScaleBarVisibility(props.showScaleBar);
   }, [props.showScaleBar]);
+
+  useMemo(() => {
+    canv.setTimestampVisibility(props.showTimestamp);
+  }, [props.showTimestamp]);
 
   // CANVAS ACTIONS /////////////////////////////////////////////////
 


### PR DESCRIPTION
Problem
=======
Closes #61, physical time!

Solution
========
- Adds new dataset metadata parameters (start time + frame duration). The default nucmorph datasets have been updated to use these values.
- Plumbing code to pass parameters + config down to the `CanvasOverlay`.
- Rendering + formatting for the new timestamp.
- Changes the rendering pattern for `CanvasOverlay`.
  - A lot of these changes needed to happen to allow the overlay elements (scale bar + timestamp) to have a transparent background beneath them. The biggest change is delaying element rendering, so that the size of the elements can be summed and a backdrop can be drawn first beneath them.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link (https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-149/)
2. Make sure the "Show timestamp" checkbox is enabled.
3. Play, and observe the timestamp updating.
4. Also, try disabling/enabling the scale bar and timestamp. The background will disappear.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/d6ef2e60-3605-4ccd-88c7-8ce39fd5c684)

### Video Talk-through (w/ Audio)

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/200feb1a-0554-4fe2-986d-7bfe4fcc222c

Addendum video about different timestamp formats:

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/28943b34-2e1f-45fd-9ae9-2c3d364a23da

Thanks for contributing!
