### PR TITLE
feat: Searching and scrolling in dropdowns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/icons": "^5.2.5",
         "antd": "^5.9.4",
+        "fuse.js": "^7.0.0",
         "mp4-muxer": "^2.2.2",
         "plotly.js-dist-min": "^2.27.0",
         "react": "^18.2.0",
@@ -6552,6 +6553,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/geckodriver": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.2.5",
     "antd": "^5.9.4",
+    "fuse.js": "^7.0.0",
     "mp4-muxer": "^2.2.2",
     "plotly.js-dist-min": "^2.27.0",
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,6 @@ import AppStyle, { AppThemeContext } from "./components/AppStyle";
 import CanvasWrapper from "./components/CanvasWrapper";
 import CategoricalColorPicker from "./components/CategoricalColorPicker";
 import ColorRampDropdown from "./components/Dropdowns/ColorRampDropdown";
-import DropdownItemList from "./components/Dropdowns/DropdownItemList";
 import HelpDropdown from "./components/Dropdowns/HelpDropdown";
 import SelectionDropdown from "./components/Dropdowns/SelectionDropdown";
 import Export from "./components/Export";
@@ -986,34 +985,6 @@ function App(): ReactElement {
               />
             </div>
           </div>
-        </div>
-        <div style={{ width: "100px" }}>
-          <DropdownItemList maxHeightPx={100}>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-            <p>Hi</p>
-          </DropdownItemList>
         </div>
       </div>
     </AppStyle>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import AppStyle, { AppThemeContext } from "./components/AppStyle";
 import CanvasWrapper from "./components/CanvasWrapper";
 import CategoricalColorPicker from "./components/CategoricalColorPicker";
 import ColorRampDropdown from "./components/Dropdowns/ColorRampDropdown";
+import DropdownItemList from "./components/Dropdowns/DropdownItemList";
 import HelpDropdown from "./components/Dropdowns/HelpDropdown";
 import SelectionDropdown from "./components/Dropdowns/SelectionDropdown";
 import Export from "./components/Export";
@@ -985,6 +986,34 @@ function App(): ReactElement {
               />
             </div>
           </div>
+        </div>
+        <div style={{ width: "100px" }}>
+          <DropdownItemList maxHeightPx={100}>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+            <p>Hi</p>
+          </DropdownItemList>
         </div>
       </div>
     </AppStyle>

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -112,11 +112,11 @@ export const ScrollShadowContainer = styled.div`
  *   const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
  *
  *   return (
- *   <div style={{maxHeight: "50px", position: "relative"}}>
+ *   <div style={{position: "relative"}}>
  *     <div
  *       ref={scrollRef}
  *       onScroll={onScrollHandler}
- *       style={{overflow-y: "auto", height: "100%"}}
+ *       style={{overflow-y: "auto", height: "50px"}}
  *     >
  *       <p>Some content</p>
  *       <p>Some more content</p>

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -1,4 +1,5 @@
 import React, { EventHandler, useEffect, useRef, useState } from "react";
+import styled from "styled-components";
 
 /**
  * Delays changes to a value until no changes have occurred for the
@@ -73,6 +74,23 @@ export function excludeUndefinedValues<T extends Object>(obj: T): Partial<T> {
 }
 
 /**
+ * Convenience styled component for use with `useScrollShadow`, intended to
+ * display the edge shadows. Place this inside the parent component as a sibling
+ * to the scrolling area, and apply the `scrollShadowStyle` to it.
+ */
+export const ScrollShadowContainer = styled.div`
+  position: absolute;
+  pointer-events: none;
+  // Fill the parent completely so we can overlay the
+  // shadow effects above the content.
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transition: box-shadow 0.1s ease-in;
+`;
+
+/**
  * Hook for adding scroll shadows to an element.
  *
  * Adapted with edits from https://medium.com/dfind-consulting/react-scroll-hook-with-shadows-9ba2d47ae32.
@@ -88,6 +106,8 @@ export function excludeUndefinedValues<T extends Object>(obj: T): Partial<T> {
  *
  * @example
  * ```
+ * import { useScrollShadow, ScrollShadowContainer } from "colorizer/utils/react_utils";
+ *
  * function MyComponent() {
  *   const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
  *
@@ -102,13 +122,7 @@ export function excludeUndefinedValues<T extends Object>(obj: T): Partial<T> {
  *       <p>Some more content</p>
  *       <p>Some more content</p>
  *     </div>
- *     <div style={{
- *       // This div applies the shadow and exists above the scrolling element.
- *       width: "100%",
- *       height: "100%",
- *       position: "absolute",
- *       top: 0,
- *       pointerEvents: "none",
+ *     <ScrollShadowContainer style={{
  *       ...scrollShadowStyle
  *     }} />
  *   </div>

--- a/src/components/Dropdowns/AccessibleDropdown.tsx
+++ b/src/components/Dropdowns/AccessibleDropdown.tsx
@@ -41,7 +41,7 @@ type AccessibleDropdownProps = {
    * `onFocus`, or `onBlur`. See implementation of `IconButton.tsx` for an example.
    */
   renderButton?: ((props: AccessibleDropdownProps, isOpen: boolean, onClick: () => void) => ReactElement) | null;
-  onButtonClicked?: (key: string) => void;
+  onButtonClicked?: () => void;
   /** Whether the tooltip should appear when hovered. */
   showTooltip?: boolean;
   /** If null, uses button text. */
@@ -258,7 +258,10 @@ export default function AccessibleDropdown(inputProps: AccessibleDropdownProps):
           placement="right"
           trigger={["hover", "focus"]}
         >
-          {renderButton(props, forceOpenState === true, () => setForceOpenState(!forceOpenState))}
+          {renderButton(props, forceOpenState === true, () => {
+            props.onButtonClicked();
+            setForceOpenState(!forceOpenState);
+          })}
         </Tooltip>
       </Dropdown>
     </MainContainer>

--- a/src/components/Dropdowns/AccessibleDropdown.tsx
+++ b/src/components/Dropdowns/AccessibleDropdown.tsx
@@ -165,12 +165,11 @@ export default function AccessibleDropdown(inputProps: AccessibleDropdownProps):
     if (forceOpenState === null) {
       // Null = default behavior, do nothing.
       return;
-    }
-
-    if (!forceOpenState) {
+    } else if (!forceOpenState) {
       // Immediately reset the open state to null if the dropdown was forced closed. This is used
       // to close the dropdown when the user makes a selection.
       setForceOpenState(null);
+      return;
     }
 
     const doesContainTarget = (target: EventTarget | null): boolean => {

--- a/src/components/Dropdowns/DropdownItem.tsx
+++ b/src/components/Dropdowns/DropdownItem.tsx
@@ -50,14 +50,6 @@ const DropdownItemButton = styled(Button)<{ $selected: boolean }>`
   }}
 `;
 
-/** Convenience styled div for alignment and spacing of dropdown items. */
-export const DropdownItemList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  overflow-y: auto;
-`;
-
 /** Styled Antd Button for use with Dropdown inputs. */
 export default function DropdownItem(inputProps: PropsWithChildren<DropdownItemProps>): ReactElement {
   const props = { ...defaultProps, ...inputProps } as PropsWithChildren<Required<DropdownItemProps>>;

--- a/src/components/Dropdowns/DropdownItem.tsx
+++ b/src/components/Dropdowns/DropdownItem.tsx
@@ -55,6 +55,7 @@ export const DropdownItemList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
+  overflow-y: auto;
 `;
 
 /** Styled Antd Button for use with Dropdown inputs. */

--- a/src/components/Dropdowns/DropdownItemList.tsx
+++ b/src/components/Dropdowns/DropdownItemList.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren, ReactElement } from "react";
 import styled from "styled-components";
 
 import { ScrollShadowContainer, useScrollShadow } from "../../colorizer/utils/react_utils";
+import { FlexColumn } from "../../styles/utils";
 
 type DropdownItemListProps = {
   maxHeightPx?: number;
@@ -12,17 +13,12 @@ const defaultProps: Partial<DropdownItemListProps> = {
 
 const MainContainer = styled.div`
   position: relative;
-  overflow: auto;
   width: auto;
 `;
 
 /** Convenience styled div for alignment and spacing of dropdown items. */
-const DropdownItemContainer = styled.div`
-  display: block;
-  flex-direction: column;
-  gap: 4px;
+const ScrollContainer = styled.div`
   overflow-y: auto;
-  height: 100%;
 `;
 
 export default function DropdownItemList(inputProps: PropsWithChildren<DropdownItemListProps>): ReactElement {
@@ -31,10 +27,10 @@ export default function DropdownItemList(inputProps: PropsWithChildren<DropdownI
   const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
 
   return (
-    <MainContainer style={{ maxHeight: props.maxHeightPx }}>
-      <DropdownItemContainer onScroll={onScrollHandler} ref={scrollRef}>
-        {props.children}
-      </DropdownItemContainer>
+    <MainContainer>
+      <ScrollContainer onScroll={onScrollHandler} ref={scrollRef} style={{ maxHeight: props.maxHeightPx }}>
+        <FlexColumn $gap={4}>{props.children}</FlexColumn>
+      </ScrollContainer>
       <ScrollShadowContainer style={{ ...scrollShadowStyle }} />
     </MainContainer>
   );

--- a/src/components/Dropdowns/DropdownItemList.tsx
+++ b/src/components/Dropdowns/DropdownItemList.tsx
@@ -1,0 +1,41 @@
+import React, { PropsWithChildren, ReactElement } from "react";
+import styled from "styled-components";
+
+import { ScrollShadowContainer, useScrollShadow } from "../../colorizer/utils/react_utils";
+
+type DropdownItemListProps = {
+  maxHeightPx?: number;
+};
+const defaultProps: Partial<DropdownItemListProps> = {
+  maxHeightPx: 300,
+};
+
+const MainContainer = styled.div`
+  position: relative;
+  overflow: auto;
+  width: auto;
+`;
+
+/** Convenience styled div for alignment and spacing of dropdown items. */
+const DropdownItemContainer = styled.div`
+  display: block;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+  height: 100%;
+`;
+
+export default function DropdownItemList(inputProps: PropsWithChildren<DropdownItemListProps>): ReactElement {
+  const props = { ...defaultProps, ...inputProps } as PropsWithChildren<Required<DropdownItemListProps>>;
+
+  const { scrollShadowStyle, onScrollHandler, scrollRef } = useScrollShadow();
+
+  return (
+    <MainContainer style={{ maxHeight: props.maxHeightPx }}>
+      <DropdownItemContainer onScroll={onScrollHandler} ref={scrollRef}>
+        {props.children}
+      </DropdownItemContainer>
+      <ScrollShadowContainer style={{ ...scrollShadowStyle }} />
+    </MainContainer>
+  );
+}

--- a/src/components/Dropdowns/HelpDropdown.tsx
+++ b/src/components/Dropdowns/HelpDropdown.tsx
@@ -5,7 +5,8 @@ import React, { ReactElement } from "react";
 import { VisuallyHidden } from "../../styles/utils";
 
 import AccessibleDropdown from "./AccessibleDropdown";
-import DropdownItem, { DropdownItemList } from "./DropdownItem";
+import DropdownItem from "./DropdownItem";
+import DropdownItemList from "./DropdownItemList";
 
 export default function HelpDropdown(): ReactElement {
   const makeOnButtonClick = (link: string) => {

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -1,8 +1,8 @@
 import { SearchOutlined } from "@ant-design/icons";
-import { Input, Tooltip } from "antd";
+import { Input, InputRef, Tooltip } from "antd";
 import { ItemType, MenuItemType } from "antd/es/menu/hooks/useItems";
 import Fuse from "fuse.js";
-import React, { ReactElement, useMemo, useState, useTransition } from "react";
+import React, { MutableRefObject, ReactElement, useMemo, useRef, useState, useTransition } from "react";
 
 import { FlexColumn } from "../../styles/utils";
 
@@ -72,6 +72,7 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
   const [isPending, startTransition] = useTransition();
   const [searchInput, setSearchInput] = useState("");
   const [filteredItems, setFilteredItems] = useState<MenuItemType[]>([]);
+  const searchInputRef = useRef<InputRef>();
 
   // Convert items into MenuItemType, adding missing properties as needed
   const items = useMemo((): MenuItemType[] => {
@@ -174,6 +175,11 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
             prefix={<SearchOutlined style={{ color: "var(--color-text-hint)" }} />}
             placeholder="Type to search"
             allowClear
+            ref={searchInputRef as MutableRefObject<InputRef>}
+            onFocus={() => {
+              // Keep the dropdown pinned open if the user clicks into the input box
+              setForceOpen(true);
+            }}
           ></Input>
           <LoadingSpinner loading={isPending} style={{ borderRadius: "4px", overflow: "hidden" }}>
             <DropdownItemList>{getDropdownItems(closeDropdown)}</DropdownItemList>
@@ -200,6 +206,12 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
       buttonText={selectedLabel}
       showTooltip={props.showTooltip}
       dropdownContent={getDropdownContent}
+      onButtonClicked={() => {
+        // Focus the search input when the dropdown is opened
+        if (searchInputRef.current) {
+          searchInputRef.current.focus();
+        }
+      }}
     ></AccessibleDropdown>
   );
 }

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -4,8 +4,9 @@ import { ItemType, MenuItemType } from "antd/es/menu/hooks/useItems";
 import Fuse from "fuse.js";
 import React, { ReactElement, useMemo, useState, useTransition } from "react";
 
-import { FlexColumn, FlexRow, FlexRowAlignCenter } from "../../styles/utils";
+import { FlexColumn } from "../../styles/utils";
 
+import LoadingSpinner from "../LoadingSpinner";
 import AccessibleDropdown from "./AccessibleDropdown";
 import DropdownItem, { DropdownItemList } from "./DropdownItem";
 
@@ -141,18 +142,21 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
   });
 
   const dropdownContent = (
-    <FlexColumn $gap={2}>
+    <FlexColumn $gap={6}>
       <Input
         style={{ paddingLeft: "6px" }}
         value={searchInput}
         onChange={(e) => {
           setSearchInput(e.target.value);
         }}
+        size="middle"
         prefix={<SearchOutlined style={{ color: "var(--color-text-hint)" }} />}
         placeholder="Type to search"
         allowClear
       ></Input>
-      <DropdownItemList>{dropdownList}</DropdownItemList>
+      <LoadingSpinner loading={isPending} style={{ borderRadius: "4px", overflow: "hidden" }}>
+        <DropdownItemList>{dropdownList}</DropdownItemList>
+      </LoadingSpinner>
     </FlexColumn>
   );
 

--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -159,7 +159,7 @@ export default function SelectionDropdown(inputProps: SelectionDropdownProps): R
 
   const showSearch = props.enableSearch && items.length > props.searchThresholdCount;
   const getDropdownContent = (setForceOpen: (forceOpen: boolean) => void): ReactElement => {
-    const closeDropdown = () => {
+    const closeDropdown = (): void => {
       setForceOpen(false);
     };
     if (showSearch) {

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -6,11 +6,12 @@ import styled, { css } from "styled-components";
 type LoadingSpinnerProps = {
   loading: boolean;
   iconSize?: number;
-  style: React.CSSProperties;
+  style?: React.CSSProperties;
 };
 
 const defaultProps: Partial<LoadingSpinnerProps> = {
   iconSize: 48,
+  style: {},
 };
 
 const LoadingSpinnerContainer = styled.div`

--- a/src/components/Tabs/FeatureThresholdsTab.tsx
+++ b/src/components/Tabs/FeatureThresholdsTab.tsx
@@ -14,7 +14,7 @@ import {
   ThresholdType,
 } from "../../colorizer/types";
 import { thresholdMatchFinder } from "../../colorizer/utils/data_utils";
-import { useScrollShadow } from "../../colorizer/utils/react_utils";
+import { ScrollShadowContainer, useScrollShadow } from "../../colorizer/utils/react_utils";
 import { MAX_FEATURE_CATEGORIES } from "../../constants";
 import { FlexColumn } from "../../styles/utils";
 
@@ -61,18 +61,6 @@ const FiltersContent = styled.div`
   height: 100%;
   padding: 0 10px;
   position: relative;
-`;
-
-const FiltersShadow = styled.div`
-  position: absolute;
-  pointer-events: none;
-  // Fill the parent (FiltersCardContainer) completely so we can overlay the
-  // shadow effects above the content (FiltersCard).
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  transition: box-shadow 0.1s ease-in;
 `;
 
 const FeatureLabel = styled.h3<{ $disabled?: boolean }>`
@@ -380,7 +368,7 @@ export default function FeatureThresholdsTab(inputProps: FeatureThresholdsTabPro
             }}
           />
         </FiltersContent>
-        <FiltersShadow style={scrollShadowStyle}></FiltersShadow>
+        <ScrollShadowContainer style={scrollShadowStyle} />
       </FiltersContainer>
     </PanelContainer>
   );


### PR DESCRIPTION
Problem
=======
Closes #204, "searchable and scrollable dropdowns for long lists."

Solution
========
- Adds a search bar and scrolling to `SelectionDropdowns` that exceed a certain number of items.
  - Search input uses fuzzy searching (using `fuse.js`) on the list of provided items.
  - Scrolling uses scroll shadows to indicate information above/below the fold.
  - Clicking on the dropdown button will focus the search input.

- Behavioral changes to dropdowns based on feedback from Lyndsay:
  - Selecting an item clears the search area and closes the dropdown.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
