### PR TITLE
feature: GitHub pages build

### DIFF
--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: "18"
 
       - name: Install and Build
-        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/
+        run: npm ci && npx vite build
 
       - name: Run Linter
         run: npm run lint

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -18,9 +18,8 @@ jobs:
         with:
           node-version: "18"
 
-        # Must override default vite build base so that assets can still be accessed when not placed in the root directory of gh-pages branch.
       - name: Install and Build
-        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/public/
+        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/
 
       - name: Run Linter
         run: npm run lint
@@ -35,4 +34,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          publish_dir: .

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install and Build
         run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/public/
 
+      - name: Run Linter
+        run: npm run lint
+
       - name: Run Typechecker
         run: npm run typeCheck
 

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -32,4 +32,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
+          publish_dir: ./public

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -6,10 +6,10 @@ on:
     branches:
       - main
 
-concurrency: deploy-public-build-${{ github.ref }}
+concurrency: pages-build-deployment-${{ github.ref }}
 
 jobs:
-  deploy-public-build:
+  pages-build-deployment:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -1,0 +1,35 @@
+# Adapted from https://github.com/marketplace/actions/deploy-pr-preview.
+name: Deploy Public Build
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: deploy-public-build-${{ github.ref }}
+
+jobs:
+  deploy-public-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+        # Must override default vite build base so that assets can still be accessed when not placed in the root directory of gh-pages branch.
+      - name: Install and Build
+        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/public/
+
+      - name: Run Typechecker
+        run: npm run typeCheck
+
+      - name: Run Tests
+        run: npx vitest run
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .


### PR DESCRIPTION
Adds an action that triggers on pushes to main that will deploy a public build to GitHub pages.

New builds should be accessible via this link: 
https://allen-cell-animated.github.io/nucmorph-colorizer/
