### PR TITLE
fix: Build and deploy GitHub action no longer deletes existing files

### DIFF
--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -19,19 +19,10 @@ jobs:
           node-version: "18"
 
       - name: Install and Build
-        run: npm ci && npx vite build
-
-      - name: Run Linter
-        run: npm run lint
-
-      - name: Run Typechecker
-        run: npm run typeCheck
-
-      - name: Run Tests
-        run: npx vitest run
+        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/public/
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
+          publish_dir: ./public/

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -11,15 +11,17 @@ concurrency: pages-build-deployment-${{ github.ref }}
 jobs:
   pages-build:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: "18"
 
       - name: Install and Build
-        run: npm ci && npx vite build --base=/public/
+        run: npm ci && npx vite build --base=/nucmorph-colorizer/
 
       - name: Upload build files
         uses: actions/upload-artifact@v3
@@ -43,4 +45,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public/
+          publish_dir: ./dist

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: "18"
 
       - name: Install and Build
-        run: npm ci && npx vite build --base=/nucmorph-colorizer/
+        run: npm ci && npx vite build --base=/nucmorph-colorizer/main/
 
       - name: Upload build files
         uses: actions/upload-artifact@v3
@@ -46,3 +46,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          destination_dir: main

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -1,4 +1,5 @@
-# Adapted from https://github.com/marketplace/actions/deploy-pr-preview.
+# Adapted from https://github.com/marketplace/actions/deploy-pr-preview and
+# https://github.com/sitek94/vite-deploy-demo
 name: Deploy Public Build
 
 on:

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -9,7 +9,7 @@ on:
 concurrency: pages-build-deployment-${{ github.ref }}
 
 jobs:
-  pages-build-deployment:
+  pages-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,7 +19,25 @@ jobs:
           node-version: "18"
 
       - name: Install and Build
-        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/public/
+        run: npm ci && npx vite build --base=/public/
+
+      - name: Upload build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: production-files
+          path: ./public
+
+  pages-deploy:
+    needs: pages-build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: production-files
+          path: ./public
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -25,19 +25,19 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: production-files
-          path: ./public
+          path: ./dist
 
   pages-deploy:
     needs: pages-build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: production-files
-          path: ./public
+          path: ./dist
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,7 +20,7 @@ jobs:
 
         # Must override default vite build base so that assets can still be accessed when not placed in the root directory of gh-pages branch.
       - name: Install and Build
-        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-${PR_NUMBER}/
+        run: npm ci && npx vite build --base=/nucmorph-colorizer/pr-preview/pr-${PR_NUMBER}/
         env:
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,7 +20,7 @@ jobs:
 
         # Must override default vite build base so that assets can still be accessed when not placed in the root directory of gh-pages branch.
       - name: Install and Build
-        run: npm ci && npx vite build --base=/nucmorph-colorizer/pr-preview/pr-${PR_NUMBER}/
+        run: npm ci && npx vite build --base=https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-${PR_NUMBER}/
         env:
           PR_NUMBER: ${{ github.event.number }}
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ This project originated from the [Allen Institute for Cell Science (AICS)](https
 project and is being updated to support broader use cases. View our [Issues page](https://github.com/allen-cell-animated/nucmorph-colorizer/issues)
 for more details about potential future features!
 
-**[Access our current stable build here!](https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html)**
+### Builds:
+
+**Stable build: [https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html](https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html)**
+
+**Latest (`main` branch): [https://allen-cell-animated.github.io/nucmorph-colorizer/main/](https://allen-cell-animated.github.io/nucmorph-colorizer/main/)**
 
 ![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/81130299-7e75-4fc2-a344-19aba7aae8a5)
 


### PR DESCRIPTION
Problem
=======
Fixes an issue where the GitHub deployment action would delete the existing PR preview files. Now, the build files are placed in a subdirectory `/main`. Also updates the resource links and adds artifacts so the build files can be inspected.