### PR TITLE
fix: Include UI overlays in export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -579,7 +579,7 @@ function App(): ReactElement {
           <Export
             totalFrames={dataset?.numberOfFrames || 0}
             setFrame={setFrameAndRender}
-            getCanvas={() => canv.canvasElement}
+            getCanvas={() => canv.domElement}
             // Stop playback when exporting
             onClick={() => timeControls.handlePauseButtonClick()}
             currentFrame={currentFrame}

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -352,7 +352,7 @@ export default class CanvasOverlay {
    * Render the overlay to the canvas.
    */
   render(): void {
-    const ctx = this.canvas.getContext("2d");
+    const ctx = this.canvas.getContext("2d") as OffscreenCanvasRenderingContext2D | null;
     if (ctx === null) {
       console.error("Could not get canvas context");
       return;

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -75,26 +75,20 @@ type RenderInfo = {
  * with `ColorizeCanvas`.)
  */
 export default class CanvasOverlay {
-  private canvas: OffscreenCanvas;
+  public canvas: OffscreenCanvas;
   private scaleBarOptions: ScaleBarOptions;
   private timestampOptions: TimestampOptions;
   private backgroundOptions: BackgroundOptions;
 
   constructor(
-    width: number = 256,
-    height: number = 256,
     scaleBarOptions: ScaleBarOptions = defaultScaleBarOptions,
     timestampOptions: TimestampOptions = defaultTimestampOptions,
     overlayOptions: BackgroundOptions = defaultBackgroundOptions
   ) {
-    this.canvas = new OffscreenCanvas(width, height);
+    this.canvas = new OffscreenCanvas(1, 1);
     this.scaleBarOptions = scaleBarOptions;
     this.timestampOptions = timestampOptions;
     this.backgroundOptions = overlayOptions;
-  }
-
-  get offscreenCanvas(): OffscreenCanvas {
-    return this.canvas;
   }
 
   /**
@@ -356,7 +350,6 @@ export default class CanvasOverlay {
 
   /**
    * Render the overlay to the canvas.
-   * @returns an ImageBitmap of the rendered overlay, or null if the overlay cannot be drawn or is empty.
    */
   render(): void {
     const ctx = this.canvas.getContext("2d");

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -75,22 +75,26 @@ type RenderInfo = {
  * with `ColorizeCanvas`.)
  */
 export default class CanvasOverlay {
-  private canvas: HTMLCanvasElement;
+  private canvas: OffscreenCanvas;
   private scaleBarOptions: ScaleBarOptions;
   private timestampOptions: TimestampOptions;
   private backgroundOptions: BackgroundOptions;
 
   constructor(
+    width: number = 256,
+    height: number = 256,
     scaleBarOptions: ScaleBarOptions = defaultScaleBarOptions,
     timestampOptions: TimestampOptions = defaultTimestampOptions,
     overlayOptions: BackgroundOptions = defaultBackgroundOptions
   ) {
-    this.canvas = document.createElement("canvas");
-    // Disable pointer events on the canvas overlay so it doesn't block mouse events on the main canvas.
-    this.canvas.style.pointerEvents = "none";
+    this.canvas = new OffscreenCanvas(width, height);
     this.scaleBarOptions = scaleBarOptions;
     this.timestampOptions = timestampOptions;
     this.backgroundOptions = overlayOptions;
+  }
+
+  get offscreenCanvas(): OffscreenCanvas {
+    return this.canvas;
   }
 
   /**
@@ -113,7 +117,7 @@ export default class CanvasOverlay {
     this.backgroundOptions = { ...this.backgroundOptions, ...options };
   }
 
-  private getTextDimensions(ctx: CanvasRenderingContext2D, text: string, options: StyleOptions): Vector2 {
+  private getTextDimensions(ctx: OffscreenCanvasRenderingContext2D, text: string, options: StyleOptions): Vector2 {
     ctx.font = `${options.fontSizePx}px ${options.fontFamily}`;
     ctx.fillStyle = options.fontColor;
     const textWidth = ctx.measureText(text).width;
@@ -129,7 +133,7 @@ export default class CanvasOverlay {
    * @returns the width and height of the text, as a Vector2.
    */
   private renderRightAlignedText(
-    ctx: CanvasRenderingContext2D,
+    ctx: OffscreenCanvasRenderingContext2D,
     originPx: Vector2,
     text: string,
     options: StyleOptions
@@ -197,7 +201,7 @@ export default class CanvasOverlay {
    *  - `size`: a vector representing the width and height of the rendered scale bar, in pixels.
    *  - `render`: a callback that renders the scale bar to the canvas.
    */
-  private getScaleBarRenderer(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
+  private getScaleBarRenderer(ctx: OffscreenCanvasRenderingContext2D, originPx: Vector2): RenderInfo {
     if (!this.scaleBarOptions.unitsPerScreenPixel || !this.scaleBarOptions.visible) {
       return { sizePx: new Vector2(0, 0), render: () => {} };
     }
@@ -299,7 +303,7 @@ export default class CanvasOverlay {
    *  - `size`: a vector representing the width and height of the rendered scale bar, in pixels.
    *  - `render`: a callback that renders the scale bar to the canvas.
    */
-  private getTimestampRenderer(ctx: CanvasRenderingContext2D, originPx: Vector2): RenderInfo {
+  private getTimestampRenderer(ctx: OffscreenCanvasRenderingContext2D, originPx: Vector2): RenderInfo {
     if (!this.timestampOptions.visible) {
       return { sizePx: new Vector2(0, 0), render: () => {} };
     }
@@ -330,7 +334,11 @@ export default class CanvasOverlay {
    * @param size Size of the background overlay.
    * @param options Configuration for the background overlay.
    */
-  private static renderBackground(ctx: CanvasRenderingContext2D, size: Vector2, options: BackgroundOptions): void {
+  private static renderBackground(
+    ctx: OffscreenCanvasRenderingContext2D,
+    size: Vector2,
+    options: BackgroundOptions
+  ): void {
     ctx.fillStyle = options.fill;
     ctx.strokeStyle = options.stroke;
     ctx.beginPath();
@@ -348,6 +356,7 @@ export default class CanvasOverlay {
 
   /**
    * Render the overlay to the canvas.
+   * @returns an ImageBitmap of the rendered overlay, or null if the overlay cannot be drawn or is empty.
    */
   render(): void {
     const ctx = this.canvas.getContext("2d");
@@ -382,9 +391,5 @@ export default class CanvasOverlay {
     // Draw elements over the background
     renderScaleBar();
     renderTimestamp();
-  }
-
-  get domElement(): HTMLElement {
-    return this.canvas;
   }
 }

--- a/src/colorizer/CanvasOverlay.ts
+++ b/src/colorizer/CanvasOverlay.ts
@@ -75,7 +75,7 @@ type RenderInfo = {
  * with `ColorizeCanvas`.)
  */
 export default class CanvasOverlay {
-  public canvas: OffscreenCanvas;
+  public readonly canvas: OffscreenCanvas;
   private scaleBarOptions: ScaleBarOptions;
   private timestampOptions: TimestampOptions;
   private backgroundOptions: BackgroundOptions;

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -199,7 +199,7 @@ export default class ColorizeCanvas {
     this.updateScaling = this.updateScaling.bind(this);
   }
 
-  get canvasElement(): HTMLCanvasElement {
+  get domElement(): HTMLCanvasElement {
     return this.renderer.domElement;
   }
 

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -1,6 +1,7 @@
 import {
   BufferAttribute,
   BufferGeometry,
+  CanvasTexture,
   Color,
   DataTexture,
   GLSL3,
@@ -56,6 +57,7 @@ type ColorizeUniformTypes = {
   inRangeIds: Texture;
   featureColorRampMin: number;
   featureColorRampMax: number;
+  overlay: Texture;
   colorRamp: Texture;
   backgroundColor: Color;
   outlierColor: Color;
@@ -76,6 +78,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
   const emptyOutliers = packDataTexture([0], FeatureDataType.U8);
   const emptyInRangeIds = packDataTexture([0], FeatureDataType.U8);
   const emptyColorRamp = new ColorRamp(["black"]).texture;
+  const emptyOverlay = new DataTexture(new Uint8Array([0, 0, 0, 0]), 1, 1, RGBAIntegerFormat, UnsignedByteType);
 
   return {
     canvasToFrameScale: new Uniform(new Vector2(1, 1)),
@@ -83,6 +86,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
     featureData: new Uniform(emptyFeature),
     outlierData: new Uniform(emptyOutliers),
     inRangeIds: new Uniform(emptyInRangeIds),
+    overlay: new Uniform(emptyOverlay),
     featureColorRampMin: new Uniform(0),
     featureColorRampMax: new Uniform(1),
     colorRamp: new Uniform(emptyColorRamp),
@@ -97,8 +101,6 @@ const getDefaultUniforms = (): ColorizeUniforms => {
 };
 
 export default class ColorizeCanvas {
-  private canvasContainer: HTMLDivElement;
-
   private geometry: PlaneGeometry;
   private material: ShaderMaterial;
   private pickMaterial: ShaderMaterial;
@@ -195,23 +197,13 @@ export default class ColorizeCanvas {
     this.getCurrentFrame = this.getCurrentFrame.bind(this);
     this.setOutOfRangeDrawMode = this.setOutOfRangeDrawMode.bind(this);
     this.updateScaling = this.updateScaling.bind(this);
-
-    // Set up the canvas overlay as a sibling in the DOM layout
-    // by creating a dummy parent container.
-    this.canvasContainer = document.createElement("div");
-    this.canvasContainer.appendChild(this.renderer.domElement);
-    this.canvasContainer.appendChild(this.overlay.domElement);
-    this.canvasContainer.style.position = "relative";
-    this.overlay.domElement.style.position = "absolute";
-    this.overlay.domElement.style.left = "0";
-    this.overlay.domElement.style.top = "0";
   }
 
   /**
    * The DOM element containing the canvas and its overlay.
    */
-  get domElement(): HTMLDivElement {
-    return this.canvasContainer;
+  get domElement(): HTMLCanvasElement {
+    return this.renderer.domElement;
   }
 
   get canvasElement(): HTMLCanvasElement {
@@ -544,10 +536,18 @@ export default class ColorizeCanvas {
   render(): void {
     this.updateHighlightedId();
     this.updateTrackRange();
-    this.renderer.render(this.scene, this.camera);
+
     this.updateScaleBar();
     this.updateTimestamp();
+
     this.overlay.render();
+    // Draw the overlay over the canvas
+    const overlayTexture = new CanvasTexture(this.overlay.offscreenCanvas);
+    console.log("Render!");
+    console.log(overlayTexture);
+    this.setUniform("overlay", overlayTexture);
+
+    this.renderer.render(this.scene, this.camera);
   }
 
   dispose(): void {

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -199,13 +199,6 @@ export default class ColorizeCanvas {
     this.updateScaling = this.updateScaling.bind(this);
   }
 
-  /**
-   * The DOM element containing the canvas and its overlay.
-   */
-  get domElement(): HTMLCanvasElement {
-    return this.renderer.domElement;
-  }
-
   get canvasElement(): HTMLCanvasElement {
     return this.renderer.domElement;
   }
@@ -540,11 +533,9 @@ export default class ColorizeCanvas {
     this.updateScaleBar();
     this.updateTimestamp();
 
+    // Draw the overlay, and pass the resulting image as a texture to the shader.
     this.overlay.render();
-    // Draw the overlay over the canvas
-    const overlayTexture = new CanvasTexture(this.overlay.offscreenCanvas);
-    console.log("Render!");
-    console.log(overlayTexture);
+    const overlayTexture = new CanvasTexture(this.overlay.canvas);
     this.setUniform("overlay", overlayTexture);
 
     this.renderer.render(this.scene, this.camera);

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -17,6 +17,7 @@ uniform float featureColorRampMax;
 uniform vec2 canvasToFrameScale;
 uniform sampler2D colorRamp;
 uniform vec3 backgroundColor;
+uniform sampler2D overlay;
 
 /** MUST be synchronized with the DrawMode enum in ColorizeCanvas! */
 const uint DRAW_MODE_HIDE = 0u;
@@ -80,15 +81,15 @@ vec4 getColorFromDrawMode(uint drawMode, vec3 defaultColor) {
   }
 }
 
-void main() {
+vec4 getMainPixelColor() {
+
   // Scale uv to compensate for the aspect of the frame
   ivec2 frameDims = textureSize(frame, 0);
   vec2 sUv = (vUv - 0.5) * canvasToFrameScale + 0.5;
 
   // This pixel is background if, after scaling uv, it is outside the frame
   if (sUv.x < 0.0 || sUv.y < 0.0 || sUv.x > 1.0 || sUv.y > 1.0) {
-    gOutputColor = vec4(backgroundColor, 1.0);
-    return;
+    return vec4(backgroundColor, 1.0);
   }
 
   // Get the segmentation id at this pixel
@@ -96,13 +97,11 @@ void main() {
 
   // A segmentation id of 0 represents background
   if (id == 0u) {
-    gOutputColor = vec4(backgroundColor, 1.0);
-    return;
+    return vec4(backgroundColor, 1.0);
   } else if (int(id) - 1 == highlightedId) {
     // do an outline around highlighted object
     if (isEdge(sUv, frameDims)) {
-      gOutputColor = vec4(1.0, 0.0, 1.0, 1.0);
-      return;
+      return vec4(1.0, 0.0, 1.0, 1.0);
     }
   }
 
@@ -120,11 +119,23 @@ void main() {
   // Features inside the range can either be outliers or standard values, and are colored accordingly.
   if (isInRange) {
     if (isOutlier) {
-      gOutputColor = getColorFromDrawMode(outlierDrawMode, outlierColor);
+      return getColorFromDrawMode(outlierDrawMode, outlierColor);
     } else {
-      gOutputColor = getColorRamp(normFeatureVal);
+      return getColorRamp(normFeatureVal);
     }
   } else {
-    gOutputColor = getColorFromDrawMode(outOfRangeDrawMode, outOfRangeColor);
+    return getColorFromDrawMode(outOfRangeDrawMode, outOfRangeColor);
   }
+}
+
+void main() {
+
+  vec4 mainColor = getMainPixelColor();
+
+  // Add overlay texture
+  vec4 overlayColor = texture(overlay, vUv).rgba;  // Unscaled UVs, because it is sized to the canvas
+
+  float overlayAlpha = float(overlayColor.a);
+
+  gOutputColor = mix(mainColor, overlayColor, overlayAlpha);
 }

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -135,12 +135,9 @@ vec4 getMainPixelColor() {
 }
 
 void main() {
-
   vec4 mainColor = getMainPixelColor();
-
   // Add overlay texture
   vec4 overlayColor = texture(overlay, vUv).rgba;  // Unscaled UVs, because it is sized to the canvas
 
   gOutputColor = alphaBlend(overlayColor, mainColor);
-  // gOutputColor = vec4(overlayAlpha, overlayAlpha, overlayAlpha, 1.0);
 }

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -81,6 +81,12 @@ vec4 getColorFromDrawMode(uint drawMode, vec3 defaultColor) {
   }
 }
 
+vec4 alphaBlend(vec4 a, vec4 b) {
+  // Implements a over b operation. See https://en.wikipedia.org/wiki/Alpha_compositing
+  float alpha = a.a + b.a * (1.0 - a.a);
+  return vec4((a.rgb * a.a + b.rgb * b.a * (1.0 - a.a)) / alpha, alpha);
+}
+
 vec4 getMainPixelColor() {
 
   // Scale uv to compensate for the aspect of the frame
@@ -135,7 +141,6 @@ void main() {
   // Add overlay texture
   vec4 overlayColor = texture(overlay, vUv).rgba;  // Unscaled UVs, because it is sized to the canvas
 
-  float overlayAlpha = float(overlayColor.a);
-
-  gOutputColor = mix(mainColor, overlayColor, overlayAlpha);
+  gOutputColor = alphaBlend(overlayColor, mainColor);
+  // gOutputColor = vec4(overlayAlpha, overlayAlpha, overlayAlpha, 1.0);
 }

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -69,7 +69,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   // Mount the canvas to the wrapper's location in the document.
   useEffect(() => {
-    canvasRef.current?.parentNode?.replaceChild(canv.domElement, canvasRef.current);
+    canvasRef.current?.parentNode?.replaceChild(canv.canvasElement, canvasRef.current);
   }, []);
 
   // These are all useMemo calls because the updates to the canvas must happen in the same render;

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -69,7 +69,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   // Mount the canvas to the wrapper's location in the document.
   useEffect(() => {
-    canvasRef.current?.parentNode?.replaceChild(canv.canvasElement, canvasRef.current);
+    canvasRef.current?.parentNode?.replaceChild(canv.domElement, canvasRef.current);
   }, []);
 
   // These are all useMemo calls because the updates to the canvas must happen in the same render;
@@ -147,9 +147,9 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   );
 
   useEffect(() => {
-    canv.canvasElement.addEventListener("click", handleCanvasClick);
+    canv.domElement.addEventListener("click", handleCanvasClick);
     return () => {
-      canv.canvasElement.removeEventListener("click", handleCanvasClick);
+      canv.domElement.removeEventListener("click", handleCanvasClick);
     };
   }, [handleCanvasClick]);
 
@@ -169,8 +169,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
    * hovered value wwhen the canvas frame updates.
    */
   useEffect(() => {
-    canv.canvasElement.addEventListener("mouseenter", () => (isMouseOverCanvas.current = true));
-    canv.canvasElement.addEventListener("mouseleave", () => (isMouseOverCanvas.current = false));
+    canv.domElement.addEventListener("mouseenter", () => (isMouseOverCanvas.current = true));
+    canv.domElement.addEventListener("mouseleave", () => (isMouseOverCanvas.current = false));
   });
 
   /** Update hovered id when the canvas updates the current frame */
@@ -186,11 +186,11 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       lastMousePositionPx.current = [event.offsetX, event.offsetY];
     };
 
-    canv.canvasElement.addEventListener("mousemove", onMouseMove);
-    canv.canvasElement.addEventListener("mouseleave", props.onMouseLeave);
+    canv.domElement.addEventListener("mousemove", onMouseMove);
+    canv.domElement.addEventListener("mouseleave", props.onMouseLeave);
     return () => {
-      canv.canvasElement.removeEventListener("mousemove", onMouseMove);
-      canv.canvasElement.removeEventListener("mouseleave", props.onMouseLeave);
+      canv.domElement.removeEventListener("mousemove", onMouseMove);
+      canv.domElement.removeEventListener("mouseleave", props.onMouseLeave);
     };
   }, [props.dataset, canv]);
 


### PR DESCRIPTION
Problem
=======
Closes #135, [Include UI overlays (scale bar, time, etc.) in exported frames and video](https://github.com/allen-cell-animated/nucmorph-colorizer/issues/135)!

Solution
========
- Converts `CanvasOverlay` to an `OffscreenCanvas`, and provides the rendered canvas image as a texture to the shader.
- The shader then composites the overlay over the base image.
- Video/image export samples from the resulting `ColorizeCanvas` canvas.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Click the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-156/
1. Click export, and export a video sequence of any length. Open the file.
1. The timestamp and scale bar should be visible in the exported video.

Screenshots (optional):
-----------------------

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/5e7e2e50-1e01-4290-978c-909c8307b841
