### PR TITLE
fix: Fixed link to work with dev build

### DIFF
--- a/src/routes/LandingPage.tsx
+++ b/src/routes/LandingPage.tsx
@@ -27,7 +27,7 @@ export default function LandingPage(): ReactElement {
           <code>
             https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html
             <b>
-              <span style={{ color: "var(--color-text-theme)" }}>/#/viewer</span>
+              <span style={{ color: "var(--color-text-theme)" }}>#/viewer</span>
             </b>
             ?collection=....
           </code>


### PR DESCRIPTION
Problem
=======
Found out that the recommended link instructions I had put as a placeholder on the landing page is actually incorrect and results in a 404 error. This is a quick patch for it!

Broken link: https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html/#/viewer
Correct link: https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html#/viewer

*Estimated size: tiny, 1 minute*