### PR TITLE
refactor: Changed Dataset outliers to load as a buffer instead of texture

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -329,7 +329,7 @@ export default class ColorizeCanvas {
     }
     this.dataset = dataset;
     if (this.dataset.outliers) {
-      this.setUniform("outlierData", this.dataset.outliers);
+      this.setUniform("outlierData", packDataTexture(Array.from(this.dataset.outliers), FeatureDataType.U8));
     } else {
       this.setUniform("outlierData", packDataTexture([0], FeatureDataType.U8));
     }

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -61,7 +61,7 @@ export default class Dataset {
   private features: Map<string, FeatureData>;
 
   private outlierFile?: string;
-  public outliers?: Texture | null;
+  public outliers?: Uint8Array | null;
 
   private tracksFile?: string;
   private timesFile?: string;
@@ -227,18 +227,18 @@ export default class Dataset {
    * @throws An error if fileUrl is not undefined and the data cannot be loaded from the file.
    * @returns Promise of a texture loaded from the file. If `fileUrl` is undefined, returns null.
    */
-  private async loadToTexture(dataType: FeatureDataType, fileUrl?: string): Promise<Texture | null> {
-    if (!fileUrl) {
-      return null;
-    }
-    try {
-      const url = this.resolveUrl(fileUrl);
-      const source = await this.arrayLoader.load(url);
-      return source.getTexture(dataType);
-    } catch (e) {
-      return null;
-    }
-  }
+  // private async loadToTexture(dataType: FeatureDataType, fileUrl?: string): Promise<Texture | null> {
+  //   if (!fileUrl) {
+  //     return null;
+  //   }
+  //   try {
+  //     const url = this.resolveUrl(fileUrl);
+  //     const source = await this.arrayLoader.load(url);
+  //     return source.getTexture(dataType);
+  //   } catch (e) {
+  //     return null;
+  //   }
+  // }
 
   /**
    * Fetches and loads a data file as an array and returns its data as a TypedArray using the provided dataType.
@@ -365,7 +365,7 @@ export default class Dataset {
     );
 
     const result = await Promise.all([
-      this.loadToTexture(FeatureDataType.U8, this.outlierFile),
+      this.loadToBuffer(FeatureDataType.U8, this.outlierFile),
       this.loadToBuffer(FeatureDataType.U32, this.tracksFile),
       this.loadToBuffer(FeatureDataType.U32, this.timesFile),
       this.loadToBuffer(FeatureDataType.U16, this.centroidsFile),

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -221,26 +221,6 @@ export default class Dataset {
   }
 
   /**
-   * Fetches and loads a data file as an array and returns its data as a Texture using the provided dataType.
-   * @param dataType The expected format of the data.
-   * @param fileUrl String url of the file to be loaded.
-   * @throws An error if fileUrl is not undefined and the data cannot be loaded from the file.
-   * @returns Promise of a texture loaded from the file. If `fileUrl` is undefined, returns null.
-   */
-  // private async loadToTexture(dataType: FeatureDataType, fileUrl?: string): Promise<Texture | null> {
-  //   if (!fileUrl) {
-  //     return null;
-  //   }
-  //   try {
-  //     const url = this.resolveUrl(fileUrl);
-  //     const source = await this.arrayLoader.load(url);
-  //     return source.getTexture(dataType);
-  //   } catch (e) {
-  //     return null;
-  //   }
-  // }
-
-  /**
    * Fetches and loads a data file as an array and returns its data as a TypedArray using the provided dataType.
    * @param dataType The expected format of the data.
    * @param fileUrl String url of the file to be loaded.


### PR DESCRIPTION
Changes the Dataset so it loads outliers to a buffer/array that can then be read from directly.

This will let the scatterplot colorizer read which values are outliers as part of the changes for #189.