### PR TITLE
fix: Fixes track path desync for tracks that skipped times

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -387,12 +387,24 @@ export default class ColorizeCanvas {
     }
     // Make a new array of the centroid positions in pixel coordinates.
     // Points are in 3D while centroids are pairs of 2D coordinates in a 1D array
-    this.points = new Float32Array(track.length() * 3);
+    this.points = new Float32Array(track.duration() * 3);
 
-    for (let i = 0; i < track.length(); i++) {
+    // Tracks may be missing objects for some timepoints, so use the last known good value as a fallback
+    let lastTrackIndex = 0;
+    for (let i = 0; i < track.duration(); i++) {
+      const absTime = i + track.startTime();
+
+      let trackIndex = track.times.findIndex((t) => t === absTime);
+      if (trackIndex === -1) {
+        // Track has no object for this time, use fallback
+        trackIndex = lastTrackIndex;
+      } else {
+        lastTrackIndex = trackIndex;
+      }
+
       // Normalize from pixel coordinates to canvas space [-1, 1]
-      this.points[3 * i + 0] = (track.centroids[2 * i] / this.dataset.frameResolution.x) * 2.0 - 1.0;
-      this.points[3 * i + 1] = -((track.centroids[2 * i + 1] / this.dataset.frameResolution.y) * 2.0 - 1.0);
+      this.points[3 * i + 0] = (track.centroids[2 * trackIndex] / this.dataset.frameResolution.x) * 2.0 - 1.0;
+      this.points[3 * i + 1] = -((track.centroids[2 * trackIndex + 1] / this.dataset.frameResolution.y) * 2.0 - 1.0);
       this.points[3 * i + 2] = 0;
     }
     // Assign new BufferAttribute because the old array has been discarded.
@@ -417,10 +429,9 @@ export default class ColorizeCanvas {
     }
 
     // Show path up to current frame
-    const trackFirstFrame = this.track.times[0];
-    let range = this.currentFrame - trackFirstFrame;
+    let range = this.currentFrame - this.track.startTime() + 1;
 
-    if (range > this.track.length() || range < 0) {
+    if (range > this.track.duration() || range < 0) {
       // Hide track if we are outside the track range
       range = 0;
     }

--- a/src/colorizer/Track.ts
+++ b/src/colorizer/Track.ts
@@ -25,7 +25,7 @@ export default class Track {
       }, [] as number[]);
     }
     console.log(
-      `Track ${trackId} has ${this.length()} timepoints starting from ${this.times[0]} to ${
+      `Track ${trackId} has ${this.duration()} timepoints starting from ${this.times[0]} to ${
         this.times[this.times.length - 1]
       }`
     );
@@ -41,10 +41,18 @@ export default class Track {
     return this.ids[index];
   }
 
-  length(): number {
-    // tracks may have gaps (missing or elided data) in their list of times.
-    // So since the times are pre-sorted above, the length of the track is the difference between the last time and the first time.
-    // note that a track with only one time in it will report length 0
-    return this.times[this.times.length - 1] - this.times[0];
+  /**
+   * Gets the duration, in frames, that the track exists for. Note that the track
+   * may not have objects for all frames in the duration.
+   *
+   * - A track with only 1 id has a duration of 1.
+   * - A track that exists from frame 1 to frame 10 has a duration of 10.
+   */
+  duration(): number {
+    return this.times[this.times.length - 1] - this.times[0] + 1;
+  }
+
+  startTime(): number {
+    return this.times[0];
   }
 }

--- a/src/colorizer/Track.ts
+++ b/src/colorizer/Track.ts
@@ -25,9 +25,9 @@ export default class Track {
       }, [] as number[]);
     }
     console.log(
-      `Track ${trackId} has ${this.duration()} timepoints starting from ${this.times[0]} to ${
-        this.times[this.times.length - 1]
-      }`
+      `Track ${trackId} has ${this.times.length} objects over ${this.duration()} timepoints starting from ${
+        this.times[0]
+      } to ${this.times[this.times.length - 1]}`
     );
     console.log(this.ids);
   }


### PR DESCRIPTION
Fixes a bug where the calculation of points for the track paths didn't take into account that some tracks could be missing segmentations for certain frames. This would cause paths to advance one or more frames ahead of where they should be.

I fixed this by using fallbacks on frames where a track did not exist, during the calculation of points in the path.
This update also adds better documentation and adjusts a few property names (`length` vs. `duration`).

### Testing
Tracks with missing frames would not update their paths at the very end of the tracks due to the desync. Open the following links and advance a few frames to the very end of the selected track. In the fixed build, you should be able to see the track path update until the very last frame. (it also won't update the track path on the missing frame like in the broken build)

Main (broken) build: https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Mama%20Bear&feature=Volume&track=279&t=97&color=esri-green_4&palette-key=adobe
Fixed build: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-210/?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Mama%20Bear&feature=Volume&track=279&t=97&color=esri-green_4&palette-key=adobe
