### PR TITLE
fix: Fixed bug where changing a threshold would reset the color map range

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,14 +93,16 @@ function App(): ReactElement {
         const oldThreshold = featureThresholds.find(thresholdMatchFinder(featureName, featureData.units));
         const newThreshold = newThresholds.find(thresholdMatchFinder(featureName, featureData.units));
 
-        if (newThreshold && oldThreshold && isThresholdNumeric(newThreshold)) {
-          setColorRampMin(newThreshold.min);
-          setColorRampMax(newThreshold.max);
+        if (newThreshold && oldThreshold && isThresholdNumeric(newThreshold) && isThresholdNumeric(oldThreshold)) {
+          if (newThreshold.min !== oldThreshold.min || newThreshold.max !== oldThreshold.max) {
+            setColorRampMin(newThreshold.min);
+            setColorRampMax(newThreshold.max);
+          }
         }
       }
       _setFeatureThresholds(newThresholds);
     },
-    [featureThresholds, featureName]
+    [featureName, dataset, featureThresholds]
   );
 
   const [playbackFps, setPlaybackFps] = useState(DEFAULT_PLAYBACK_FPS);

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -210,11 +210,10 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   };
 
   const onCategoricalThresholdChanged = (index: number, enabled_categories: boolean[]): void => {
+    const newThreshold = { ...props.featureThresholds[index], enabled_categories };
     const newThresholds = [...props.featureThresholds];
-    const threshold = newThresholds[index];
-    if (isThresholdCategorical(threshold)) {
-      threshold.enabledCategories = enabled_categories;
-    }
+    newThresholds[index] = newThreshold;
+
     props.onChange(newThresholds);
   };
 
@@ -225,11 +224,9 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
       newThreshold.min = min;
       newThreshold.max = max;
     }
-    const newThresholds = [
-      ...props.featureThresholds.slice(0, index),
-      newThreshold,
-      ...props.featureThresholds.slice(index + 1),
-    ];
+    const newThresholds = [...props.featureThresholds];
+    newThresholds[index] = newThreshold;
+
     props.onChange(newThresholds);
   };
 

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -219,12 +219,17 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   };
 
   const onNumericThresholdChanged = (index: number, min: number, max: number): void => {
-    const newThresholds = [...props.featureThresholds];
-    const threshold = newThresholds[index];
-    if (isThresholdNumeric(threshold)) {
-      threshold.min = min;
-      threshold.max = max;
+    // Make a copy of the threshold and the threshold array to avoid mutating state directly.
+    const newThreshold = { ...props.featureThresholds[index] };
+    if (isThresholdNumeric(newThreshold)) {
+      newThreshold.min = min;
+      newThreshold.max = max;
     }
+    const newThresholds = [
+      ...props.featureThresholds.slice(0, index),
+      newThreshold,
+      ...props.featureThresholds.slice(index + 1),
+    ];
     props.onChange(newThresholds);
   };
 


### PR DESCRIPTION
Problem
=======
Fixes a bug I found when testing the colorizer for the demo! Normally, changing the threshold for the currently selected feature will also change the color map min and max bounds. This should only happen when changing the currently selected feature's threshold, but I found that adding or removing other thresholds would also cause it to reset.

This was caused by a missing check, which was also failing because the updated threshold state was being directly mutated (rather than making a copy).

Solution
========
- Adds a check for changes to the currently selected feature threshold before resetting the min and max color map bounds.
- Edits `FeatureThresholdTab` to make copies of the array and modified thresholds before passing them to change callbacks.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-199/
1. Set a custom range on the color ramp slider.
1. Switch to the filters tab.
1. Add both features as filters (volume and height). The color ramp range slider should remain unchanged.
1. Change the currently selected feature's filter (volume). The color ramp range slider should jump to match the new range.

