### PR TITLE
feature: ScatterPlot config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,14 @@ import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useRe
 import { ColorizeCanvas, Dataset, Track } from "./colorizer";
 import { DEFAULT_CATEGORICAL_PALETTE_ID, DEFAULT_CATEGORICAL_PALETTES } from "./colorizer/colors/categorical_palettes";
 import { DEFAULT_COLOR_RAMP_ID, DEFAULT_COLOR_RAMPS } from "./colorizer/colors/color_ramps";
-import { defaultViewerConfig, FeatureThreshold, isThresholdNumeric, ViewerConfig } from "./colorizer/types";
+import {
+  defaultViewerConfig,
+  FeatureThreshold,
+  getDefaultScatterPlotConfig,
+  isThresholdNumeric,
+  ScatterPlotConfig,
+  ViewerConfig,
+} from "./colorizer/types";
 import { getColorMap, getInRangeLUT, thresholdMatchFinder, validateThresholds } from "./colorizer/utils/data_utils";
 import { numberToStringDecimal } from "./colorizer/utils/math_utils";
 import { useConstructor, useDebounce } from "./colorizer/utils/react_utils";
@@ -61,6 +68,10 @@ function App(): ReactElement {
   const [config, updateConfig] = useReducer(
     (current: ViewerConfig, newProperties: Partial<ViewerConfig>) => ({ ...current, ...newProperties }),
     defaultViewerConfig
+  );
+  const [scatterPlotConfig, updateScatterPlotConfig] = useReducer(
+    (current: ScatterPlotConfig, newProperties: Partial<ScatterPlotConfig>) => ({ ...current, ...newProperties }),
+    getDefaultScatterPlotConfig()
   );
 
   const [isInitialDatasetLoaded, setIsInitialDatasetLoaded] = useState(false);
@@ -941,6 +952,8 @@ function App(): ReactElement {
                           categoricalPalette={categoricalPalette}
                           inRangeIds={inRangeLUT}
                           viewerConfig={config}
+                          scatterPlotConfig={scatterPlotConfig}
+                          updateScatterPlotConfig={updateScatterPlotConfig}
                         />
                       </div>
                     ),

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -167,3 +167,22 @@ export const defaultViewerConfig: ViewerConfig = {
   outOfRangeDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUT_OF_RANGE_COLOR_DEFAULT) },
   outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
 };
+
+export enum RangeType {
+  ALL_TIME = "All time",
+  CURRENT_TRACK = "Current track",
+  CURRENT_FRAME = "Current frame",
+}
+
+export type ScatterPlotConfig = {
+  xAxis: string | null;
+  yAxis: string | null;
+  rangeType: RangeType;
+};
+
+// Use a function instead of a constant to avoid sharing the same object reference.
+export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
+  xAxis: null,
+  yAxis: null,
+  rangeType: RangeType.ALL_TIME,
+});

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -28,7 +28,7 @@ const LoadingSpinnerOverlay = styled.div<{ $loading: boolean }>`
   z-index: 100;
   pointer-events: none;
   background-color: #00000040;
-  transition: opacity 0.2s ease-in-out 0.1s;
+  transition: opacity 0.2s ease-in-out 0.2s;
 
   ${(props) => {
     return css`

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -135,60 +135,22 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     }
   }, [isPlaying]);
 
+  const [scatterConfig, _setScatterConfig] = useState(props.scatterPlotConfig);
+  useEffect(() => {
+    if (props.scatterPlotConfig !== scatterConfig) {
+      setIsRendering(true);
+      startTransition(() => {
+        _setScatterConfig(props.scatterPlotConfig);
+      });
+    }
+  }, [props.scatterPlotConfig]);
+  const { xAxis: xAxisFeatureName, yAxis: yAxisFeatureName, rangeType } = scatterConfig;
+
   const isDebouncePending =
-    dataset !== props.dataset || colorRampMin !== props.colorRampMin || colorRampMax !== props.colorRampMax;
-
-  /**
-   * Wrapper around a prop value and its setter. Triggers a callback whenever the values are set or the
-   * prop value changes, and tracks its own copy of the prop value as state to defer re-renders.
-   * @param propValue The prop value to track.
-   * @param setPropValue The setter for the prop value.
-   * @param onChange An optional callback to call when the prop value changes.
-   * @returns A tuple with the current value and a setter that triggers a render.
-   */
-  const usePropTransitionWrapper = <T extends any>(
-    propValue: T,
-    setPropValue: (newValue: T) => void,
-    onChange?: () => void
-  ): [T, (value: T) => void] => {
-    const [value, _setValue] = useState(propValue);
-
-    // Returned setter which will flag that a render is occurring.
-    const setState = (newPropValue: T): void => {
-      if (newPropValue === propValue) {
-        return;
-      }
-      setPropValue(newPropValue);
-      onChange && onChange();
-    };
-
-    // Trigger a render when the prop value changes.
-    useEffect(() => {
-      if (propValue !== value) {
-        onChange && onChange();
-        startTransition(() => {
-          _setValue(propValue);
-        });
-      }
-    }, [propValue]);
-    return [value, setState];
-  };
-
-  const [rangeType, setRangeType] = usePropTransitionWrapper<RangeType>(
-    props.scatterPlotConfig.rangeType,
-    (rangeType: RangeType) => props.updateScatterPlotConfig({ rangeType }),
-    () => setIsRendering(true)
-  );
-  const [xAxisFeatureName, setXAxisFeatureName] = usePropTransitionWrapper<string | null>(
-    props.scatterPlotConfig.xAxis,
-    (xAxis: string | null) => props.updateScatterPlotConfig({ xAxis }),
-    () => setIsRendering(true)
-  );
-  const [yAxisFeatureName, setYAxisFeatureName] = usePropTransitionWrapper<string | null>(
-    props.scatterPlotConfig.yAxis,
-    (yAxis: string | null) => props.updateScatterPlotConfig({ yAxis }),
-    () => setIsRendering(true)
-  );
+    props.scatterPlotConfig !== scatterConfig ||
+    dataset !== props.dataset ||
+    colorRampMin !== props.colorRampMin ||
+    colorRampMax !== props.colorRampMax;
 
   //////////////////////////////////
   // Click Handlers
@@ -792,13 +754,15 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           label={"X"}
           selected={xAxisFeatureName || ""}
           items={menuItems}
-          onChange={setXAxisFeatureName}
+          onChange={(key) => props.updateScatterPlotConfig({ xAxis: key })}
         />
         <Tooltip title="Swap axes" trigger={["hover", "focus"]}>
           <IconButton
             onClick={() => {
-              setXAxisFeatureName(yAxisFeatureName);
-              setYAxisFeatureName(xAxisFeatureName);
+              props.updateScatterPlotConfig({
+                xAxis: yAxisFeatureName,
+                yAxis: xAxisFeatureName,
+              });
             }}
             type="link"
           >
@@ -809,7 +773,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           label={"Y"}
           selected={yAxisFeatureName || ""}
           items={menuItems}
-          onChange={setYAxisFeatureName}
+          onChange={(key) => props.updateScatterPlotConfig({ yAxis: key })}
         />
 
         <LabeledDropdown
@@ -818,7 +782,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           selected={rangeType}
           items={Object.values(RangeType)}
           width={"120px"}
-          onChange={(value) => setRangeType(value as RangeType)}
+          onChange={(value) => props.updateScatterPlotConfig({ rangeType: value as RangeType })}
         ></LabeledDropdown>
       </FlexRowAlignCenter>
     );


### PR DESCRIPTION
Problem
=======
First step in #182, "Save Scatter Plot settings to URL (+current open tab)"

*Expected review time: small, 15-20 min*

Creates a new config object for the Scatter Plot tab, containing its current selected feature axes and the range type. This is passed into the `ScatterPlotTab`, and stored as state in the `App`.

The config object will eventually be serialized to the URL for sharing!

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-232/
2. Open the scatter plot tab and click around, changing various settings. Everything should still load in and work as expected.
