### PR TITLE
fix: Fixed bug where tracks with one time could not be selected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -239,7 +239,7 @@ function App(): ReactElement {
 
       const newTrack = dataset!.buildTrack(trackId);
 
-      if (newTrack.length() < 1) {
+      if (newTrack.ids.length < 1) {
         // Check track validity
         return;
       }


### PR DESCRIPTION
Fixes #188.

`Track.length()` returns 0 for tracks with only a single timepoint, so I substituted a check for the number of object IDs instead.