### PR TITLE
fix: Adds support for ordered feature arrays

### DIFF
--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -11,7 +11,6 @@ import { FeatureArrayType, FeatureDataType } from "./types";
 import * as urlUtils from "./utils/url_utils";
 import { MAX_FEATURE_CATEGORIES } from "../constants";
 import { AnyManifestFile, ManifestFile, ManifestFileMetadata, update_manifest_version } from "./utils/dataset_utils";
-import { RecordValue } from "./utils/type_utils";
 
 export enum FeatureType {
   CONTINUOUS = "continuous",
@@ -48,7 +47,8 @@ export default class Dataset {
   private frameDimensions: Vector2 | null;
 
   private arrayLoader: IArrayLoader;
-  public features: Record<string, FeatureData>;
+  // Use map to enforce ordering
+  private features: Map<string, FeatureData>;
 
   private outlierFile?: string;
   public outliers?: Texture | null;
@@ -88,7 +88,7 @@ export default class Dataset {
     this.frameDimensions = null;
 
     this.arrayLoader = arrayLoader || new JsonArrayLoader();
-    this.features = {};
+    this.features = new Map();
     this.metadata = defaultMetadata;
   }
 
@@ -121,8 +121,10 @@ export default class Dataset {
 
   /**
    * Loads a feature from the dataset, fetching its data from the provided url.
+   * @returns A promise of an array tuple containing the feature name and its FeatureData.
    */
-  private async loadFeature(name: string, metadata: RecordValue<ManifestFile["features"]>): Promise<void> {
+  private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData]> {
+    const name = metadata.name;
     const url = this.resolveUrl(metadata.data);
     const source = await this.arrayLoader.load(url);
     const featureType = this.getFeatureTypeFromString(metadata?.type || "", FeatureType.CONTINUOUS);
@@ -137,27 +139,26 @@ export default class Dataset {
       );
     }
 
-    this.features[name] = {
-      tex: source.getTexture(FeatureDataType.F32),
-      data: source.getBuffer(FeatureDataType.F32),
-      min: source.getMin(),
-      max: source.getMax(),
-      units: metadata?.units || "",
-      type: featureType,
-      categories: featureCategories || null,
-    };
+    return [
+      name,
+      {
+        tex: source.getTexture(FeatureDataType.F32),
+        data: source.getBuffer(FeatureDataType.F32),
+        min: source.getMin(),
+        max: source.getMax(),
+        units: metadata?.units || "",
+        type: featureType,
+        categories: featureCategories || null,
+      },
+    ];
   }
 
   public hasFeature(name: string): boolean {
     return this.featureNames.includes(name);
   }
 
-  public getFeatureData(name: string): FeatureData | null {
-    if (Object.keys(this.features).includes(name)) {
-      return this.features[name];
-    } else {
-      return null;
-    }
+  public getFeatureData(name: string): FeatureData | undefined {
+    return this.features.get(name);
   }
 
   public getFeatureNameWithUnits(name: string): string {
@@ -169,20 +170,25 @@ export default class Dataset {
     }
   }
 
+  /**
+   * Gets the feature's units if it exists; otherwise returns an empty string.
+   */
   public getFeatureUnits(name: string): string {
-    return this.features[name].units;
+    return this.features.get(name)?.units || "";
   }
 
   /**
    * Returns the FeatureType of the given feature, if it exists.
    * @param name Feature name to retrieve
+   * @throws An error if the feature does not exist.
    * @returns The FeatureType of the given feature (categorical, continuous, or discrete)
    */
   public getFeatureType(name: string): FeatureType {
-    if (this.features[name] === undefined) {
+    const featureData = this.features.get(name);
+    if (!featureData) {
       throw new Error(`Feature ${name} does not exist.`);
     }
-    return this.features[name].type;
+    return featureData.type;
   }
 
   /**
@@ -191,15 +197,16 @@ export default class Dataset {
    * @returns The array of string categories for the given feature, or null if the feature is not categorical.
    */
   public getFeatureCategories(name: string): string[] | null {
-    if (this.features[name] && this.features[name].type === FeatureType.CATEGORICAL) {
-      return this.features[name].categories;
+    const featureData = this.features.get(name);
+    if (featureData && featureData.type === FeatureType.CATEGORICAL) {
+      return featureData.categories;
     }
     return null;
   }
 
   /** Returns whether the given feature represents categorical data. */
   public isFeatureCategorical(name: string): boolean {
-    return this.features[name].type === FeatureType.CATEGORICAL;
+    return this.features.get(name)?.type === FeatureType.CATEGORICAL;
   }
 
   /**
@@ -250,11 +257,12 @@ export default class Dataset {
   }
 
   public get featureNames(): string[] {
-    return Object.keys(this.features);
+    return Array.from(this.features.keys());
   }
 
   public get numObjects(): number {
-    return this.features[this.featureNames[0]].data.length;
+    // TODO: This is potentially unsafe if the first feature failed to load.
+    return this.features.get(this.featureNames[0])?.data.length || 0;
   }
 
   /** Loads a single frame from the dataset */
@@ -303,9 +311,7 @@ export default class Dataset {
     this.frames = new FrameCache(this.frameFiles.length, MAX_CACHED_FRAMES);
 
     // Load feature data
-    const featuresPromises: Promise<void>[] = Object.keys(manifest.features).map((name) =>
-      this.loadFeature.bind(this)(name, manifest.features[name])
-    );
+    const featuresPromises: Promise<[string, FeatureData]>[] = manifest.features.map((data) => this.loadFeature(data));
 
     const result = await Promise.all([
       this.loadToTexture(FeatureDataType.U8, this.outlierFile),
@@ -313,15 +319,21 @@ export default class Dataset {
       this.loadToBuffer(FeatureDataType.U32, this.timesFile),
       this.loadToBuffer(FeatureDataType.U16, this.centroidsFile),
       this.loadToBuffer(FeatureDataType.U16, this.boundsFile),
-      ...featuresPromises,
+      Promise.all(featuresPromises),
     ]);
-    const [outliers, tracks, times, centroids, bounds] = result;
+    const [outliers, tracks, times, centroids, bounds, featureResults] = result;
 
     this.outliers = outliers;
     this.trackIds = tracks;
     this.times = times;
     this.centroids = centroids;
     this.bounds = bounds;
+
+    // Keep original sorting order of features by inserting in promise order.
+    // Map is ordered by insertion.
+    featureResults.forEach(([name, data]) => {
+      this.features.set(name, data);
+    });
 
     // TODO: Dynamically fetch features
     // TODO: Pre-process feature data to handle outlier values by interpolating between known good values (#21)
@@ -380,7 +392,7 @@ export default class Dataset {
   // get the times and values of a track for a given feature
   // this data is suitable to hand to d3 or plotly as two arrays of domain and range values
   public buildTrackFeaturePlot(track: Track, feature: string): { domain: number[]; range: number[] } {
-    const range = track.ids.map((i) => this.features[feature].data[i]);
+    const range = track.ids.map((i) => this.features.get(feature)?.data[i] || -1);
     const domain = track.times;
     return { domain, range };
   }

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -108,7 +108,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     // that has the same feature/unit but different min/max values. That way, our saved min/max bounds
     // reflect the last known good values.
     for (const threshold of props.featureThresholds) {
-      const featureData = props.dataset?.features[threshold.featureName];
+      const featureData = props.dataset?.getFeatureData(threshold.featureName);
       if (featureData && featureData.units === threshold.units) {
         featureMinMaxBoundsFallback.current.set(thresholdToKey(threshold), [featureData.min, featureData.max]);
       }
@@ -119,7 +119,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
 
   /** Handle the user selecting new features from the Select dropdown. */
   const onSelect = (featureName: string): void => {
-    const featureData = props.dataset?.features[featureName];
+    const featureData = props.dataset?.getFeatureData(featureName);
     const newThresholds = [...props.featureThresholds];
     if (featureData) {
       // Add a new threshold for the selected value if valid
@@ -136,7 +136,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   /** Handle the user removing features from the Select dropdown. */
   const onDeselect = (featureName: string): void => {
     // Find the exact match for the threshold and remove it
-    const featureData = props.dataset?.features[featureName];
+    const featureData = props.dataset?.getFeatureData(featureName);
     const newThresholds = [...props.featureThresholds];
     if (featureData) {
       const index = props.featureThresholds.findIndex(thresholdMatchFinder(featureName, featureData.units));
@@ -177,7 +177,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   // Filter out thresholds that no longer match the dataset (feature and/or unit), so we only
   // show selections that are actually valid.
   const thresholdsInDataset = props.featureThresholds.filter((t) => {
-    const featureData = props.dataset?.features[t.featureName];
+    const featureData = props.dataset?.getFeatureData(t.featureName);
     return featureData && featureData.units === t.units;
   });
   const selectedFeatures = thresholdsInDataset.map((t) => t.featureName);
@@ -185,7 +185,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   const renderListItems = (item: FeatureThreshold, index: number): ReactNode => {
     // Thresholds are matched on both feature names and units; a threshold must match
     // both in the current dataset to be valid.
-    const featureData = props.dataset?.features[item.featureName];
+    const featureData = props.dataset?.getFeatureData(item.featureName);
     const disabled = featureData === undefined || featureData.units !== item.units;
     // If the feature is no longer in the dataset, use the saved min/max bounds.
     const savedMinMax = featureMinMaxBoundsFallback.current.get(thresholdToKey(item)) || [0, 1];

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -42,6 +42,17 @@ describe("Dataset", () => {
 
   const defaultManifest: ManifestFile = {
     frames: ["frame0.json"],
+    features: [
+      { name: "feature1", data: "feature1.json", units: "meters", type: "continuous" },
+      { name: "feature2", data: "feature2.json", units: "(m)", type: "discrete" },
+      { name: "feature3", data: "feature3.json", units: "μm/s", type: "bad-type" },
+      { name: "feature4", data: "feature4.json" },
+      { name: "feature5", data: "feature4.json", type: "categorical", categories: ["small", "medium", "large"] },
+    ],
+  };
+
+  const manifestV2: AnyManifestFile = {
+    frames: ["frame0.json"],
     features: {
       feature1: { data: "feature1.json", units: "meters", type: "continuous" },
       feature2: { data: "feature2.json", units: "(m)", type: "discrete" },
@@ -51,7 +62,7 @@ describe("Dataset", () => {
     },
   };
 
-  const deprecatedManifest: AnyManifestFile = {
+  const manifestV1: AnyManifestFile = {
     frames: ["frame0.json"],
     features: {
       feature1: "feature1.json",
@@ -71,7 +82,8 @@ describe("Dataset", () => {
 
   const manifestsToTest: [string, AnyManifestFile][] = [
     ["Default Manifest", defaultManifest],
-    ["Deprecated Manifest", deprecatedManifest],
+    ["Deprecated Manifest V2", manifestV2],
+    ["Deprecated Manifest V1", manifestV1],
   ];
 
   // Test both normal and deprecated manifests


### PR DESCRIPTION
Problem
=======
Fixes #155, "Features are out of order." 

Solution
========
- Updates the manifest definition to accept `features` as an array, rather than a map with no guarantee of ordering.
- Changes `Dataset.ts` to use a `Map` internally, which enforces key ordering.
  - (technically JS objects _should_ enforce key ordering but it's not guaranteed.)
- Adds tests to accept both the outdated and new datasets.
  - Note: I don't think any datasets have actually been created with the last format (V2). Should I just remove the definitions for it altogether?

## Type of change

* Bug fix (non-breaking change which fixes an issue)

