### PR TITLE
feature: Saving current scatterplot to the URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,7 +120,6 @@ function App(): ReactElement {
   }, [dataset, featureThresholds]);
 
   const [playbackFps, setPlaybackFps] = useState(DEFAULT_PLAYBACK_FPS);
-  const [openTab, setOpenTab] = useState(TabType.TRACK_PLOT);
 
   // Provides a mounting point for Antd's notification component. Otherwise, the notifications
   // are mounted outside of App and don't receive CSS styling variables.
@@ -917,8 +916,8 @@ function App(): ReactElement {
                 type="card"
                 style={{ marginBottom: 0, width: "100%" }}
                 size="large"
-                activeKey={openTab}
-                onChange={(key) => setOpenTab(key as TabType)}
+                activeKey={config.openTab}
+                onChange={(key) => updateConfig({ openTab: key as TabType })}
                 items={[
                   {
                     label: "Track Plot",
@@ -949,7 +948,7 @@ function App(): ReactElement {
                           selectedTrack={selectedTrack}
                           findTrack={findTrack}
                           setFrame={setFrameAndRender}
-                          isVisible={openTab === TabType.SCATTER_PLOT}
+                          isVisible={config.openTab === TabType.SCATTER_PLOT}
                           isPlaying={timeControls.isPlaying() || isRecording}
                           selectedFeatureName={featureName}
                           colorRampMin={colorRampMin}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -429,6 +429,9 @@ function App(): ReactElement {
       if (initialUrlParams.config) {
         updateConfig(initialUrlParams.config);
       }
+      if (initialUrlParams.scatterPlotConfig) {
+        updateScatterPlotConfig(initialUrlParams.scatterPlotConfig);
+      }
     };
 
     setupInitialParameters();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   getDefaultScatterPlotConfig,
   isThresholdNumeric,
   ScatterPlotConfig,
+  TabType,
   ViewerConfig,
 } from "./colorizer/types";
 import { getColorMap, getInRangeLUT, thresholdMatchFinder, validateThresholds } from "./colorizer/utils/data_utils";
@@ -42,7 +43,7 @@ import LabeledRangeSlider from "./components/LabeledRangeSlider";
 import LoadDatasetButton from "./components/LoadDatasetButton";
 import PlaybackSpeedControl from "./components/PlaybackSpeedControl";
 import SpinBox from "./components/SpinBox";
-import { FeatureThresholdsTab, PlotTab, ScatterPlotTab, SettingsTab, TabType } from "./components/Tabs";
+import { FeatureThresholdsTab, PlotTab, ScatterPlotTab, SettingsTab } from "./components/Tabs";
 
 import styles from "./App.module.css";
 
@@ -193,8 +194,7 @@ function App(): ReactElement {
   const getUrlParams = useCallback((): string => {
     const { datasetParam, collectionParam } = getDatasetAndCollectionParam();
     const rangeParam = getRangeParam();
-
-    return urlUtils.paramsToUrlQueryString({
+    const state: Partial<urlUtils.UrlParams> = {
       collection: collectionParam,
       dataset: datasetParam,
       feature: featureName,
@@ -208,7 +208,9 @@ function App(): ReactElement {
       categoricalPalette: categoricalPalette,
       config: config,
       selectedBackdropKey,
-    } as Required<urlUtils.UrlParams>);
+      scatterPlotConfig,
+    };
+    return urlUtils.paramsToUrlQueryString(state);
   }, [
     getDatasetAndCollectionParam,
     getRangeParam,
@@ -219,8 +221,9 @@ function App(): ReactElement {
     colorRampKey,
     colorRampReversed,
     categoricalPalette,
-    selectedBackdropKey,
     config,
+    selectedBackdropKey,
+    scatterPlotConfig,
   ]);
 
   // Update url whenever the viewer settings change

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -134,12 +134,17 @@ export type DrawSettings = {
   color: Color;
 };
 
+// CHANGING THESE VALUES CAN POTENTIALLY BREAK URLs. See `url_utils.parseDrawSettings` for parsing logic.
 export enum TabType {
   FILTERS = "filters",
   TRACK_PLOT = "track_plot",
   SCATTER_PLOT = "scatter_plot",
   SETTINGS = "settings",
 }
+
+export const isTabType = (tab: string): tab is TabType => {
+  return Object.values(TabType).includes(tab as TabType);
+};
 
 /**
  * Configuration for the viewer. These are high-level settings

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -134,6 +134,13 @@ export type DrawSettings = {
   color: Color;
 };
 
+export enum TabType {
+  FILTERS = "filters",
+  TRACK_PLOT = "track_plot",
+  SCATTER_PLOT = "scatter_plot",
+  SETTINGS = "settings",
+}
+
 /**
  * Configuration for the viewer. These are high-level settings
  * that are not specific to a particular dataset.
@@ -151,6 +158,7 @@ export type ViewerConfig = {
   objectOpacity: number;
   outOfRangeDrawSettings: DrawSettings;
   outlierDrawSettings: DrawSettings;
+  openTab: TabType;
 };
 
 export const defaultViewerConfig: ViewerConfig = {
@@ -166,6 +174,7 @@ export const defaultViewerConfig: ViewerConfig = {
   objectOpacity: 100,
   outOfRangeDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUT_OF_RANGE_COLOR_DEFAULT) },
   outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
+  openTab: TabType.TRACK_PLOT,
 };
 
 export enum PlotRangeType {

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -168,7 +168,7 @@ export const defaultViewerConfig: ViewerConfig = {
   outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color(OUTLIER_COLOR_DEFAULT) },
 };
 
-export enum RangeType {
+export enum PlotRangeType {
   ALL_TIME = "All time",
   CURRENT_TRACK = "Current track",
   CURRENT_FRAME = "Current frame",
@@ -177,12 +177,12 @@ export enum RangeType {
 export type ScatterPlotConfig = {
   xAxis: string | null;
   yAxis: string | null;
-  rangeType: RangeType;
+  rangeType: PlotRangeType;
 };
 
 // Use a function instead of a constant to avoid sharing the same object reference.
 export const getDefaultScatterPlotConfig = (): ScatterPlotConfig => ({
   xAxis: null,
   yAxis: null,
-  rangeType: RangeType.ALL_TIME,
+  rangeType: PlotRangeType.ALL_TIME,
 });

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -14,6 +14,7 @@ import {
   DrawSettings,
   FeatureThreshold,
   isDrawMode,
+  isTabType,
   isThresholdCategorical,
   PlotRangeType,
   ScatterPlotConfig,
@@ -49,6 +50,7 @@ enum UrlParam {
   SCATTERPLOT_X_AXIS = "scatter-x",
   SCATTERPLOT_Y_AXIS = "scatter-y",
   SCATTERPLOT_RANGE_MODE = "scatter-range",
+  OPEN_TAB = "tab",
 }
 
 const ALLEN_FILE_PREFIX = "/allen/";
@@ -241,6 +243,9 @@ function serializeViewerConfig(config: Partial<ViewerConfig>): string[] {
     parameters.push(`${UrlParam.FILTERED_COLOR}=${config.outOfRangeDrawSettings.color.getHexString()}`);
     parameters.push(`${UrlParam.FILTERED_MODE}=${config.outOfRangeDrawSettings.mode}`);
   }
+  if (config.openTab) {
+    parameters.push(`${UrlParam.OPEN_TAB}=${config.openTab}`);
+  }
 
   tryAddBooleanParam(parameters, config.showScaleBar, UrlParam.SHOW_SCALEBAR);
   tryAddBooleanParam(parameters, config.showTimestamp, UrlParam.SHOW_TIMESTAMP);
@@ -295,6 +300,10 @@ function deserializeViewerConfig(params: URLSearchParams): Partial<ViewerConfig>
       params.get(UrlParam.FILTERED_MODE),
       defaultViewerConfig.outOfRangeDrawSettings
     );
+  }
+  const openTab = params.get(UrlParam.OPEN_TAB);
+  if (openTab && isTabType(openTab)) {
+    newConfig.openTab = openTab;
   }
 
   newConfig.showScaleBar = getBooleanParam(params.get(UrlParam.SHOW_SCALEBAR));

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -324,8 +324,8 @@ function serializeScatterPlotConfig(config: Partial<ScatterPlotConfig>): string[
     const rangeString = rangeTypeToUrlParam[config.rangeType];
     parameters.push(`${UrlParam.SCATTERPLOT_RANGE_MODE}=${rangeString}`);
   }
-  config.xAxis && parameters.push(`${UrlParam.SCATTERPLOT_X_AXIS}=${config.xAxis}`);
-  config.yAxis && parameters.push(`${UrlParam.SCATTERPLOT_Y_AXIS}=${config.yAxis}`);
+  config.xAxis && parameters.push(`${UrlParam.SCATTERPLOT_X_AXIS}=${encodeURIComponent(config.xAxis)}`);
+  config.yAxis && parameters.push(`${UrlParam.SCATTERPLOT_Y_AXIS}=${encodeURIComponent(config.yAxis)}`);
   return parameters;
 }
 
@@ -335,8 +335,8 @@ function deserializeScatterPlotConfig(params: URLSearchParams): Partial<ScatterP
   if (rangeString && urlParamToRangeType[rangeString]) {
     newConfig.rangeType = urlParamToRangeType[rangeString];
   }
-  newConfig.xAxis = params.get(UrlParam.SCATTERPLOT_X_AXIS);
-  newConfig.yAxis = params.get(UrlParam.SCATTERPLOT_Y_AXIS);
+  newConfig.xAxis = decodePossiblyNullString(params.get(UrlParam.SCATTERPLOT_X_AXIS));
+  newConfig.yAxis = decodePossiblyNullString(params.get(UrlParam.SCATTERPLOT_Y_AXIS));
   const finalConfig = removeUndefinedProperties(newConfig);
   return Object.keys(finalConfig).length === 0 ? undefined : finalConfig;
 }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -617,5 +617,6 @@ export function loadParamsFromUrlQueryString(queryString: string): Partial<UrlPa
     categoricalPalette,
     config,
     selectedBackdropKey,
+    scatterPlotConfig,
   });
 }

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -335,8 +335,14 @@ function deserializeScatterPlotConfig(params: URLSearchParams): Partial<ScatterP
   if (rangeString && urlParamToRangeType[rangeString]) {
     newConfig.rangeType = urlParamToRangeType[rangeString];
   }
-  newConfig.xAxis = decodePossiblyNullString(params.get(UrlParam.SCATTERPLOT_X_AXIS));
-  newConfig.yAxis = decodePossiblyNullString(params.get(UrlParam.SCATTERPLOT_Y_AXIS));
+  const xAxis = decodePossiblyNullString(params.get(UrlParam.SCATTERPLOT_X_AXIS));
+  const yAxis = decodePossiblyNullString(params.get(UrlParam.SCATTERPLOT_Y_AXIS));
+  if (xAxis) {
+    newConfig.xAxis = xAxis;
+  }
+  if (yAxis) {
+    newConfig.yAxis = yAxis;
+  }
   const finalConfig = removeUndefinedProperties(newConfig);
   return Object.keys(finalConfig).length === 0 ? undefined : finalConfig;
 }

--- a/src/components/Tabs/ScatterPlotTab.tsx
+++ b/src/components/Tabs/ScatterPlotTab.tsx
@@ -7,7 +7,7 @@ import { Color, ColorRepresentation, HexColorString } from "three";
 
 import { SwitchIconSVG } from "../../assets";
 import { ColorRamp, Dataset, Track } from "../../colorizer";
-import { DrawMode, RangeType, ScatterPlotConfig, ViewerConfig } from "../../colorizer/types";
+import { DrawMode, PlotRangeType, ScatterPlotConfig, ViewerConfig } from "../../colorizer/types";
 import { useDebounce } from "../../colorizer/utils/react_utils";
 import { FlexRow, FlexRowAlignCenter } from "../../styles/utils";
 import {
@@ -44,7 +44,7 @@ const NUM_RESERVED_BUCKETS = 2;
 const BUCKET_INDEX_OUTOFRANGE = 0;
 const BUCKET_INDEX_OUTLIERS = 1;
 
-const DEFAULT_RANGE_TYPE = RangeType.ALL_TIME;
+const DEFAULT_RANGE_TYPE = PlotRangeType.ALL_TIME;
 
 type ScatterPlotTabProps = {
   dataset: Dataset | null;
@@ -174,9 +174,9 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     return [value, setState];
   };
 
-  const [rangeType, setRangeType] = usePropTransitionWrapper<RangeType>(
+  const [rangeType, setRangeType] = usePropTransitionWrapper<PlotRangeType>(
     props.scatterPlotConfig.rangeType,
-    (rangeType: RangeType) => props.updateScatterPlotConfig({ rangeType }),
+    (rangeType: PlotRangeType) => props.updateScatterPlotConfig({ rangeType }),
     () => setIsRendering(true)
   );
   const [xAxisFeatureName, setXAxisFeatureName] = usePropTransitionWrapper<string | null>(
@@ -239,7 +239,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
 
   // Track last rendered props + state to make optimizations on re-renders
   type LastRenderedState = {
-    rangeType: RangeType;
+    rangeType: PlotRangeType;
     xAxisFeatureName: string | null;
     yAxisFeatureName: string | null;
   } & ScatterPlotTabProps;
@@ -267,7 +267,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   const shouldDelayRender = (): boolean => {
     // Don't render when tab is not visible.
     // Also, don't render updates during playback, to prevent blocking the UI.
-    return !props.isVisible || (isPlaying && rangeType === RangeType.ALL_TIME);
+    return !props.isVisible || (isPlaying && rangeType === PlotRangeType.ALL_TIME);
   };
 
   const clearPlotAndStopRender = (): void => {
@@ -290,7 +290,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
   const filterDataByRange = (
     rawXData: DataArray,
     rawYData: DataArray,
-    range: RangeType
+    range: PlotRangeType
   ):
     | undefined
     | {
@@ -304,7 +304,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     let objectIds: number[] = [];
     let trackIds: number[] = [];
 
-    if (range === RangeType.CURRENT_FRAME) {
+    if (range === PlotRangeType.CURRENT_FRAME) {
       // Filter data to only show the current frame.
       if (!dataset?.times) {
         return undefined;
@@ -317,7 +317,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           yData.push(rawYData[i]);
         }
       }
-    } else if (range === RangeType.CURRENT_TRACK) {
+    } else if (range === PlotRangeType.CURRENT_TRACK) {
       // Filter data to only show the current track.
       if (!selectedTrack) {
         return { xData: [], yData: [], objectIds: [], trackIds: [] };
@@ -633,7 +633,7 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     const { xData, yData, objectIds, trackIds } = result;
 
     let markerBaseColor = undefined;
-    if (rangeType === RangeType.ALL_TIME && selectedTrack) {
+    if (rangeType === PlotRangeType.ALL_TIME && selectedTrack) {
       // Use a light grey for other markers when a track is selected.
       markerBaseColor = new Color("#dddddd");
     }
@@ -666,8 +666,8 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
     traces.push(yHistogram);
 
     // Render current track as an extra trace.
-    const trackData = filterDataByRange(rawXData, rawYData, RangeType.CURRENT_TRACK);
-    if (trackData && rangeType !== RangeType.CURRENT_FRAME) {
+    const trackData = filterDataByRange(rawXData, rawYData, PlotRangeType.CURRENT_TRACK);
+    if (trackData && rangeType !== PlotRangeType.CURRENT_FRAME) {
       // Render an extra trace for lines connecting the points in the current track when time is a feature.
       if (isUsingTime) {
         const hovertemplate = getHoverTemplate(dataset, xAxisFeatureName, yAxisFeatureName);
@@ -816,9 +816,9 @@ export default memo(function ScatterPlotTab(props: ScatterPlotTabProps): ReactEl
           label={"Show objects from"}
           style={{ marginLeft: "10px" }}
           selected={rangeType}
-          items={Object.values(RangeType)}
+          items={Object.values(PlotRangeType)}
           width={"120px"}
-          onChange={(value) => setRangeType(value as RangeType)}
+          onChange={(value) => setRangeType(value as PlotRangeType)}
         ></LabeledDropdown>
       </FlexRowAlignCenter>
     );

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -3,11 +3,4 @@ import PlotTab from "./PlotTab";
 import ScatterPlotTab from "./ScatterPlotTab";
 import SettingsTab from "./SettingsTab";
 
-enum TabType {
-  FILTERS = "filters",
-  TRACK_PLOT = "track_plot",
-  SCATTER_PLOT = "scatter_plot",
-  SETTINGS = "settings",
-}
-
-export { FeatureThresholdsTab, PlotTab, ScatterPlotTab, SettingsTab, TabType };
+export { FeatureThresholdsTab, PlotTab, ScatterPlotTab, SettingsTab };

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -375,9 +375,8 @@ describe("Loading + saving from URL query strings", () => {
       }
     });
 
-    it("Keeps backwards-compatible with existing tab strings", () => {
-      // This test will break if the tab strings are changed, and signal that
-      // we need to keep backwards compatibility.
+    it("Keeps backwards-compatibility with existing tab strings", () => {
+      // This test will break if the tab strings are ever changed as a warning.
       const knownTabStrings: Record<string, TabType> = {
         filters: TabType.FILTERS,
         track_plot: TabType.TRACK_PLOT,

--- a/tests/url_utils.test.ts
+++ b/tests/url_utils.test.ts
@@ -2,7 +2,14 @@ import { Color, ColorRepresentation } from "three";
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_CATEGORICAL_PALETTE_ID, DEFAULT_CATEGORICAL_PALETTES, DEFAULT_COLOR_RAMPS } from "../src/colorizer";
-import { defaultViewerConfig, DrawMode, DrawSettings, ThresholdType, ViewerConfig } from "../src/colorizer/types";
+import {
+  defaultViewerConfig,
+  DrawMode,
+  DrawSettings,
+  PlotRangeType,
+  ThresholdType,
+  ViewerConfig,
+} from "../src/colorizer/types";
 import {
   isAllenPath,
   isHexColor,
@@ -149,8 +156,13 @@ describe("Loading + saving from URL query strings", () => {
         objectOpacity: 25,
         outOfRangeDrawSettings: { mode: DrawMode.HIDE, color: new Color("#ff0000") } as DrawSettings,
         outlierDrawSettings: { mode: DrawMode.USE_COLOR, color: new Color("#00ff00") } as DrawSettings,
-      } as Required<ViewerConfig>,
+      },
       selectedBackdropKey: "some_backdrop",
+      scatterPlotConfig: {
+        xAxis: "x axis name",
+        yAxis: "y axis name",
+        rangeType: PlotRangeType.ALL_TIME,
+      },
     };
     const queryString = paramsToUrlQueryString(originalParams);
     const expectedQueryString =


### PR DESCRIPTION
Problem
=======
Closes #182! Saves the currently open tab and the scatterplot configuration to the URL.

*Expected review size: medium, ~20-30 minutes*

Solution
========
- Adds serializing and deserializing for the `ScatterPlotConfig`, allowing it to be saved and retrieved from the URL.
- Adds the currently open tab to the `ViewerConfig`, and saves it to and from the URL.

## Type of change

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-233/?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Mama%20Bear&feature=Volume&track=602&t=123&color=matplotlib-cool&palette-key=adobe&bg-sat=100&bg-brightness=100&fg-alpha=100&outlier-color=c0c0c0&outlier-mode=1&filter-color=dddddd&filter-mode=1&tab=scatter_plot&scalebar=1&timestamp=1&path=1&keep-range=0&scatter-range=frame&scatter-x=Height&scatter-y=Volume
2. The scatterplot tab should already be open, with "Height" and "Volume" as the two axes. The range should be set to "Current frame."

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/1b177351-a1ab-4477-ac5e-c07b4b9f2893)


Thanks for contributing!
