### PR TITLE
fix: Incorrect range when loading non-default feature from URL without range parameter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,14 +264,14 @@ function App(): ReactElement {
   );
 
   /**
-   * Updates the color ramp to default min and max values based on a feature and dataset.
-   *
-   * Does nothing if the viewer is configured to keep the range between datasets.
+   * Resets the color ramp to a default min and max value based on the feature and dataset.
    *
    * If the feature is thresholded, the color ramp will be set to the threshold's min and max.
    * Otherwise, the color ramp will be set to the feature's min and max.
+   *
+   * (Does nothing if the viewer is configured to keep the range between datasets.)
    */
-  const resetColorRampToDefaults = useCallback(
+  const resetColorRampRangeToDefaults = useCallback(
     (featureDataset: Dataset, featureName: string): void => {
       const featureData = featureDataset.getFeatureData(featureName);
       if (!config.keepRangeBetweenDatasets && featureData) {
@@ -379,7 +379,7 @@ function App(): ReactElement {
         setColorRampMax(initialUrlParams.range[1]);
       } else {
         // Load default range from dataset for the current feature
-        dataset && resetColorRampToDefaults(dataset, newFeatureName);
+        dataset && resetColorRampRangeToDefaults(dataset, newFeatureName);
       }
 
       if (initialUrlParams.track && initialUrlParams.track >= 0) {
@@ -429,7 +429,7 @@ function App(): ReactElement {
         newFeatureName = newDataset.featureNames[0];
       }
       replaceFeature(newDataset, newFeatureName);
-      resetColorRampToDefaults(newDataset, newFeatureName);
+      resetColorRampRangeToDefaults(newDataset, newFeatureName);
       setFeatureName(newFeatureName);
 
       await canv.setDataset(newDataset);
@@ -453,7 +453,7 @@ function App(): ReactElement {
       currentFrame,
       getUrlParams,
       replaceFeature,
-      resetColorRampToDefaults,
+      resetColorRampRangeToDefaults,
       featureThresholds,
     ]
   );
@@ -668,7 +668,7 @@ function App(): ReactElement {
             onChange={(value) => {
               if (value !== featureName && dataset) {
                 replaceFeature(dataset, value);
-                resetColorRampToDefaults(dataset, value);
+                resetColorRampRangeToDefaults(dataset, value);
               }
             }}
           />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,9 +322,10 @@ function App(): ReactElement {
           setFeatureThresholds(initialUrlParams.thresholds);
         }
       }
+      let newFeatureName = featureName;
       if (initialUrlParams.feature && dataset) {
         // Load feature (if unset, do nothing because replaceDataset already loads a default)
-        await updateFeature(dataset, initialUrlParams.feature);
+        newFeatureName = await updateFeature(dataset, initialUrlParams.feature);
       }
       // Range, track, and time setting must be done after the dataset and feature is set.
       if (initialUrlParams.range) {
@@ -332,8 +333,8 @@ function App(): ReactElement {
         setColorRampMax(initialUrlParams.range[1]);
       } else {
         // Load default range from dataset for the current feature
-        setColorRampMin(dataset?.getFeatureData(featureName)?.min || 0);
-        setColorRampMax(dataset?.getFeatureData(featureName)?.max || 0);
+        setColorRampMin(dataset?.getFeatureData(newFeatureName)?.min || 0);
+        setColorRampMax(dataset?.getFeatureData(newFeatureName)?.max || 0);
       }
 
       if (initialUrlParams.track && initialUrlParams.track >= 0) {
@@ -459,10 +460,10 @@ function App(): ReactElement {
   );
 
   const updateFeature = useCallback(
-    async (newDataset: Dataset, newFeatureName: string): Promise<void> => {
+    async (newDataset: Dataset, newFeatureName: string): Promise<string> => {
       if (!newDataset?.hasFeature(newFeatureName)) {
         console.warn("Dataset does not have feature '" + newFeatureName + "'.");
-        return;
+        return featureName;
       }
       setFeatureName(newFeatureName);
 
@@ -480,6 +481,7 @@ function App(): ReactElement {
       }
 
       canv.setFeature(newFeatureName);
+      return newFeatureName;
     },
     [config.keepRangeBetweenDatasets, colorRampMin, colorRampMax, canv, selectedTrack, currentFrame]
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -260,7 +260,7 @@ function App(): ReactElement {
       canv.setFeature(newFeatureName);
       return newFeatureName;
     },
-    [canv]
+    [canv, featureName]
   );
 
   /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -325,7 +325,7 @@ function App(): ReactElement {
       let newFeatureName = featureName;
       if (initialUrlParams.feature && dataset) {
         // Load feature (if unset, do nothing because replaceDataset already loads a default)
-        newFeatureName = await updateFeature(dataset, initialUrlParams.feature);
+        newFeatureName = updateFeature(dataset, initialUrlParams.feature);
       }
       // Range, track, and time setting must be done after the dataset and feature is set.
       if (initialUrlParams.range) {
@@ -459,8 +459,13 @@ function App(): ReactElement {
     [replaceDataset]
   );
 
+  /** Attempts to update the current feature. Also updates the color ramp min/max if the feature has changed.
+   * @param newDataset the dataset to pull feature data from.
+   * @param newFeatureName the name of the new feature to select.
+   * @returns the new feature name if it was successfully found and loaded. Otherwise, returns the old feature name.
+   */
   const updateFeature = useCallback(
-    async (newDataset: Dataset, newFeatureName: string): Promise<string> => {
+    (newDataset: Dataset, newFeatureName: string): string => {
       if (!newDataset?.hasFeature(newFeatureName)) {
         console.warn("Dataset does not have feature '" + newFeatureName + "'.");
         return featureName;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -325,7 +325,7 @@ function App(): ReactElement {
       let newFeatureName = featureName;
       if (initialUrlParams.feature && dataset) {
         // Load feature (if unset, do nothing because replaceDataset already loads a default)
-        newFeatureName = updateFeature(dataset, initialUrlParams.feature);
+        newFeatureName = replaceFeatureAndUpdateColorRamp(dataset, initialUrlParams.feature);
       }
       // Range, track, and time setting must be done after the dataset and feature is set.
       if (initialUrlParams.range) {
@@ -383,7 +383,7 @@ function App(): ReactElement {
       if (!newDataset.hasFeature(newFeatureName)) {
         newFeatureName = newDataset.featureNames[0];
       }
-      updateFeature(newDataset, newFeatureName);
+      replaceFeatureAndUpdateColorRamp(newDataset, newFeatureName);
       setFeatureName(newFeatureName);
 
       await canv.setDataset(newDataset);
@@ -459,12 +459,14 @@ function App(): ReactElement {
     [replaceDataset]
   );
 
-  /** Attempts to update the current feature. Also updates the color ramp min/max if the feature has changed.
+  /**
+   * Attempts to replace the current feature with a new feature from a dataset, optionally updating
+   * the color ramp bounds. If the feature cannot be loaded, returns the old feature name and does nothing.
    * @param newDataset the dataset to pull feature data from.
    * @param newFeatureName the name of the new feature to select.
    * @returns the new feature name if it was successfully found and loaded. Otherwise, returns the old feature name.
    */
-  const updateFeature = useCallback(
+  const replaceFeatureAndUpdateColorRamp = useCallback(
     (newDataset: Dataset, newFeatureName: string): string => {
       if (!newDataset?.hasFeature(newFeatureName)) {
         console.warn("Dataset does not have feature '" + newFeatureName + "'.");
@@ -644,7 +646,7 @@ function App(): ReactElement {
             items={getFeatureDropdownData()}
             onChange={(value) => {
               if (value !== featureName && dataset) {
-                updateFeature(dataset, value);
+                replaceFeatureAndUpdateColorRamp(dataset, value);
               }
             }}
           />


### PR DESCRIPTION
Fixed a bug where loading any feature besides the first (default) feature in a dataset via the URL would cause it to use the default feature's color map range instead. This caused odd, unexpected coloring on initial load.

Also fixes #197!

This fixes the bug by using a local variable (`newFeatureName`) to get the feature's color ramp range, rather than the `featureName` state (which may not be updated).

To test:
- Broken build (should appear in bright cyan): https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Mama%20Bear&feature=Height&color=matplotlib-cool
- Fixed build: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-202/?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Mama%20Bear&feature=Height&color=matplotlib-cool