### PR TITLE
fix: Fixed OpenGL warning from zero-sized texture

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -80,7 +80,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
   const emptyFeature = packDataTexture([0], FeatureDataType.F32);
   const emptyOutliers = packDataTexture([0], FeatureDataType.U8);
   const emptyInRangeIds = packDataTexture([0], FeatureDataType.U8);
-  const emptyColorRamp = new ColorRamp(["black"]).texture;
+  const emptyColorRamp = new ColorRamp(["#aaa", "#fff"]).texture;
 
   return {
     canvasToFrameScale: new Uniform(new Vector2(1, 1)),
@@ -481,8 +481,10 @@ export default class ColorizeCanvas {
 
   setInRangeLUT(inRangeLUT: Uint8Array): void {
     // Save the array to a texture and pass it into the shader
-    this.setUniform("inRangeIds", packDataTexture(Array.from(inRangeLUT), FeatureDataType.U8));
-    this.render();
+    if (inRangeLUT.length > 0) {
+      this.setUniform("inRangeIds", packDataTexture(Array.from(inRangeLUT), FeatureDataType.U8));
+      this.render();
+    }
   }
 
   getColorMapRangeMin(): number {


### PR DESCRIPTION
Problem
=======
Fixes a warning @toloudis and I noticed yesterday, where OpenGL was warning about a zero-sized texture.

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/37c96734-a9dd-4a95-8d04-5828f1f82259)

*Estimated review size: tiny, ~2 minutes*

Solution
========
- Adds a check for zero-sized textures for the `inRangeIds` data texture and skips the update if needed.

Steps to Verify:
----------------
1. Open the preview link and confirm from the console that there are no OpenGL warnings: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-251/

