### PR TITLE
fix: Fixed categorical thresholds not changing on click

### DIFF
--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -213,7 +213,6 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     const newThreshold = { ...props.featureThresholds[index], enabledCategories };
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = newThreshold;
-    console.log(newThreshold);
     props.onChange(newThresholds);
   };
 

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -209,11 +209,11 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     props.onChange(newThresholds);
   };
 
-  const onCategoricalThresholdChanged = (index: number, enabled_categories: boolean[]): void => {
-    const newThreshold = { ...props.featureThresholds[index], enabled_categories };
+  const onCategoricalThresholdChanged = (index: number, enabledCategories: boolean[]): void => {
+    const newThreshold = { ...props.featureThresholds[index], enabledCategories };
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = newThreshold;
-
+    console.log(newThreshold);
     props.onChange(newThresholds);
   };
 

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -214,7 +214,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
     if (!isThresholdCategorical(oldThreshold)) {
       return;
     }
-    const newThreshold: FeatureThreshold = { ...oldThreshold, enabledCategories };
+    const newThreshold: CategoricalFeatureThreshold = { ...oldThreshold, enabledCategories };
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = newThreshold;
     props.onChange(newThresholds);
@@ -226,7 +226,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
       return;
     }
     // Make a copy of the threshold and the threshold array to avoid mutating state directly.
-    const newThreshold: FeatureThreshold = { ...oldThreshold };
+    const newThreshold: NumericFeatureThreshold = { ...oldThreshold };
 
     newThreshold.min = min;
     newThreshold.max = max;

--- a/src/components/tabs/FeatureThresholdsTab.tsx
+++ b/src/components/tabs/FeatureThresholdsTab.tsx
@@ -210,19 +210,27 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
   };
 
   const onCategoricalThresholdChanged = (index: number, enabledCategories: boolean[]): void => {
-    const newThreshold = { ...props.featureThresholds[index], enabledCategories };
+    const oldThreshold = props.featureThresholds[index];
+    if (!isThresholdCategorical(oldThreshold)) {
+      return;
+    }
+    const newThreshold: FeatureThreshold = { ...oldThreshold, enabledCategories };
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = newThreshold;
     props.onChange(newThresholds);
   };
 
   const onNumericThresholdChanged = (index: number, min: number, max: number): void => {
-    // Make a copy of the threshold and the threshold array to avoid mutating state directly.
-    const newThreshold = { ...props.featureThresholds[index] };
-    if (isThresholdNumeric(newThreshold)) {
-      newThreshold.min = min;
-      newThreshold.max = max;
+    const oldThreshold = props.featureThresholds[index];
+    if (!isThresholdNumeric(oldThreshold)) {
+      return;
     }
+    // Make a copy of the threshold and the threshold array to avoid mutating state directly.
+    const newThreshold: FeatureThreshold = { ...oldThreshold };
+
+    newThreshold.min = min;
+    newThreshold.max = max;
+
     const newThresholds = [...props.featureThresholds];
     newThresholds[index] = newThreshold;
 


### PR DESCRIPTION
Fixes a bug where filters for categorical features would not change when clicked (caused by a variable accidentally named with snake_case instead of camelCase.)

Testing: Switch to the filters view and try enabling/disabling the categories.
- Broken build: https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2F3500005828_25%2Fmanifest.json&feature=Cell%20type&filters=Cell%2520type%3A%3Afff&color=matplotlib-cool
- Fixed build: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-201/?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2F3500005828_25%2Fmanifest.json&feature=Cell%20type&filters=Cell%2520type%3A%3Afff&color=matplotlib-cool