### PR TITLE
feature: Colorize scatterplot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/icons": "^5.2.5",
         "antd": "^5.9.4",
         "mp4-muxer": "^2.2.2",
-        "plotly.js-dist-min": "^2.22.0",
+        "plotly.js-dist-min": "^2.27.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "styled-components": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ant-design/icons": "^5.2.5",
     "antd": "^5.9.4",
     "mp4-muxer": "^2.2.2",
-    "plotly.js-dist-min": "^2.22.0",
+    "plotly.js-dist-min": "^2.27.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^6.0.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -881,7 +881,7 @@ function App(): ReactElement {
                           selectedFeatureName={featureName}
                           colorRampMin={colorRampMin}
                           colorRampMax={colorRampMax}
-                          colorRamp={colorRampData.get(colorRampKey)!}
+                          colorRamp={getColorMap(colorRampData, colorRampKey, colorRampReversed)}
                           categoricalPalette={categoricalPalette}
                           viewerConfig={config}
                         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -878,6 +878,12 @@ function App(): ReactElement {
                           setFrame={setFrameAndRender}
                           isVisible={openTab === TabType.SCATTER_PLOT}
                           isPlaying={timeControls.isPlaying() || isRecording}
+                          selectedFeatureName={featureName}
+                          colorRampMin={colorRampMin}
+                          colorRampMax={colorRampMax}
+                          colorRamp={colorRampData.get(colorRampKey)!}
+                          categoricalPalette={categoricalPalette}
+                          viewerConfig={config}
                         />
                       </div>
                     ),

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -51,6 +51,9 @@ export function remap(
   if (clamp) {
     input = Math.min(Math.max(input, inMin), inMax);
   }
+  if (inMin === inMax) {
+    return outMin;
+  }
   return ((input - inMin) / (inMax - inMin)) * (outMax - outMin) + outMin;
 }
 

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -49,7 +49,9 @@ export function remap(
   clamp: boolean = true
 ): number {
   if (clamp) {
-    input = Math.min(Math.max(input, inMin), inMax);
+    const min = Math.min(inMin, inMax);
+    const max = Math.max(inMin, inMax);
+    input = Math.min(Math.max(input, min), max);
   }
   if (inMin === inMax) {
     return outMin;

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -36,7 +36,9 @@ function numberToUnicodeSuperscript(input: number): string {
 }
 
 /**
- * Remaps a value from one range to another.
+ * Remaps a value from one range to another, optionally clamping the input value to the input range.
+ *
+ * Handles reversed ranges (e.g. `inMin > inMax` or `outMin > outMax`). If `inMin === inMax`, returns `outMin`.
  *
  * @param clamp If true (default), clamps the input to the input range.
  */

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -41,34 +41,6 @@ export function useDebounce<T>(value: T, delayMs?: number): T {
 }
 
 /**
- * Combines useTransition and useDebounce. Debounces value and initiates a state transition once the value has come
- * to rest.
- * @param inputValue The value to debounce and transition.
- * @param startTransition The startTransition function returned by useTransition.
- * @param onChange An optional callback that triggers when the debounced value changes, but before the transition.
- * @param delayMs The delay, in milliseconds. 500 ms by default.
- */
-export function useTransitionedDebounce<T>(
-  inputValue: T,
-  startTransition: React.TransitionStartFunction,
-  onChange: () => void = () => {},
-  delayMs: number = 500
-): T {
-  const [value, setValue] = useState<T>(inputValue);
-  const debouncedValue = useDebounce(inputValue, delayMs);
-
-  // Only update value when the debounced value has changed.
-  useEffect(() => {
-    onChange();
-    startTransition(() => {
-      setValue(debouncedValue);
-    });
-  }, [debouncedValue]);
-
-  return value;
-}
-
-/**
  * Returns a reference to a constructed value that will not be re-computed between renders.
  *
  * Functionally, this is a wrapper around useRef and allows it to be used in a type-safe way.

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -25,7 +25,6 @@ import {
   splitTraceData,
   subsampleColorRamp,
 } from "./scatter_plot_data_utils";
-import { clamp } from "three/src/math/MathUtils";
 
 /** Extra feature that's added to the dropdowns representing the frame number. */
 const TIME_FEATURE = { key: "scatterplot_time", name: "Time" };
@@ -597,7 +596,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       if (isUsingTime) {
         traces.push(makeLineTrace(trackData.xData, trackData.yData));
       }
-      // Render track only
+      // Render track points
       const trackTraces = colorizeScatterplotPoints(
         trackData.xData,
         trackData.yData,

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -35,6 +35,7 @@ const PLOTLY_CONFIG: Partial<Plotly.Config> = {
 };
 
 const MAX_POINTS_PER_TRACE = 1024;
+const COLOR_RAMP_SUBSAMPLES = 100;
 
 enum RangeType {
   ALL_TIME = "All time",
@@ -452,7 +453,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   /**
    * Applies coloring to point traces in a scatterplot. Does this by splitting the data into multiple traces each with a solid
    * color, which is much faster than using Plotly's native color ramping. Also enforces a maximum number of points
-   * per trace, which also seems to speed up Plotly renders.
+   * per trace, which significantly speeds up Plotly renders.
    *
    * @param xData
    * @param yData
@@ -489,12 +490,11 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       });
     } else {
       // Generate colors
-      const NUM_RANGE_COLORS = 100; // TBD if this is a good number?
       const categories = dataset.getFeatureCategories(selectedFeatureName);
       const colors =
         categories !== null
           ? categoricalPalette.slice(0, categories.length)
-          : subsampleColorRamp(colorRamp, NUM_RANGE_COLORS);
+          : subsampleColorRamp(colorRamp, COLOR_RAMP_SUBSAMPLES);
 
       // Make a bucket group for each ramp/palette color and for the out-of-range and outliers.
       // index 0 = out of filter range, index 1 = outliers.

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -512,7 +512,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
 
       // Sort data into buckets
       for (let i = 0; i < xData.length; i++) {
-        const isOutOfRange = false;
+        const isOutOfRange = false; // TODO: Implement out of range filtering
         const isOutlier = dataset.outliers ? dataset.outliers[objectIds[i]] : false;
         const objectId = objectIds[i];
 

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -450,8 +450,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   };
 
   /**
-   *
-   * Applies colorization to point traces in a scatterplot. Does this by splitting the data into multiple traces each with a solid
+   * Applies coloring to point traces in a scatterplot. Does this by splitting the data into multiple traces each with a solid
    * color, which is much faster than using Plotly's native color ramping. Also enforces a maximum number of points
    * per trace, which also seems to speed up Plotly renders.
    *
@@ -476,11 +475,6 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       return [];
     }
 
-    // Hovertext for points. Shows the X and Y values; the track and object ID are passed in via the `text` attribute.
-    const hoverTemplate =
-      `${xAxisFeatureName}: %{x} ${dataset.getFeatureUnits(xAxisFeatureName)}` +
-      `<br>${yAxisFeatureName}: %{y} ${dataset.getFeatureUnits(yAxisFeatureName)}` +
-      `<br>Track ID: %{customdata}<br>Object ID: %{id}`;
     const featureData = dataset.getFeatureData(selectedFeatureName);
 
     let traceDataBuckets: TraceData[] = [];
@@ -496,7 +490,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     } else {
       // Generate colors
       const NUM_RANGE_COLORS = 100; // TBD if this is a good number?
-      const categories = dataset.getFeatureCategories(selectedFeatureName) || [];
+      const categories = dataset.getFeatureCategories(selectedFeatureName);
       const colors =
         categories !== null
           ? categoricalPalette.slice(0, categories.length)
@@ -523,7 +517,8 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       for (let i = 0; i < xData.length; i++) {
         // Add one to bucketIndex to adjust for the out of bounds bucket.
         // const isOutlier = dataset.outliers. // TODO: Handle Outliers!!!!
-        const bucketIndex = getBucketIndex(featureData.data[i], colorRampMin, colorRampMax, colors.length) + 2;
+        const objectId = objectIds[i];
+        const bucketIndex = getBucketIndex(featureData.data[objectId], colorRampMin, colorRampMax, colors.length) + 2;
         const bucket = traceDataBuckets[bucketIndex];
         bucket.x.push(xData[i]);
         bucket.y.push(yData[i]);
@@ -559,11 +554,13 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
             size: 4,
             ...markerConfig,
           },
-          hovertemplate: hoverTemplate,
+          hovertemplate:
+            `${xAxisFeatureName}: %{x} ${dataset.getFeatureUnits(xAxisFeatureName)}` +
+            `<br>${yAxisFeatureName}: %{y} ${dataset.getFeatureUnits(yAxisFeatureName)}` +
+            `<br>Track ID: %{customdata}<br>Object ID: %{id}`,
         };
       });
 
-    console.log(traces);
     return traces;
   };
 

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -5,7 +5,7 @@ import React, { ReactElement, memo, useCallback, useContext, useEffect, useRef, 
 import styled from "styled-components";
 
 import { AppThemeContext } from "../AppStyle";
-import { ColorRampData, Dataset, Track } from "../../colorizer";
+import { ColorRamp, ColorRampData, Dataset, Track } from "../../colorizer";
 import { remap } from "../../colorizer/utils/math_utils";
 import { useDebounce } from "../../colorizer/utils/react_utils";
 import IconButton from "../IconButton";
@@ -55,7 +55,7 @@ type ScatterPlotTabProps = {
   selectedFeatureName: string | null;
   colorRampMin: number;
   colorRampMax: number;
-  colorRamp: ColorRampData;
+  colorRamp: ColorRamp;
   categoricalPalette: Color[];
 
   viewerConfig: ViewerConfig;
@@ -494,7 +494,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       const colors =
         categories !== null
           ? categoricalPalette.slice(0, categories.length)
-          : subsampleColorRamp(colorRamp.colorRamp, NUM_RANGE_COLORS);
+          : subsampleColorRamp(colorRamp, NUM_RANGE_COLORS);
 
       // Reserve two extra colors for out of bounds and outliers.
       const outlierColor = viewerConfig.outlierDrawSettings.color;
@@ -648,10 +648,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
         trackData.xData,
         trackData.yData,
         trackData.objectIds,
-        trackData.trackIds,
-        {
-          size: 5,
-        }
+        trackData.trackIds
       );
       traces.push(...trackTraces);
     }

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -116,13 +116,6 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   const isDebouncePending =
     dataset !== props.dataset || colorRampMin !== props.colorRampMin || colorRampMax !== props.colorRampMax;
 
-  // Signal that the plot is stalled when playback starts.
-  useEffect(() => {
-    if (isPlaying) {
-      setIsRendering(true);
-    }
-  }, [isPlaying]);
-
   // TODO: Implement color ramps in a worker thread. This was originally removed for performance issues.
   // Plotly's performance can be improved by generating traces for colors rather than feeding it the raw
   // data and asking it to colorize it.
@@ -422,7 +415,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
 
     const traceDataBuckets: TraceData[] = [];
     if (!featureData || markerConfig.color || overrideColor) {
-      // Do no coloring! Keep all points in the same bucket.
+      // Do no coloring! Keep all points in the same bucket, which will still be split up later.
       traceDataBuckets.push({
         x: Array.from(xData),
         y: Array.from(yData),
@@ -757,7 +750,10 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     <>
       {makeControlBar()}
       <div style={{ position: "relative" }}>
-        <LoadingSpinner loading={isPending || isRendering || isDebouncePending} style={{ marginTop: "10px" }}>
+        <LoadingSpinner
+          loading={isPending || isRendering || isDebouncePending || isPlaying}
+          style={{ marginTop: "10px" }}
+        >
           {makePlotButtons()}
           <ScatterPlotContainer
             style={{ width: "100%", height: "475px", padding: "5px" }}

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -44,8 +44,6 @@ enum RangeType {
 }
 const DEFAULT_RANGE_TYPE = RangeType.ALL_TIME;
 
-type DataArray = Uint32Array | Float32Array | number[];
-
 type ScatterPlotTabProps = {
   dataset: Dataset | null;
   currentFrame: number;

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -24,6 +24,7 @@ import {
   splitTraceData,
   subsampleColorRamp,
 } from "./scatter_plot_data_utils";
+import { clamp } from "three/src/math/MathUtils";
 
 /** Extra feature that's added to the dropdowns representing the frame number. */
 const TIME_FEATURE = { key: "scatterplot_time", name: "Time" };
@@ -457,10 +458,10 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     } else {
       // Generate colors
       const categories = dataset.getFeatureCategories(selectedFeatureName);
-      const colors =
-        categories !== null
-          ? categoricalPalette.slice(0, categories.length)
-          : subsampleColorRamp(colorRamp, COLOR_RAMP_SUBSAMPLES);
+      const isCategorical = categories !== null;
+      const colors = isCategorical
+        ? categoricalPalette.slice(0, categories.length)
+        : subsampleColorRamp(colorRamp, COLOR_RAMP_SUBSAMPLES);
 
       // Make a bucket group for each ramp/palette color and for the out-of-range and outliers.
       // index 0 = out of filter range, index 1 = outliers.
@@ -487,6 +488,9 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           bucketIndex = 0;
         } else if (isOutlier) {
           bucketIndex = 1;
+        } else if (isCategorical) {
+          // Clamp handles case where an unexpected NaN appears
+          bucketIndex = clamp(featureData.data[objectId], 0, colors.length - 1) + 2;
         } else {
           bucketIndex = getBucketIndex(featureData.data[objectId], colorRampMin, colorRampMax, colors.length) + 2;
         }

--- a/src/components/tabs/ScatterPlotTab.tsx
+++ b/src/components/tabs/ScatterPlotTab.tsx
@@ -34,7 +34,7 @@ const PLOTLY_CONFIG: Partial<Plotly.Config> = {
   responsive: true,
 };
 
-const MAX_POINTS_PER_TRACE = 1_000;
+const MAX_POINTS_PER_TRACE = 1024;
 
 enum RangeType {
   ALL_TIME = "All time",
@@ -496,8 +496,11 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     } else {
       // Generate colors
       const NUM_RANGE_COLORS = 100; // TBD if this is a good number?
-      const isCategory = dataset.isFeatureCategorical(selectedFeatureName);
-      const colors = isCategory ? categoricalPalette : subsampleColorRamp(colorRamp, NUM_RANGE_COLORS);
+      const categories = dataset.getFeatureCategories(selectedFeatureName) || [];
+      const colors =
+        categories !== null
+          ? categoricalPalette.slice(0, categories.length)
+          : subsampleColorRamp(colorRamp.colorRamp, NUM_RANGE_COLORS);
 
       // Reserve two extra colors for out of bounds and outliers.
       const outlierColor = viewerConfig.outlierDrawSettings.color;
@@ -520,7 +523,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
       for (let i = 0; i < xData.length; i++) {
         // Add one to bucketIndex to adjust for the out of bounds bucket.
         // const isOutlier = dataset.outliers. // TODO: Handle Outliers!!!!
-        const bucketIndex = getBucketIndex(featureData.data[i], colorRampMin, colorRampMax, colors.length) + 1;
+        const bucketIndex = getBucketIndex(featureData.data[i], colorRampMin, colorRampMax, colors.length) + 2;
         const bucket = traceDataBuckets[bucketIndex];
         bucket.x.push(xData[i]);
         bucket.y.push(yData[i]);

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -1,5 +1,5 @@
 import { PlotData } from "plotly.js-dist-min";
-import { ColorRampData } from "../../colorizer";
+import { ColorRamp } from "../../colorizer";
 import { remap } from "../../colorizer/utils/math_utils";
 import { Color } from "three";
 
@@ -13,28 +13,32 @@ export type TraceData = {
   color: Color;
 };
 
-export function subsampleColorRamp(colorRamp: ColorRampData, numColors: number): Color[] {
+/**
+ * Sample a color ramp at evenly-spaced points, returning an array of colors.
+ * @param {ColorRampData} colorRamp The gradient to sample.
+ * @param {number} numColors The number of colors to sample.
+ * @returns {Color[]} An array of length `numColors` containing the sampled colors.
+ */
+export function subsampleColorRamp(colorRamp: ColorRamp, numColors: number): Color[] {
   const colors: Color[] = [];
   for (let i = 0; i < numColors; i++) {
-    colors.push(colorRamp.colorRamp.sample(i / (numColors - 1)));
+    colors.push(colorRamp.sample(i / (numColors - 1)));
   }
   return colors;
 }
 
 /**
- * Returns the index of a bucket that a value should be sorted into, based on a provided range.
+ * Returns the index of a bucket that a value should be sorted into, based on a provided range and number of buckets.
+ * Assumes that each bucket is evenly spaced.
  * @param value
  * @param minValue Min value, inclusive.
  * @param maxValue Max value, inclusive.
  * @param numBuckets Number of buckets in the range between min and max values.
- * @returns The index of the bucket that the value should be sorted into, from 0 to `numBuckets - 1`.
- * Returns -1 if the value is out of bounds for the given range.
+ * @returns The index of the nearest bucket that the value should be sorted into, from 0 to `numBuckets - 1`. Clamps the value
+ * to the min/max values if it is outside the range.
  */
 export function getBucketIndex(value: number, minValue: number, maxValue: number, numBuckets: number): number {
-  if (value < minValue || value > maxValue) {
-    return -1;
-  }
-  return Math.round(remap(value, minValue, maxValue, 0, numBuckets - 1));
+  return Math.round(remap(value, minValue, maxValue, 0, numBuckets - 1, true));
 }
 
 /**

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -1,0 +1,61 @@
+import { ColorRampData } from "../../colorizer";
+import { remap } from "../../colorizer/utils/math_utils";
+import { Color } from "three";
+
+export type TraceData = {
+  x: number[];
+  y: number[];
+  objectIds: number[];
+  trackIds: number[];
+  color: Color;
+};
+
+export function subsampleColorRamp(colorRamp: ColorRampData, numColors: number): Color[] {
+  const colors: Color[] = [];
+  for (let i = 0; i < numColors; i++) {
+    colors.push(colorRamp.colorRamp.sample(i / (numColors - 1)));
+  }
+  return colors;
+}
+
+/**
+ * Returns the index of a bucket that a value should be sorted into, based on a provided range.
+ * @param value
+ * @param minValue Min value, inclusive.
+ * @param maxValue Max value, inclusive.
+ * @param numBuckets Number of buckets in the range between min and max values.
+ * @returns The index of the bucket that the value should be sorted into, from 0 to `numBuckets - 1`.
+ * Returns -1 if the value is out of bounds for the given range.
+ */
+export function getBucketIndex(value: number, minValue: number, maxValue: number, numBuckets: number): number {
+  if (value < minValue || value > maxValue) {
+    return -1;
+  }
+  return Math.round(remap(value, minValue, maxValue, 0, numBuckets - 1));
+}
+
+/**
+ * Splits a trace into one or more traces so that all traces have at most `maxPoints`
+ * data points.
+ * @param traceData The trace to split. (Will not be modified.)
+ * @param maxPoints The maximum number of points any trace can have.
+ * @returns An array of traces, with the same color as the original trace.
+ */
+export function splitTraceData(traceData: TraceData, maxPoints: number): TraceData[] {
+  if (traceData.x.length <= maxPoints) {
+    return [traceData];
+  }
+  const traces: TraceData[] = [];
+  for (let i = 0; i < traceData.x.length; i += maxPoints) {
+    const end = Math.min(i + maxPoints, traceData.x.length);
+    const trace: TraceData = {
+      x: traceData.x.slice(i, end),
+      y: traceData.y.slice(i, end),
+      objectIds: traceData.objectIds.slice(i, end),
+      trackIds: traceData.trackIds.slice(i, end),
+      color: traceData.color,
+    };
+    traces.push(trace);
+  }
+  return traces;
+}

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -1,4 +1,4 @@
-import { PlotData } from "plotly.js-dist-min";
+import Plotly, { PlotData } from "plotly.js-dist-min";
 import { ColorRamp } from "../../colorizer";
 import { remap } from "../../colorizer/utils/math_utils";
 import { Color } from "three";

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -29,13 +29,26 @@ export function subsampleColorRamp(colorRamp: ColorRamp, numColors: number): Col
 
 /**
  * Returns the index of a bucket that a value should be sorted into, based on a provided range and number of buckets.
- * Assumes that each bucket is evenly spaced.
+ * Buckets are evenly spaced and the first and last buckets center on the min and max values.
+ *
  * @param value
  * @param minValue Min value, inclusive.
  * @param maxValue Max value, inclusive.
  * @param numBuckets Number of buckets in the range between min and max values.
  * @returns The index of the nearest bucket that the value should be sorted into, from 0 to `numBuckets - 1`. Clamps the value
  * to the min/max values if it is outside the range.
+ *
+ * Note: Buckets at the endpoints of the value range are half-sized, as they are centered on `minValue` and `maxValue`
+ * and the values out of range are clipped. This matches color ramp gradient behavior.
+ * @example
+ * ```
+ * getBucketIndex(i, 0, 1, 2) = 0 for i < 0.5
+ * .                          = 1 for 0.5 <= i
+ *
+ * getBucketIndex(i, 0, 1, 3) = 0 for i < 0.25
+ * .                          = 1 for 0.25 <= i < 0.75
+ * .                          = 2 for 0.75 <= i
+ * ```
  */
 export function getBucketIndex(value: number, minValue: number, maxValue: number, numBuckets: number): number {
   return Math.round(remap(value, minValue, maxValue, 0, numBuckets - 1, true));

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -42,11 +42,12 @@ export function getBucketIndex(value: number, minValue: number, maxValue: number
 }
 
 /**
- * Splits a trace into one or more traces so that all traces have at most `maxPoints`
- * data points.
+ * Splits a trace into one or more smaller subtraces so that all the subtraces have at
+ * most `maxPoints` data points.
  * @param traceData The trace to split. (Will not be modified.)
- * @param maxPoints The maximum number of points any trace can have.
- * @returns An array of traces, with the same color as the original trace.
+ * @param maxPoints The maximum number of points any subtrace can have.
+ * @returns An array of subtraces, with the same color as the original trace. Each will have
+ * a (non-overlapping) subset of the original trace's data points.
  */
 export function splitTraceData(traceData: TraceData, maxPoints: number): TraceData[] {
   if (traceData.x.length <= maxPoints) {
@@ -67,12 +68,36 @@ export function splitTraceData(traceData: TraceData, maxPoints: number): TraceDa
   return traces;
 }
 
-/** Draws a simple line graph over the data points. */
+/**
+ * Returns true if a Plotly mouse event took place over a histogram subplot.
+ */
+export function isHistogramEvent(eventData: Plotly.PlotMouseEvent): boolean {
+  return eventData.points.length > 0 && eventData.points[0].data.type === "histogram";
+}
+
+/**
+ * Returns a hex color string with increasing transparency as the number of markers increases.
+ * Base color must be a 7-character RGB hex string (e.g. `#000000`).
+ */
+export function applyMarkerTransparency(numMarkers: number, baseColor: string): string {
+  if (baseColor.length !== 7) {
+    throw new Error("ScatterPlotTab.getMarkerColor: Base color '" + baseColor + "' must be 7-character hex string.");
+  }
+  // Interpolate linearly between 80% and 25% transparency from 0 up to a max of 1000 markers.
+  const opacity = remap(numMarkers, 0, 1000, 0.8, 0.25);
+  return (
+    baseColor +
+    Math.floor(opacity * 255)
+      .toString(16)
+      .padStart(2, "0")
+  );
+}
+
+/** Draws a simple line graph with the provided data points. */
 export function makeLineTrace(xData: DataArray, yData: DataArray): Partial<Plotly.PlotData> {
   return {
     x: xData,
     y: yData,
-    name: "",
     type: "scattergl",
     mode: "lines",
     line: {
@@ -99,7 +124,7 @@ export function drawCrosshair(x: number, y: number): Partial<PlotData>[] {
       symbol: "cross-thin",
     },
   };
-  // Add a transparent white outline around the marker for contrast.
+  // Add a transparent white outline behind the marker for contrast.
   const crosshairBg = { ...crosshair };
   crosshairBg.marker = {
     ...crosshairBg.marker,

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -14,9 +14,9 @@ export type TraceData = {
 };
 
 /**
- * Sample a color ramp at evenly-spaced points, returning an array of colors.
+ * Sample a color ramp at evenly-spaced points, returning the resulting array of colors.
  * @param {ColorRampData} colorRamp The gradient to sample.
- * @param {number} numColors The number of colors to sample.
+ * @param {number} numColors The number of colors to sample. Must be >= 2.
  * @returns {Color[]} An array of length `numColors` containing the sampled colors.
  */
 export function subsampleColorRamp(colorRamp: ColorRamp, numColors: number): Color[] {

--- a/src/components/tabs/scatter_plot_data_utils.ts
+++ b/src/components/tabs/scatter_plot_data_utils.ts
@@ -1,6 +1,9 @@
+import { PlotData } from "plotly.js-dist-min";
 import { ColorRampData } from "../../colorizer";
 import { remap } from "../../colorizer/utils/math_utils";
 import { Color } from "three";
+
+export type DataArray = Uint32Array | Float32Array | number[];
 
 export type TraceData = {
   x: number[];
@@ -58,4 +61,48 @@ export function splitTraceData(traceData: TraceData, maxPoints: number): TraceDa
     traces.push(trace);
   }
   return traces;
+}
+
+/** Draws a simple line graph over the data points. */
+export function makeLineTrace(xData: DataArray, yData: DataArray): Partial<Plotly.PlotData> {
+  return {
+    x: xData,
+    y: yData,
+    name: "",
+    type: "scattergl",
+    mode: "lines",
+    line: {
+      color: "#aaaaaa",
+    },
+  };
+}
+
+/**
+ * Returns an array of Plotly traces that render a crosshair at the X,Y coordinates.
+ */
+export function drawCrosshair(x: number, y: number): Partial<PlotData>[] {
+  const crosshair: Partial<PlotData> = {
+    x: [x],
+    y: [y],
+    type: "scattergl",
+    mode: "markers",
+    marker: {
+      size: 10,
+      line: {
+        color: "#000",
+        width: 1,
+      },
+      symbol: "cross-thin",
+    },
+  };
+  // Add a transparent white outline around the marker for contrast.
+  const crosshairBg = { ...crosshair };
+  crosshairBg.marker = {
+    ...crosshairBg.marker,
+    line: {
+      color: "#ffffffa0",
+      width: 4,
+    },
+  };
+  return [crosshairBg, crosshair];
 }

--- a/tests/math_utils.test.ts
+++ b/tests/math_utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { numberToSciNotation } from "../src/colorizer/utils/math_utils";
+import { numberToSciNotation, remap } from "../src/colorizer/utils/math_utils";
 
 describe("numberToSciNotation", () => {
   it("Handles zero", () => {
@@ -41,5 +41,43 @@ describe("numberToSciNotation", () => {
     expect(numberToSciNotation(0.999, 2)).to.equal("1.0×10⁰");
     expect(numberToSciNotation(-0.05, 1)).to.equal("-5×10⁻²");
     expect(numberToSciNotation(1400, 3)).to.equal("1.40×10³");
+  });
+});
+
+describe("remap", () => {
+  it("Remaps values from one range to another", () => {
+    expect(remap(5, 0, 10, 0, 1)).to.equal(0.5);
+    expect(remap(0.5, 0, 1, 0, 10)).to.equal(5);
+  });
+
+  it("Can flip input range to match output", () => {
+    expect(remap(7, 0, 10, 10, 0)).to.equal(3);
+    expect(remap(-15, -30, 0, 0, 30)).to.equal(15);
+  });
+
+  it("Does nothing if the input and output ranges are the same", () => {
+    expect(remap(0, 0, 1, 0, 1)).to.equal(0);
+    expect(remap(0.125, -5, 5, -5, 5)).to.equal(0.125);
+  });
+
+  it("Handles zero-range inputs", () => {
+    expect(remap(0, 0.5, 0.5, 0, 1)).to.equal(0);
+    expect(remap(0.5, 0.5, 0.5, 0, 1)).to.equal(0);
+    expect(remap(1, 0.5, 0.5, 0, 1)).to.equal(0);
+  });
+
+  it("Handles zero-range outputs", () => {
+    expect(remap(0, 0, 1, 10, 10)).to.equal(10);
+    expect(remap(-1, 0, 1, 10, 10)).to.equal(10);
+  });
+
+  it("Enforces range clamping", () => {
+    expect(remap(-1000, 0, 1, -1, 1)).to.equal(-1);
+    expect(remap(1000, 0, 1, -1, 1)).to.equal(1);
+  });
+
+  it("Handles values outside of input min/max", () => {
+    expect(remap(-1, 0, 1, 0, 10, false)).to.equal(-10);
+    expect(remap(2, 0, 1, 0, 10, false)).to.equal(20);
   });
 });

--- a/tests/math_utils.test.ts
+++ b/tests/math_utils.test.ts
@@ -50,9 +50,12 @@ describe("remap", () => {
     expect(remap(0.5, 0, 1, 0, 10)).to.equal(5);
   });
 
-  it("Can flip input range to match output", () => {
+  it("Handles flipped input/output ranges", () => {
     expect(remap(7, 0, 10, 10, 0)).to.equal(3);
+    expect(remap(3, 10, 0, 0, 10)).to.equal(7);
+
     expect(remap(-15, -30, 0, 0, 30)).to.equal(15);
+    expect(remap(15, 0, 30, -30, 0)).to.equal(-15);
   });
 
   it("Does nothing if the input and output ranges are the same", () => {
@@ -60,13 +63,13 @@ describe("remap", () => {
     expect(remap(0.125, -5, 5, -5, 5)).to.equal(0.125);
   });
 
-  it("Handles zero-range inputs", () => {
+  it("Handles input bounds with a range of zero", () => {
     expect(remap(0, 0.5, 0.5, 0, 1)).to.equal(0);
     expect(remap(0.5, 0.5, 0.5, 0, 1)).to.equal(0);
     expect(remap(1, 0.5, 0.5, 0, 1)).to.equal(0);
   });
 
-  it("Handles zero-range outputs", () => {
+  it("Handles output bounds with a range of zero", () => {
     expect(remap(0, 0, 1, 10, 10)).to.equal(10);
     expect(remap(-1, 0, 1, 10, 10)).to.equal(10);
   });
@@ -76,7 +79,7 @@ describe("remap", () => {
     expect(remap(1000, 0, 1, -1, 1)).to.equal(1);
   });
 
-  it("Handles values outside of input min/max", () => {
+  it("Handles values outside of input min/max when clamping is disabled", () => {
     expect(remap(-1, 0, 1, 0, 10, false)).to.equal(-10);
     expect(remap(2, 0, 1, 0, 10, false)).to.equal(20);
   });

--- a/tests/scatter_plot_data_utils.test.ts
+++ b/tests/scatter_plot_data_utils.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { ColorRamp } from "../src/colorizer";
+import { Color } from "three";
+import {
+  TraceData,
+  getBucketIndex,
+  splitTraceData,
+  subsampleColorRamp,
+} from "../src/components/tabs/scatter_plot_data_utils";
+
+describe("subsampleColorRamp", () => {
+  it("Returns endpoints of a color ramp", () => {
+    const ramp = new ColorRamp(["#ff0000", "#0000ff"]);
+    const colors = subsampleColorRamp(ramp, 2);
+    expect(colors).to.deep.equal([new Color("#ff0000"), new Color("#0000ff")]);
+  });
+
+  it("Returns evenly spaced colors", () => {
+    const ramp = new ColorRamp(["#a0a0a0", "#000000"]);
+    const expectedColors = [
+      new Color("#a0a0a0"),
+      new Color("#808080"),
+      new Color("#606060"),
+      new Color("#404040"),
+      new Color("#202020"),
+      new Color("#000000"),
+    ];
+    const colors = subsampleColorRamp(ramp, 6);
+    expect(colors).to.deep.equal(expectedColors);
+  });
+});
+
+describe("getBucketIndex", () => {
+  const bucketSorterFactory = (minValue: number, maxValue: number, numBuckets: number) => {
+    return (value: number) => getBucketIndex(value, minValue, maxValue, numBuckets);
+  };
+
+  it("Sorts values into buckets correctly", () => {
+    // Each integer value maps to its same bucket
+    const sorter = bucketSorterFactory(0, 9, 10);
+    for (let i = 0; i < 10; i++) {
+      expect(sorter(i)).to.equal(i);
+      // Check that values between integers are also sorted correctly
+      expect(sorter(i - 0.1)).to.equal(i);
+      expect(sorter(i + 0.1)).to.equal(i);
+    }
+  });
+
+  it("Clamps values outside of range", () => {
+    const sorter = bucketSorterFactory(0, 9, 10);
+    expect(sorter(-1)).to.equal(0);
+    expect(sorter(-100)).to.equal(0);
+    expect(sorter(Number.NEGATIVE_INFINITY)).to.equal(0);
+    expect(sorter(10)).to.equal(9);
+    expect(sorter(100)).to.equal(9);
+    expect(sorter(Number.POSITIVE_INFINITY)).to.equal(9);
+  });
+
+  it("Uses rounding to determine bucket index", () => {
+    const sorter = bucketSorterFactory(0, 1, 2);
+    expect(sorter(0.499999)).to.equal(0);
+    expect(sorter(0.5)).to.equal(1);
+  });
+
+  it("Handles a single bucket", () => {
+    const sorter = bucketSorterFactory(0, 0, 1);
+    expect(sorter(0)).to.equal(0);
+    expect(sorter(-10000)).to.equal(0);
+    expect(sorter(10000)).to.equal(0);
+  });
+});
+
+describe("splitTraceData", () => {
+  const makeTraceData = (numPoints: number): TraceData => {
+    const traceData: TraceData = {
+      x: [],
+      y: [],
+      objectIds: [],
+      trackIds: [],
+      color: new Color("#ff00ff"),
+    };
+    for (let i = 0; i < numPoints; i++) {
+      traceData.x.push(i);
+      traceData.y.push(i);
+      traceData.objectIds.push(i);
+      traceData.trackIds.push(i);
+    }
+    return traceData;
+  };
+
+  it("Handles zero data", () => {
+    const traceData = makeTraceData(0);
+    expect(splitTraceData(traceData, 10)).to.deep.equal([traceData]);
+  });
+
+  it("Does not split data at or under maxPoints", () => {
+    const traceData1 = makeTraceData(100);
+    const traceData2 = makeTraceData(50);
+    expect(splitTraceData(traceData1, 100)).to.deep.equal([traceData1]);
+    expect(splitTraceData(traceData2, 100)).to.deep.equal([traceData2]);
+  });
+
+  it("Can split large trace data into multiple traces", () => {
+    const traceData = makeTraceData(1000);
+    const traces = splitTraceData(traceData, 100);
+
+    expect(traces.length).to.equal(10);
+
+    for (let i = 0; i < 10; i++) {
+      const trace = traces[i];
+      for (let j = 0; j < 100; j++) {
+        const originalIndex = i * 100 + j;
+        expect(trace.x[j]).to.equal(traceData.x[originalIndex]);
+        expect(trace.y[j]).to.equal(traceData.y[originalIndex]);
+        expect(trace.objectIds[j]).to.equal(traceData.objectIds[originalIndex]);
+        expect(trace.trackIds[j]).to.equal(traceData.trackIds[originalIndex]);
+      }
+    }
+  });
+});

--- a/tests/scatter_plot_data_utils.test.ts
+++ b/tests/scatter_plot_data_utils.test.ts
@@ -56,10 +56,33 @@ describe("getBucketIndex", () => {
     expect(sorter(Number.POSITIVE_INFINITY)).to.equal(9);
   });
 
-  it("Uses rounding to determine bucket index", () => {
-    const sorter = bucketSorterFactory(0, 1, 2);
+  it("Uses evenly-spaced buckets to determine bucket index", () => {
+    // See note on getBucketIndex for expected behavior.
+    // Buckets at the endpoints of the value range are half-sized.
+    let sorter = bucketSorterFactory(0, 1, 2);
     expect(sorter(0.499999)).to.equal(0);
     expect(sorter(0.5)).to.equal(1);
+
+    sorter = bucketSorterFactory(0, 1, 3);
+    expect(sorter(0.249999)).to.equal(0);
+    expect(sorter(0.25)).to.equal(1);
+    expect(sorter(0.749999)).to.equal(1);
+    expect(sorter(0.75)).to.equal(2);
+    expect(sorter(1)).to.equal(2);
+
+    sorter = bucketSorterFactory(0, 1, 6);
+    expect(sorter(0)).to.equal(0);
+    expect(sorter(0.099999)).to.equal(0);
+    expect(sorter(0.1)).to.equal(1);
+    expect(sorter(0.2999)).to.equal(1);
+    expect(sorter(0.3)).to.equal(2);
+    expect(sorter(0.4999)).to.equal(2);
+    expect(sorter(0.5)).to.equal(3);
+    expect(sorter(0.6999)).to.equal(3);
+    expect(sorter(0.7)).to.equal(4);
+    expect(sorter(0.8999)).to.equal(4);
+    expect(sorter(0.9)).to.equal(5);
+    expect(sorter(1.0)).to.equal(5);
   });
 
   it("Handles a single bucket", () => {


### PR DESCRIPTION
Problem
=======
Closes #189, adding the color ramp coloring to the scatter plot view!

Solution
========
Plotly's existing color ramp rendering is very, very slow. To work around it, we split the color ramp gradient into many smaller colors, then take our data and sort them into many different buckets corresponding to each color. Each of these buckets can then be rendered with a single color marker, which Plotly is able to handle much faster.

This PR adds the new method `colorizeScatterPlotPoints` in `ScatterPlotTab`, which does the following steps:
1. It subsamples the current color ramp (or uses the current categorical palette).
1. It uses the feature data to sort each object into a bucket with its matching color.
1. It splits large buckets into smaller buckets (enforcing a max point size of 1024). 
1. Transforms the buckets into individual traces (think groups of data + formatting) that can be rendered by Plotly.

These changes led to a BIG performance increase on top of the existing coloring! I suspect that Plotly dislikes huge data arrays, and splitting up the changes allowed it to run much faster.

New helper methods have been added to `scatter_plot_data_utils.ts`, and I've included unit tests for the new functionality.

## Type of change
* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Adds color ramp + palette coloring to the `ScatterPlotTab`.
* Refactors how traces are handled by `ScatterPlotTab`.
* Adds helper methods for Plotly data and associated unit tests.

Steps to Verify:
----------------
Experiment with these two preview links: 
  - https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-194/
  -  https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-194/?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2F3500005828_25%2Fmanifest.json

Screenshots (optional):
-----------------------

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/56e5488f-6449-4b5f-ac41-fe99557dddda

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/1b0e4ab3-b689-4d40-914b-023d2827065a)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/7f85d349-bee6-4588-b345-e02ed7b48b7d)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/11cb7cc6-28bc-418b-b2af-889543876e61)

Suggested review order:
-----------------------
1. `scatter_plot_data_utils.ts`
3. `ScatterPlotTab`

