### PR TITLE
feature: Load button on landing page

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -547,30 +547,11 @@ function Viewer(): ReactElement {
    * @throws an error if the URL could not be loaded.
    * @returns the absolute path of the URL resource that was loaded.
    */
-  const handleLoadRequest = useCallback(
-    async (url: string): Promise<string> => {
-      console.log("Loading '" + url + "'.");
-      const newCollection = await Collection.loadFromAmbiguousUrl(url);
-      const newDatasetKey = newCollection.getDefaultDatasetKey();
-      const loadResult = await newCollection.tryLoadDataset(newDatasetKey);
-      if (!loadResult.loaded) {
-        const errorMessage = loadResult.errorMessage;
-
-        if (errorMessage) {
-          // Remove 'Error:' prefixes
-          const matches = errorMessage.replace(/^(Error:)*/, "");
-          // Reject the promise with the error message
-          throw new Error(matches);
-          // throw new Error(errorMessage);
-        } else {
-          throw new Error();
-        }
-      }
-
+  const handleDatasetLoad = useCallback(
+    (newCollection: Collection, newDatasetKey: string, newDataset: Dataset): void => {
       setCollection(newCollection);
       setFeatureThresholds([]); // Clear when switching collections
-      await replaceDataset(loadResult.dataset, newDatasetKey);
-      return newCollection.url || newCollection.getDefaultDatasetKey();
+      replaceDataset(newDataset, newDatasetKey);
     },
     [replaceDataset]
   );
@@ -710,7 +691,7 @@ function Viewer(): ReactElement {
         {/* <h3>Dataset Name</h3> */}
         <FlexRowAlignCenter $gap={12}>
           <FlexRowAlignCenter $gap={2}>
-            <LoadDatasetButton onRequestLoad={handleLoadRequest} currentResourceUrl={collection?.url || datasetKey} />
+            <LoadDatasetButton onLoad={handleDatasetLoad} currentResourceUrl={collection?.url || datasetKey} />
             <Export
               totalFrames={dataset?.numberOfFrames || 0}
               setFrame={setFrameAndRender}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -9,7 +9,7 @@ import {
 import { Checkbox, notification, Slider, Tabs } from "antd";
 import { NotificationConfig } from "antd/es/notification/interface";
 import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { Location, useLocation, useSearchParams } from "react-router-dom";
 
 import { ColorizeCanvas, Dataset, Track } from "./colorizer";
 import {
@@ -426,8 +426,13 @@ function Viewer(): ReactElement {
       isLoadingInitialDataset.current = true;
       let newCollection: Collection;
       let datasetKey: string;
+
+      const locationHasCollectionAndDataset = (location: Location): boolean => {
+        return location.state && "collection" in location.state && "datasetKey" in location.state;
+      };
+
       // Check if we were passed a collection + dataset from the previous page.
-      if (location.state && "collection" in location.state && "datasetKey" in location.state) {
+      if (locationHasCollectionAndDataset(location)) {
         // Collect from previous page state
         const { collection: stateCollection, datasetKey: stateDatasetKey } = location.state as LocationState;
         datasetKey = stateDatasetKey;

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -424,11 +424,11 @@ function Viewer(): ReactElement {
         return;
       }
       isLoadingInitialDataset.current = true;
-
       let newCollection: Collection;
       let datasetKey: string;
       // Check if we were passed a collection + dataset from the previous page.
       if (location.state && "collection" in location.state && "datasetKey" in location.state) {
+        // Collect from previous page state
         const { collection: stateCollection, datasetKey: stateDatasetKey } = location.state as LocationState;
         datasetKey = stateDatasetKey;
         newCollection = stateCollection;

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -199,25 +199,38 @@ export function useScrollShadow(shadowColor: string = "#00000030"): {
 const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
 const MAX_RECENT_DATASETS = 10;
 
-export type RecentDataset = {
+export type RecentCollection = {
   /** The absolute URL path of the dataset resource. */
   url: string;
-  /** The user input for the dataset resource. */
+  /**
+   * The user input for the dataset resource.
+   * If `null`, uses the existing label (if already in recent datasets) or reuse the URL (if new).
+   */
   label: string;
 };
 
-export const useRecentDatasets = (): [RecentDataset[], (dataset: RecentDataset) => void] => {
-  const [recentDatasets, setRecentDatasets] = useLocalStorage<RecentDataset[]>(RECENT_DATASETS_STORAGE_KEY, []);
+/**
+ * Wrapper around locally-stored recent collections.
+ * @returns an array containing the list of recent collections and a function to add a new collection to the list.
+ */
+export const useRecentCollections = (): [RecentCollection[], (collection: RecentCollection) => void] => {
+  const [recentCollections, setRecentCollections] = useLocalStorage<RecentCollection[]>(
+    RECENT_DATASETS_STORAGE_KEY,
+    []
+  );
 
-  const addRecentDataset = (dataset: RecentDataset): void => {
-    const datasetIndex = recentDatasets.findIndex(({ url }) => url === dataset.url);
+  const addRecentCollection = (collection: RecentCollection): void => {
+    const datasetIndex = recentCollections.findIndex(({ url }) => url === collection.url);
     if (datasetIndex === -1) {
-      // New dataset, add to front while maintaining max length
-      setRecentDatasets([dataset, ...recentDatasets.slice(0, MAX_RECENT_DATASETS - 1)]);
+      setRecentCollections([collection, ...recentCollections.slice(0, MAX_RECENT_DATASETS - 1)]);
     } else {
       // Move to front; this also updates the label if it changed.
-      setRecentDatasets([dataset, ...recentDatasets.slice(0, datasetIndex), ...recentDatasets.slice(datasetIndex + 1)]);
+      setRecentCollections([
+        collection,
+        ...recentCollections.slice(0, datasetIndex),
+        ...recentCollections.slice(datasetIndex + 1),
+      ]);
     }
   };
-  return [recentDatasets, addRecentDataset];
+  return [recentCollections, addRecentCollection];
 };

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -195,15 +195,15 @@ export function useScrollShadow(shadowColor: string = "#00000030"): {
   return { scrollShadowStyle: { boxShadow: getBoxShadow() }, onScrollHandler, scrollRef };
 }
 
-/** Key for local storage to read/write recently opened datasets */
-const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
-const MAX_RECENT_DATASETS = 10;
+/** Key for local storage to read/write recently opened collections */
+const RECENT_COLLECTIONS_STORAGE_KEY = "recentDatasets";
+const MAX_RECENT_COLLECTIONS = 10;
 
 export type RecentCollection = {
-  /** The absolute URL path of the dataset resource. */
+  /** The absolute URL path of the collection resource. */
   url: string;
   /**
-   * The user input for the dataset resource.
+   * The user input for the collection resource.
    * If `null`, uses the existing label (if already in recent datasets) or reuse the URL (if new).
    */
   label: string;
@@ -215,14 +215,14 @@ export type RecentCollection = {
  */
 export const useRecentCollections = (): [RecentCollection[], (collection: RecentCollection) => void] => {
   const [recentCollections, setRecentCollections] = useLocalStorage<RecentCollection[]>(
-    RECENT_DATASETS_STORAGE_KEY,
+    RECENT_COLLECTIONS_STORAGE_KEY,
     []
   );
 
   const addRecentCollection = (collection: RecentCollection): void => {
     const datasetIndex = recentCollections.findIndex(({ url }) => url === collection.url);
     if (datasetIndex === -1) {
-      setRecentCollections([collection, ...recentCollections.slice(0, MAX_RECENT_DATASETS - 1)]);
+      setRecentCollections([collection, ...recentCollections.slice(0, MAX_RECENT_COLLECTIONS - 1)]);
     } else {
       // Move to front; this also updates the label if it changed.
       setRecentCollections([

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { useClickAnyWhere } from "usehooks-ts";
 
 import { Dataset } from "../colorizer";
-import { useRecentDatasets } from "../colorizer/utils/react_utils";
+import { useRecentCollections } from "../colorizer/utils/react_utils";
 import { convertAllenPathToHttps, isAllenPath } from "../colorizer/utils/url_utils";
 
 import Collection from "../colorizer/Collection";
@@ -78,7 +78,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     _setUrlInput(newUrl);
   }, []);
 
-  const [recentDatasets, registerDataset] = useRecentDatasets();
+  const [recentCollections, registerCollection] = useRecentCollections();
 
   const [isLoading, setIsLoading] = useState(false);
   const [errorText, setErrorText] = useState<string>("");
@@ -176,7 +176,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
           setIsLoadModalOpen(false);
           setIsLoading(false);
           // Add to recent datasets
-          registerDataset({
+          registerCollection({
             url: loadedUrl,
             label: urlInput, // Use raw url input for the label
           });
@@ -212,7 +212,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
 
   // RENDERING ////////////////////////////////////////////////////////
 
-  const datasetsDropdownItems: MenuItemType[] = recentDatasets.map(({ url, label }) => {
+  const datasetsDropdownItems: MenuItemType[] = recentCollections.map(({ url, label }) => {
     const isCurrentUrl = props.currentResourceUrl === url;
     return {
       key: url,
@@ -224,11 +224,11 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   });
 
   // Get the URLs (keys) of any recent datasets that match the currently selected urlInput.
-  const matchingKeys = recentDatasets.filter(({ label }) => label === urlInput).map(({ url }) => url);
+  const matchingKeys = recentCollections.filter(({ label }) => label === urlInput).map(({ url }) => url);
   const datasetsDropdownProps: MenuProps = {
     onClick: (info) => {
       // Set the URL input to the label of the selected dataset
-      const dataset = recentDatasets.find(({ url }) => url === info.key);
+      const dataset = recentCollections.find(({ url }) => url === info.key);
       if (dataset) {
         setUrlInput(dataset.label);
       }

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -99,7 +99,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
 
   // The dropdown should be shown whenever the user clicks on the input field, and hidden if the user starts
   // typing or clicks off of the input (including selecting options in the dropdown).
-  // TODO: It's not currently possible to open the dropdown with tab navigation. Pending further discussion with UX team.
+  // TODO: Switch to using AccessibleDropdown as a base component
   useClickAnyWhere((event) => {
     if (event.target === inputRef.current?.input) {
       setShowRecentDropdown(true);
@@ -129,7 +129,6 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
         const matches = errorMessage.replace(/^(Error:)*/, "");
         // Reject the promise with the error message
         throw new Error(matches);
-        // throw new Error(errorMessage);
       } else {
         throw new Error();
       }

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -175,7 +175,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
         setTimeout(() => {
           setIsLoadModalOpen(false);
           setIsLoading(false);
-          // Add to recent datasets
+          // Add to recent collections
           registerCollection({
             url: loadedUrl,
             label: urlInput, // Use raw url input for the label
@@ -203,7 +203,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   }, [urlInput, props.onLoad]);
 
   const handleCancel = useCallback(() => {
-    // should this cancel dataset loading mid-load?
+    // should this cancel datasets/collection loading mid-load?
     setIsLoading(false);
     setErrorText("");
     setIsLoadModalOpen(false);
@@ -212,28 +212,27 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
 
   // RENDERING ////////////////////////////////////////////////////////
 
-  const datasetsDropdownItems: MenuItemType[] = recentCollections.map(({ url, label }) => {
+  const collectionsDropdownItems: MenuItemType[] = recentCollections.map(({ url, label }) => {
     const isCurrentUrl = props.currentResourceUrl === url;
     return {
       key: url,
       label: label,
-      // Disable if dataset is currently open
-      disabled: isCurrentUrl,
+      style: isCurrentUrl ? { color: "var(--color-text-hint)" } : undefined,
       icon: isCurrentUrl ? <FolderOpenOutlined /> : undefined,
     };
   });
 
-  // Get the URLs (keys) of any recent datasets that match the currently selected urlInput.
+  // Get the URLs (keys) of any recent collections that match the currently selected urlInput.
   const matchingKeys = recentCollections.filter(({ label }) => label === urlInput).map(({ url }) => url);
-  const datasetsDropdownProps: MenuProps = {
+  const collectionsDropdownProps: MenuProps = {
     onClick: (info) => {
-      // Set the URL input to the label of the selected dataset
-      const dataset = recentCollections.find(({ url }) => url === info.key);
-      if (dataset) {
-        setUrlInput(dataset.label);
+      // Set the URL input to the label of the selected collection
+      const collection = recentCollections.find(({ url }) => url === info.key);
+      if (collection) {
+        setUrlInput(collection.label);
       }
     },
-    items: datasetsDropdownItems,
+    items: collectionsDropdownItems,
     selectable: true,
     selectedKeys: matchingKeys,
   };
@@ -261,9 +260,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
         footer={<Button onClick={handleCancel}>Cancel</Button>}
       >
         <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
-          <p style={{ marginBottom: "10px" }}>
-            Load a collection of datasets or a single dataset by providing its URL.
-          </p>
+          <p style={{ marginBottom: "10px" }}>Load a collection of datasets or a single dataset by providing a URL.</p>
 
           <div ref={dropdownContextRef} style={{ position: "relative" }}>
             <p>
@@ -275,7 +272,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
               <Space.Compact style={{ width: "100%" }}>
                 <Dropdown
                   trigger={["click"]}
-                  menu={datasetsDropdownProps}
+                  menu={collectionsDropdownProps}
                   placement="bottomLeft"
                   open={showRecentDropdown}
                   getPopupContainer={dropdownContextRef.current ? () => dropdownContextRef.current! : undefined}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
+import { ErrorPage, LandingPage } from "./routes";
+
 import AppStyle from "./components/AppStyle";
-import ErrorPage from "./routes/ErrorPage";
-import LandingPage from "./routes/LandingPage";
 import Viewer from "./Viewer";
 
 // Set up react router

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -2,15 +2,19 @@ import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, Card, Tooltip } from "antd";
 import React, { ReactElement, useContext } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
+import { Dataset } from "../colorizer";
 import { paramsToUrlQueryString } from "../colorizer/utils/url_utils";
 import { FlexColumn, FlexColumnAlignCenter, FlexRow, FlexRowAlignCenter, VisuallyHidden } from "../styles/utils";
 import { DatasetEntry, ProjectEntry } from "../types";
 
+import Collection from "../colorizer/Collection";
 import { AppThemeContext } from "../components/AppStyle";
+import HelpDropdown from "../components/Dropdowns/HelpDropdown";
 import Header from "../components/Header";
+import LoadDatasetButton from "../components/LoadDatasetButton";
 import { landingPageContent } from "./LandingPageContent";
 
 const ContentContainer = styled(FlexColumn)`
@@ -99,6 +103,15 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
 
 export default function LandingPage(): ReactElement {
   const theme = useContext(AppThemeContext);
+  const navigate = useNavigate();
+
+  // Behavior
+
+  const onDatasetLoad = (collection: Collection, datasetKey: string, newDataset: Dataset): void => {
+    navigate("viewer", { state: { collection: collection, datasetKey: datasetKey, dataset: newDataset } });
+  };
+
+  // Rendering
 
   // TODO: Should the load buttons be link elements or buttons?
   // Currently both the link and the button inside can be tab-selected.
@@ -173,7 +186,12 @@ export default function LandingPage(): ReactElement {
 
   return (
     <>
-      <Header />
+      <Header>
+        <FlexRowAlignCenter $gap={15}>
+          <LoadDatasetButton onLoad={onDatasetLoad} currentResourceUrl={""} />
+          <HelpDropdown />
+        </FlexRowAlignCenter>
+      </Header>
       <br />
       <ContentContainer $gap={10}>
         <FlexColumnAlignCenter $gap={10}>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -8,7 +8,8 @@ import styled from "styled-components";
 import { Dataset } from "../colorizer";
 import { paramsToUrlQueryString } from "../colorizer/utils/url_utils";
 import { FlexColumn, FlexColumnAlignCenter, FlexRow, FlexRowAlignCenter, VisuallyHidden } from "../styles/utils";
-import { DatasetEntry, ProjectEntry } from "../types";
+import { DatasetEntry, LocationState, ProjectEntry } from "../types";
+import { PageRoutes } from "./index";
 
 import Collection from "../colorizer/Collection";
 import { AppThemeContext } from "../components/AppStyle";
@@ -107,8 +108,14 @@ export default function LandingPage(): ReactElement {
 
   // Behavior
 
-  const onDatasetLoad = (collection: Collection, datasetKey: string, newDataset: Dataset): void => {
-    navigate("viewer", { state: { collection: collection, datasetKey: datasetKey, dataset: newDataset } });
+  const onDatasetLoad = (collection: Collection, datasetKey: string, _newDataset: Dataset): void => {
+    // Unfortunately we can't pass the dataset directly through the `navigate` `state` API due to
+    // certain Dataset state (like HTMLImageElement objects) being non-serializable. This means that the
+    // dataset will be loaded twice, once here and once in the viewer.
+    // Dataset loading is relatively fast and the browser should cache most of the loaded data so it
+    // should hopefully not be a performance issue.
+    // TODO: Pass dataset directly here?
+    navigate(PageRoutes.VIEWER, { state: { collection: collection, datasetKey: datasetKey } as LocationState });
   };
 
   // Rendering
@@ -116,7 +123,7 @@ export default function LandingPage(): ReactElement {
   // TODO: Should the load buttons be link elements or buttons?
   // Currently both the link and the button inside can be tab-selected.
   const renderDataset = (dataset: DatasetEntry, index: number): ReactElement => {
-    const viewerLink = "viewer" + paramsToUrlQueryString(dataset.loadParams);
+    const viewerLink = PageRoutes.VIEWER + paramsToUrlQueryString(dataset.loadParams);
 
     return (
       <DatasetCard key={index}>

--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -123,7 +123,7 @@ export default function LandingPage(): ReactElement {
   // TODO: Should the load buttons be link elements or buttons?
   // Currently both the link and the button inside can be tab-selected.
   const renderDataset = (dataset: DatasetEntry, index: number): ReactElement => {
-    const viewerLink = PageRoutes.VIEWER + paramsToUrlQueryString(dataset.loadParams);
+    const viewerLink = `${PageRoutes.VIEWER}${paramsToUrlQueryString(dataset.loadParams)}`;
 
     return (
       <DatasetCard key={index}>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,9 @@
+import ErrorPage from "./ErrorPage";
+import LandingPage from "./LandingPage";
+
+export enum PageRoutes {
+  VIEWER = "viewer",
+  LANDING_PAGE = "/",
+}
+
+export { ErrorPage, LandingPage };

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,5 +1,7 @@
 import { UrlParams } from "../colorizer/utils/url_utils";
 
+import Collection from "../colorizer/Collection";
+
 export type DatasetEntry = {
   name: string;
   description: string;
@@ -14,4 +16,9 @@ export type ProjectEntry = {
   loadParams?: Partial<UrlParams>;
   datasets?: DatasetEntry[];
   inReview?: boolean;
+};
+
+export type LocationState = {
+  collection: Collection;
+  datasetKey: string;
 };


### PR DESCRIPTION
Problem
=======
Closes #267, adding the load button to the landing page.

*Estimated size: small, 20 minutes*

Solution
========
This required a big refactor of the loading button! Before, it would pass out the URL and wait for the viewer to try loading it and report back whether it loaded successfully. This change moves the load into the logic for the button itself, so the loading code isn't replicated between the landing page and the viewer.

I made a lot of code moves as part of this change which I could potentially split up into smaller PRs if needed.

- Refactors LoadButton to perform the test loading step, and to pass out the loaded dataset through a callback.
- Adds the LoadButton to the landing page; loading a dataset will cause it to switch to the viewer.
- Added a nice React hook for keeping track of recently loaded datasets.
  - I want to use this in a later refactor for #229 

## Type of change
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-268/
2. Open the load dialog and try loading any of the following datasets:
  - https://raw.githubusercontent.com/allen-cell-animated/nucmorph-colorizer/main/documentation/example_dataset/manifest.json
  - https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test
  - https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data/test/3500005828_25/ (single dataset)
4. Repeat step 2 on the viewer.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/3ef68480-5e1f-4160-b9d3-12e8339a3b59)
