### PR TITLE
fix: Fixed bad aspect ratio when loading datasets

### DIFF
--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -373,7 +373,7 @@ export default class Dataset {
       this.loadFrame(0), // load first frame to set frame dimensions
       ...featuresPromises,
     ]);
-    const [outliers, tracks, times, centroids, bounds, _loadFrame, ...featureResults] = result;
+    const [outliers, tracks, times, centroids, bounds, , ...featureResults] = result;
 
     this.outliers = outliers;
     this.trackIds = tracks;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -370,10 +370,11 @@ export default class Dataset {
       this.loadToBuffer(FeatureDataType.U32, this.timesFile),
       this.loadToBuffer(FeatureDataType.U16, this.centroidsFile),
       this.loadToBuffer(FeatureDataType.U16, this.boundsFile),
-      this.loadFrame(0), // load first frame to set frame dimensions
+      this.loadFrame(0), // load first frame to set frame dimensions. Load result will be discarded
       ...featuresPromises,
     ]);
-    const [outliers, tracks, times, centroids, bounds, , ...featureResults] = result;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [outliers, tracks, times, centroids, bounds, _loaded_frame, ...featureResults] = result;
 
     this.outliers = outliers;
     this.trackIds = tracks;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -370,9 +370,10 @@ export default class Dataset {
       this.loadToBuffer(FeatureDataType.U32, this.timesFile),
       this.loadToBuffer(FeatureDataType.U16, this.centroidsFile),
       this.loadToBuffer(FeatureDataType.U16, this.boundsFile),
+      this.loadFrame(0), // load first frame to set frame dimensions
       ...featuresPromises,
     ]);
-    const [outliers, tracks, times, centroids, bounds, ...featureResults] = result;
+    const [outliers, tracks, times, centroids, bounds, _loadFrame, ...featureResults] = result;
 
     this.outliers = outliers;
     this.trackIds = tracks;

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -1,6 +1,6 @@
-import { Texture } from "three";
+import { DataTexture, RGBAFormat, Texture, UnsignedByteType, Vector2 } from "three";
 import { describe, expect, it } from "vitest";
-import { ArraySource, IArrayLoader } from "../src/colorizer";
+import { ArraySource, IArrayLoader, IFrameLoader } from "../src/colorizer";
 import Dataset, { FeatureType } from "../src/colorizer/Dataset";
 import { FeatureArrayType, FeatureDataType, featureTypeSpecs } from "../src/colorizer/types";
 import { ANY_ERROR } from "./test_utils";
@@ -18,6 +18,28 @@ describe("Dataset", () => {
       return Promise.resolve(manifestJson);
     };
   };
+
+  class MockFrameLoader implements IFrameLoader {
+    width: number;
+    height: number;
+
+    constructor(width: number = 1, height: number = 1) {
+      this.width = width;
+      this.height = height;
+    }
+
+    load(_url: string): Promise<Texture> {
+      return Promise.resolve(
+        new DataTexture(
+          new Uint8Array(this.width * this.height * 4),
+          this.width,
+          this.height,
+          RGBAFormat,
+          UnsignedByteType
+        )
+      );
+    }
+  }
 
   class MockArraySource implements ArraySource {
     getBuffer<T extends FeatureDataType>(type: T): FeatureArrayType[T] {
@@ -79,7 +101,7 @@ describe("Dataset", () => {
   for (const [name, manifest] of manifestsToTest) {
     describe(name, () => {
       it("retrieves feature units", async () => {
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
         await dataset.open(mockFetch);
 
@@ -91,7 +113,7 @@ describe("Dataset", () => {
       });
 
       it("retrieves feature types", async () => {
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
         await dataset.open(mockFetch);
 
@@ -101,7 +123,7 @@ describe("Dataset", () => {
       });
 
       it("defaults type to continuous if no type or bad type provided", async () => {
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
         await dataset.open(mockFetch);
 
@@ -110,7 +132,7 @@ describe("Dataset", () => {
       });
 
       it("gets whether features are categorical", async () => {
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
         await dataset.open(mockFetch);
 
@@ -122,7 +144,7 @@ describe("Dataset", () => {
       });
 
       it("gets feature categories", async () => {
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
         await dataset.open(mockFetch);
 
@@ -143,7 +165,7 @@ describe("Dataset", () => {
             feature1: { type: "categorical" },
           },
         };
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, badManifest);
         await expect(dataset.open(mockFetch)).rejects.toThrowError(ANY_ERROR);
       });
@@ -162,9 +184,28 @@ describe("Dataset", () => {
             },
           },
         };
-        const dataset = new Dataset(defaultPath, undefined, new MockArrayLoader());
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, badManifest);
         await expect(dataset.open(mockFetch)).rejects.toThrowError(ANY_ERROR);
+      });
+
+      it("Loads the first frame and retrieves frame dimensions on open", async () => {
+        const mockFetch = makeMockFetchMethod(defaultPath, manifest);
+        const dimensionTests = [
+          [1, 1],
+          [2, 3],
+          [1, 3],
+          [3, 1],
+          [3, 2],
+          [1000, 1000],
+        ];
+
+        for (const [width, height] of dimensionTests) {
+          const dataset = new Dataset(defaultPath, new MockFrameLoader(width, height), new MockArrayLoader());
+          expect(dataset.frameResolution).to.deep.equal(new Vector2(1, 1));
+          await dataset.open(mockFetch);
+          expect(dataset.frameResolution).to.deep.equal(new Vector2(width, height));
+        }
       });
     });
   }

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -192,6 +192,7 @@ describe("Dataset", () => {
       it("Loads the first frame and retrieves frame dimensions on open", async () => {
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
         const dimensionTests = [
+          [0, 0],
           [1, 1],
           [2, 3],
           [1, 3],


### PR DESCRIPTION
Problem
=======
Closes #186, fixing a bug where aspect ratios would occasionally appear squashed when loading a dataset.

Solution
========
It turns out the bug was caused when the viewer was at a timestep that didn't exist in the loaded dataset. This caused the viewer to skip loading that frame. There's a frame dimension variable saved inside of the Dataset that is only updated when frames are loaded, so it would be `null` and would use an (incorrect) fallback instead.

To fix it, I forced the first frame in the dataset to load when the Dataset is open, guaranteeing that the frame dimensions will be set correctly before its data can be accessed.

(I also added unit tests to validate the new fix and test it with a few different resolutions.)


## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Repro steps:
1. Open the main viewer build here: https://allen-cell-animated.github.io/nucmorph-colorizer/main/
2. Slide the time slider all the way to the right.
3. Open the load dialog and paste in this dataset: https://raw.githubusercontent.com/allen-cell-animated/nucmorph-colorizer/main/documentation/example_dataset/manifest.json
4. The boxes should appear squished instead of square.

To test the fix:
1. Repeat all the above steps on the preview build: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-196/
1. The boxes should appear square.


