### PR TITLE
fix: Change video codec version

### DIFF
--- a/src/colorizer/recorders/Mp4VideoRecorder.ts
+++ b/src/colorizer/recorders/Mp4VideoRecorder.ts
@@ -57,7 +57,8 @@ export default class Mp4VideoRecorder extends CanvasRecorder {
     // - https://developer.mozilla.org/en-US/docs/Web/Media/Formats/codecs_parameter#iso_base_media_file_format_mp4_quicktime_and_3gp
     // - List of recognized codecs: https://cconcolato.github.io/media-mime-support/#avc_codecs
     const codecs: [string, "avc" | "vp9" | "av1"][] = [
-      ["avc1.420032", "avc"], // baseline profile at level 5.0 allows 128 MB/s max bitrate
+      // 42 = baseline profile, 32 = level 5.0 (allows 128 MB/s max bitrate)
+      ["avc1.420032", "avc"],
       ["vp09.00.10.08", "vp9"],
       ["av01.0.04M.08", "av1"],
     ];

--- a/src/colorizer/recorders/Mp4VideoRecorder.ts
+++ b/src/colorizer/recorders/Mp4VideoRecorder.ts
@@ -2,7 +2,7 @@ import { ArrayBufferTarget, Muxer } from "mp4-muxer";
 
 import { sleep } from "../utils/timing_utils";
 
-import CanvasRecorder, { defaultRecordingOptions,RecordingOptions } from "./CanvasRecorder";
+import CanvasRecorder, { defaultRecordingOptions, RecordingOptions } from "./CanvasRecorder";
 
 // Eslint doesn't recognize the WebCodecs API yet.
 // This line prevents eslint from throwing errors like
@@ -52,8 +52,12 @@ export default class Mp4VideoRecorder extends CanvasRecorder {
     // just in case.
 
     // first value is browser-recognized codec, second value is muxer codec name
+    // For AVC, see the following resources:
+    // - https://blog.mediacoderhq.com/h264-profiles-and-levels/
+    // - https://developer.mozilla.org/en-US/docs/Web/Media/Formats/codecs_parameter#iso_base_media_file_format_mp4_quicktime_and_3gp
+    // - List of recognized codecs: https://cconcolato.github.io/media-mime-support/#avc_codecs
     const codecs: [string, "avc" | "vp9" | "av1"][] = [
-      ["avc1.420028", "avc"],
+      ["avc1.420032", "avc"], // baseline profile at level 5.0 allows 128 MB/s max bitrate
       ["vp09.00.10.08", "vp9"],
       ["av01.0.04M.08", "av1"],
     ];


### PR DESCRIPTION
*Estimated review size: Tiny, <5 minutes*

Updates the AVC1 video codec to actually support up to 100 MB/s, which is what the high quality video export mode is set to. (The previous version, `avc1.420032`, maxed out around 20 MB/s.)

Thanks to @interim17 for pointing this out!

## Type of change
* Bug fix (non-breaking change which fixes an issue)

