### PR TITLE
fix: Use placeholders for unknown bounds

### DIFF
--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -60,3 +60,14 @@ export function useConstructor<T>(constructor: () => T): T {
   }
   return value.current;
 }
+
+/** Returns a shallow copy of an object, excluding all entries where the value is undefined. */
+export function excludeUndefinedValues<T extends Object>(obj: T): Partial<T> {
+  const ret = {} as Partial<T>;
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      ret[key] = obj[key];
+    }
+  }
+  return ret;
+}

--- a/src/components/LabeledRangeSlider.tsx
+++ b/src/components/LabeledRangeSlider.tsx
@@ -159,6 +159,14 @@ export default function LabeledRangeSlider(inputProps: LabeledRangeSliderProps):
     });
   }
 
+  // Use a placeholder ("---") if the min/max bounds are undefined
+  const minSliderLabel = Number.isNaN(props.minSliderBound)
+    ? "--"
+    : numberToStringDecimal(props.minSliderBound, props.maxDecimalsToDisplay);
+  const maxSliderLabel = Number.isNaN(props.maxSliderBound)
+    ? "--"
+    : numberToStringDecimal(props.maxSliderBound, props.maxDecimalsToDisplay);
+
   return (
     <ComponentContainer>
       <InputNumber
@@ -190,12 +198,8 @@ export default function LabeledRangeSlider(inputProps: LabeledRangeSliderProps):
             open: props.disabled ? false : undefined, // Hide tooltip when disabled
           }}
         />
-        <SliderLabel $disabled={props.disabled}>
-          {numberToStringDecimal(props.minSliderBound, props.maxDecimalsToDisplay)}
-        </SliderLabel>
-        <SliderLabel $disabled={props.disabled}>
-          {numberToStringDecimal(props.maxSliderBound, props.maxDecimalsToDisplay)}
-        </SliderLabel>
+        <SliderLabel $disabled={props.disabled}>{minSliderLabel}</SliderLabel>
+        <SliderLabel $disabled={props.disabled}>{maxSliderLabel}</SliderLabel>
       </SliderContainer>
       <InputNumber
         ref={maxInput}

--- a/src/components/LabeledRangeSlider.tsx
+++ b/src/components/LabeledRangeSlider.tsx
@@ -3,6 +3,7 @@ import { InputNumber, Slider } from "antd";
 import { clamp } from "three/src/math/MathUtils";
 import styled, { css } from "styled-components";
 import { setMaxDecimalPrecision, numberToStringDecimal } from "../colorizer/utils/math_utils";
+import { excludeUndefinedValues } from "../colorizer/utils/react_utils";
 
 type LabeledRangeSliderProps = {
   disabled?: boolean;
@@ -10,9 +11,9 @@ type LabeledRangeSliderProps = {
   min: number;
   /** Currently selected max range value.*/
   max: number;
-  /** The lower bound for the slider. */
+  /** The lower bound for the slider. If undefined, uses Number.NaN. */
   minSliderBound?: number;
-  /** The upper bound for the slider. */
+  /** The upper bound for the slider. If undefined, uses Number.NaN. */
   maxSliderBound?: number;
   /** The lower bound for the numeric input. If undefined, uses MIN_SAFE_INTEGER. */
   minInputBound?: number;
@@ -34,8 +35,8 @@ type LabeledRangeSliderProps = {
 const defaultProps: Partial<LabeledRangeSliderProps> = {
   minInputBound: Number.MIN_SAFE_INTEGER,
   maxInputBound: Number.MAX_SAFE_INTEGER,
-  minSliderBound: 0,
-  maxSliderBound: 1,
+  minSliderBound: Number.NaN,
+  maxSliderBound: Number.NaN,
   minSteps: 25,
   maxDecimalsToDisplay: 3,
   marks: undefined,
@@ -105,7 +106,7 @@ const SliderLabel = styled.p<{ $disabled?: boolean }>`
  * separately from the min and max value bounds and acts as a suggested range.
  */
 export default function LabeledRangeSlider(inputProps: LabeledRangeSliderProps): ReactElement {
-  const props = { ...defaultProps, ...inputProps } as Required<LabeledRangeSliderProps>;
+  const props = { ...defaultProps, ...excludeUndefinedValues(inputProps) } as Required<LabeledRangeSliderProps>;
 
   // TODO: Could add a controlled/uncontrolled mode to this component, maybe with
   // a custom hook? (e.g., use state if min/max are undefined, otherwise use props)

--- a/src/components/LabeledRangeSlider.tsx
+++ b/src/components/LabeledRangeSlider.tsx
@@ -159,7 +159,7 @@ export default function LabeledRangeSlider(inputProps: LabeledRangeSliderProps):
     });
   }
 
-  // Use a placeholder ("---") if the min/max bounds are undefined
+  // Use a placeholder if the min/max bounds are undefined
   const minSliderLabel = Number.isNaN(props.minSliderBound)
     ? "--"
     : numberToStringDecimal(props.minSliderBound, props.maxDecimalsToDisplay);

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -188,7 +188,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     const featureData = props.dataset?.features[item.featureName];
     const disabled = featureData === undefined || featureData.units !== item.units;
     // If the feature is no longer in the dataset, use the saved min/max bounds.
-    const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [0, 1];
+    const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [Number.NaN, Number.NaN];
     const sliderMin = disabled ? savedMinMax[0] : featureData.min;
     const sliderMax = disabled ? savedMinMax[1] : featureData.max;
 


### PR DESCRIPTION
Problem
=======
Fixes #134, [Incorrect range when loading thresholds not in dataset from URL](https://github.com/allen-cell-animated/nucmorph-colorizer/issues/134).

Solution
========
- LabeledRangeSlider defaults to showing a `--` label when a bound is NaN.
- Changed default feature range to `[NaN, NaN]` for features from datasets that haven't been loaded yet.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-157/?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fcollection.json&dataset=Test%203%20Custom%20Manifest&feature=feature&filters=feature%3Atest%2520unit%3A0%3A140%2Cfeature%3A%3A35%3A140&range=35%2C140&color=matplotlib-cool
1. Switch to the filters tab. Observe the new placeholders.
1. Change datasets to Test 1. The range values should update to their correct values.

Screenshots (optional):
-----------------------
Before: (note how bounds go from 0 to 1, even though this doesn't represent the selected range)
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/e8a96a39-9a92-49da-b667-7a91a820406c)

After:
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/5257c5c7-18ab-4d15-b4d0-b473e71155b5)

