### PR TITLE
Refactor/viewer subpage

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -9,6 +9,7 @@ import {
 import { Checkbox, notification, Slider, Tabs } from "antd";
 import { NotificationConfig } from "antd/es/notification/interface";
 import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { ColorizeCanvas, Dataset, Track } from "./colorizer";
 import { DEFAULT_CATEGORICAL_PALETTE_ID, DEFAULT_CATEGORICAL_PALETTES } from "./colorizer/colors/categorical_palettes";
@@ -234,9 +235,14 @@ function Viewer(): ReactElement {
 
   // Update url whenever the viewer settings change
   // (but not while playing/recording for performance reasons)
+  const [searchParams, setSearchParams] = useSearchParams();
+
   useEffect(() => {
     if (!timeControls.isPlaying() && !isRecording) {
-      urlUtils.updateUrl(getUrlParams());
+      // TODO: setSearchParams converts this from a string to a URLSearchParams object,
+      // which means our unit tests don't reflect the current use case.
+      // (unit tests don't test conversion to and from URLSearchParams...)
+      setSearchParams(getUrlParams());
     }
   }, [timeControls.isPlaying(), isRecording, getUrlParams]);
 
@@ -317,14 +323,78 @@ function Viewer(): ReactElement {
     [featureThresholds, config.keepRangeBetweenDatasets]
   );
 
+  // DATASET LOADING ///////////////////////////////////////////////////////
+  /**
+   * Replaces the current dataset with another loaded dataset. Handles cleanup and state changes.
+   * @param newDataset the new Dataset to replace the existing with. If null, does nothing.
+   * @param newDatasetKey the key of the new dataset in the Collection.
+   * @returns a Promise<void> that resolves when the loading is complete.
+   */
+  const replaceDataset = useCallback(
+    async (newDataset: Dataset | null, newDatasetKey: string): Promise<void> => {
+      console.trace("Replacing dataset with " + newDatasetKey + ".");
+      // TODO: Change the way flags are handled to prevent flickering during dataset replacement
+      setDatasetOpen(false);
+      if (newDataset === null) {
+        // TODO: Determine with UX what expected behavior should be for bad datasets
+        return;
+      }
+
+      // Dispose of the old dataset
+      if (dataset !== null) {
+        dataset.dispose();
+      }
+      // State updates
+      setDataset(newDataset);
+      setDatasetKey(newDatasetKey);
+
+      // Only change the feature if there's no equivalent in the new dataset
+      let newFeatureName = featureName;
+      if (!newDataset.hasFeature(newFeatureName)) {
+        newFeatureName = newDataset.featureNames[0];
+      }
+      replaceFeature(newDataset, newFeatureName);
+      resetColorRampRangeToDefaults(newDataset, newFeatureName);
+      setFeatureName(newFeatureName);
+
+      await canv.setDataset(newDataset);
+      canv.setFeature(newFeatureName);
+
+      // Clamp frame to new range
+      const newFrame = Math.min(currentFrame, canv.getTotalFrames() - 1);
+      await setFrame(newFrame);
+
+      setFindTrackInput("");
+      if (selectedBackdropKey && !newDataset.hasBackdrop(selectedBackdropKey)) {
+        setSelectedBackdropKey(null);
+      }
+      setSelectedTrack(null);
+      setDatasetOpen(true);
+      setFeatureThresholds(validateThresholds(newDataset, featureThresholds));
+      console.log("Num Items:" + dataset?.numObjects);
+    },
+    [
+      dataset,
+      featureName,
+      canv,
+      currentFrame,
+      getUrlParams,
+      replaceFeature,
+      resetColorRampRangeToDefaults,
+      featureThresholds,
+    ]
+  );
+
   // INITIAL SETUP  ////////////////////////////////////////////////////////////////
 
   // Only retrieve parameters once, because the URL can be updated by state updates
   // and lose information (like the track, feature, time, etc.) that isn't
   // accessed in the first render.
   const initialUrlParams = useConstructor(() => {
-    return urlUtils.loadParamsFromUrl();
+    console.log(searchParams.toString());
+    return urlUtils.loadParamsFromUrl(searchParams.toString());
   });
+  console.log(initialUrlParams);
 
   // Load URL parameters into the state that don't require a dataset to be loaded.
   // This reduces flicker on initial load.
@@ -341,10 +411,18 @@ function Viewer(): ReactElement {
     }
   }, []);
 
+  // Break React rules to prevent a race condition where the initial dataset is reloaded
+  // due to useEffect being fired twice, which causes URL parameters like time to get lost.
+  const isLoadingInitialDataset = useRef<boolean>(false);
+
   // Attempt to load database and collections data from the URL.
   // This is memoized so that it only runs one time on startup.
   useEffect(() => {
     const loadInitialDataset = async (): Promise<void> => {
+      if (isLoadingInitialDataset.current || isInitialDatasetLoaded) {
+        return;
+      }
+      isLoadingInitialDataset.current = true;
       let newCollection: Collection;
       const collectionUrlParam = initialUrlParams.collection;
       const datasetParam = initialUrlParams.dataset;
@@ -417,10 +495,10 @@ function Viewer(): ReactElement {
         // Highlight the track. Seek to start of frame only if time is not defined.
         findTrack(initialUrlParams.track, initialUrlParams.time !== undefined);
       }
-      let newTime = currentFrame;
       if (initialUrlParams.time && initialUrlParams.time >= 0) {
         // Load time (if unset, defaults to track time or default t=0)
-        newTime = initialUrlParams.time;
+        const newTime = initialUrlParams.time;
+        console.log("Setting time to " + newTime + ".");
         await canv.setFrame(newTime);
         setCurrentFrame(newTime); // Force render
         setFrameInput(newTime);
@@ -442,67 +520,6 @@ function Viewer(): ReactElement {
 
     setupInitialParameters();
   }, [isInitialDatasetLoaded]);
-
-  // DATASET LOADING ///////////////////////////////////////////////////////
-  /**
-   * Replaces the current dataset with another loaded dataset. Handles cleanup and state changes.
-   * @param newDataset the new Dataset to replace the existing with. If null, does nothing.
-   * @param newDatasetKey the key of the new dataset in the Collection.
-   * @returns a Promise<void> that resolves when the loading is complete.
-   */
-  const replaceDataset = useCallback(
-    async (newDataset: Dataset | null, newDatasetKey: string): Promise<void> => {
-      // TODO: Change the way flags are handled to prevent flickering during dataset replacement
-      setDatasetOpen(false);
-      if (newDataset === null) {
-        // TODO: Determine with UX what expected behavior should be for bad datasets
-        return;
-      }
-
-      // Dispose of the old dataset
-      if (dataset !== null) {
-        dataset.dispose();
-      }
-      // State updates
-      setDataset(newDataset);
-      setDatasetKey(newDatasetKey);
-
-      // Only change the feature if there's no equivalent in the new dataset
-      let newFeatureName = featureName;
-      if (!newDataset.hasFeature(newFeatureName)) {
-        newFeatureName = newDataset.featureNames[0];
-      }
-      replaceFeature(newDataset, newFeatureName);
-      resetColorRampRangeToDefaults(newDataset, newFeatureName);
-      setFeatureName(newFeatureName);
-
-      await canv.setDataset(newDataset);
-      canv.setFeature(newFeatureName);
-
-      // Clamp frame to new range
-      const newFrame = Math.min(currentFrame, canv.getTotalFrames() - 1);
-      await setFrame(newFrame);
-
-      setFindTrackInput("");
-      if (selectedBackdropKey && !newDataset.hasBackdrop(selectedBackdropKey)) {
-        setSelectedBackdropKey(null);
-      }
-      setSelectedTrack(null);
-      setDatasetOpen(true);
-      setFeatureThresholds(validateThresholds(newDataset, featureThresholds));
-      console.log("Num Items:" + dataset?.numObjects);
-    },
-    [
-      dataset,
-      featureName,
-      canv,
-      currentFrame,
-      getUrlParams,
-      replaceFeature,
-      resetColorRampRangeToDefaults,
-      featureThresholds,
-    ]
-  );
 
   // DISPLAY CONTROLS //////////////////////////////////////////////////////
   const handleDatasetChange = useCallback(

--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -539,6 +539,7 @@ export default class ColorizeCanvas {
    * is already loaded.
    */
   async setFrame(index: number, forceUpdate: boolean = false): Promise<void> {
+    console.trace("setFrame called with index: ", index);
     // Ignore same or bad frame indices
     if ((!forceUpdate && this.currentFrame === index) || !this.isValidFrame(index)) {
       return;

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -440,17 +440,6 @@ export function paramsToUrlQueryString(state: Partial<UrlParams>): string {
 }
 
 /**
- * Replaces the current URL in the browser history with a new one, made by appending
- * the urlParams to the base URL.
- * @param urlParams A string of parameters that can be appended to the base URL.
- */
-export function updateUrl(urlParams: string): void {
-  // Use replaceState rather than pushState, because otherwise every frame will be a unique
-  // URL in the browser history
-  window.history.replaceState(null, document.title, urlParams);
-}
-
-/**
  * Returns if a string is a URL where resources can be fetched from, rather than just a
  * string name.
  * @param input String to be checked.
@@ -531,9 +520,10 @@ export function formatPath(input: string): string {
  * A parameter is `undefined` if it was not found in the URL, or if
  * it could not be parsed.
  */
-export function loadParamsFromUrl(): Partial<UrlParams> {
+export function loadParamsFromUrl(queryString: string): Partial<UrlParams> {
   // Get params from URL and load, with default fallbacks.
-  const queryString = window.location.search;
+  // const queryString = window.location.search;
+  // console.log(queryString);
   return loadParamsFromUrlQueryString(queryString);
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createHashRouter, RouterProvider } from "react-router-dom";
 
 import AppStyle from "./components/AppStyle";
 import ErrorPage from "./routes/ErrorPage";
+import LandingPage from "./routes/LandingPage";
 import Viewer from "./Viewer";
 
 // Set up react router
@@ -12,6 +13,11 @@ const router = createHashRouter(
   [
     {
       path: "/",
+      element: <LandingPage />,
+      errorElement: <ErrorPage />,
+    },
+    {
+      path: "viewer",
       element: <Viewer />,
       errorElement: <ErrorPage />,
     },

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,0 +1,21 @@
+import { Button } from "antd";
+import React, { ReactElement } from "react";
+import { Link } from "react-router-dom";
+
+import { Header, HeaderLogo } from "../components/Header";
+
+type LandingPageProps = {};
+
+export default function LandingPage(props: LandingPageProps): ReactElement {
+  return (
+    <>
+      <Header>
+        <HeaderLogo />
+      </Header>
+      <p>Hello </p>
+      <Link to="viewer">
+        <Button>Go to viewer</Button>
+      </Link>
+    </>
+  );
+}

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -1,21 +1,51 @@
-import { Button } from "antd";
-import React, { ReactElement } from "react";
+import { Button, Card } from "antd";
+import React, { ReactElement, useContext } from "react";
 import { Link } from "react-router-dom";
 
+import { FlexColumnAlignCenter, FlexRowAlignCenter } from "../styles/utils";
+
+import { AppThemeContext } from "../components/AppStyle";
 import { Header, HeaderLogo } from "../components/Header";
 
 type LandingPageProps = {};
 
 export default function LandingPage(props: LandingPageProps): ReactElement {
+  const theme = useContext(AppThemeContext);
   return (
     <>
       <Header>
         <HeaderLogo />
       </Header>
-      <p>Hello </p>
-      <Link to="viewer">
-        <Button>Go to viewer</Button>
-      </Link>
+      <br />
+      <FlexColumnAlignCenter $gap={10}>
+        <Card>
+          <h1>Hello! This is the new WIP landing page.</h1>
+          <p>
+            If you got to this page with a link that previously took you to the viewer, you can continue using it with a
+            quick edit.
+          </p>
+          <br />
+          <p>If your link previously looked like this:</p>
+          <code>https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html?collection=....</code>
+          <p>You'll need to edit it by adding the new viewer subpath:</p>
+          <code>
+            https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html
+            <span style={{ color: "var(--color-text-theme)" }}>/#/viewer</span>
+            ?collection=....
+          </code>
+          <br />
+          <br />
+          <p>
+            Make sure to update any links you've shared with other people. Thanks for your patience while the tool is
+            getting ready for release!
+          </p>
+        </Card>
+        <Link to="viewer">
+          <Button type="primary" size="large" style={{ fontSize: theme.font.size.label }}>
+            <FlexRowAlignCenter>Go to viewer</FlexRowAlignCenter>
+          </Button>
+        </Link>
+      </FlexColumnAlignCenter>
     </>
   );
 }


### PR DESCRIPTION
Problem
=======
Part II of work on #250. This change moves the viewer to a subpage, and makes various fixes to loading and saving of URLs so that functionality remains the same.

Solution
========
- The default base path now has a placeholder landing page, with placeholder text explaining how to get to the viewer.
- The viewer has been moved to the `#/viewer/` path. 
  - (he `#` tells the browser to only process the rest of the path client-side, which is what we want for a single-page application. 
    - I don't know if this will mess up analytics though!
- Updating and loading URL parameters now uses hooks from `react-router-dom`.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link:
2. Click through to the viewer.
3. On the viewer page, click the `Timelapse Colorizer` link text. It should take you to the landing page again.

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
4. other important file

Thanks for contributing!
