### PR TITLE
feature: Handle v1.1.0 collection JSON schema

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -707,7 +707,7 @@ function Viewer(): ReactElement {
       <div ref={notificationContainer}>{notificationContextHolder}</div>
 
       <Header>
-        {/* <h3>Dataset Name</h3> */}
+        <h3>{collection?.metadata.name ?? null}</h3>
         <FlexRowAlignCenter $gap={12}>
           <FlexRowAlignCenter $gap={2}>
             <LoadDatasetButton onRequestLoad={handleLoadRequest} currentResourceUrl={collection?.url || datasetKey} />

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -1,19 +1,14 @@
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_DATASET_FILENAME } from "../constants";
+import {
+  CollectionEntry,
+  CollectionFile,
+  CollectionFileMetadata,
+  updateCollectionVersion,
+} from "./utils/collection_utils";
 import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout, formatPath, isJson, isUrl } from "./utils/url_utils";
 
 import Dataset from "./Dataset";
 
-/**
- * Dataset properties in a collection. Collections are defined as .json files containing an array of objects
- * with the following properties:
- *
- * - `path`: a relative path from the base directory of the collection URL, or a URL to a dataset.
- * - `name`: the display name for the dataset.
- */
-export type CollectionEntry = {
-  path: string;
-  name: string;
-};
 export type CollectionData = Map<string, CollectionEntry>;
 
 export type DatasetLoadResult =
@@ -34,6 +29,7 @@ export type DatasetLoadResult =
  */
 export default class Collection {
   private entries: CollectionData;
+  public metadata: Partial<CollectionFileMetadata>;
   /**
    * The URL this Collection was loaded from. `null` if this Collection is a placeholder object,
    * such as when generating dummy Collections for single datasets.
@@ -47,9 +43,10 @@ export default class Collection {
    * @param url the optional string url representing the source of the Collection. `null` by default.
    * @throws an error if a `path` is not a URL to a JSON resource.
    */
-  constructor(entries: CollectionData, url: string | null = null) {
+  constructor(entries: CollectionData, url: string | null = null, metadata: Partial<CollectionFileMetadata> = {}) {
     this.entries = entries;
     this.url = url ? Collection.formatAbsoluteCollectionPath(url) : url;
+    this.metadata = metadata;
 
     // Check that all entry paths are JSON urls.
     this.entries.forEach((value, key) => {
@@ -224,16 +221,22 @@ export default class Collection {
       throw new Error(`Could not retrieve collections JSON data from url '${absoluteCollectionUrl}': Fetch failed.`);
     }
 
-    const json = await response.json();
-    if (!Array.isArray(json)) {
-      throw new Error(
-        `Could not retrieve collections JSON data from url '${absoluteCollectionUrl}': JSON is not an array.`
-      );
+    let collection: CollectionFile;
+    try {
+      const json = await response.json();
+      collection = updateCollectionVersion(json);
+    } catch (e) {
+      throw new Error(`Could not parse collections JSON data from url '${absoluteCollectionUrl}': '${e}'`);
     }
 
     // Convert JSON array into map
+    if (collection.datasets.length === 0) {
+      throw new Error(
+        `Could not retrieve collections JSON data from url '${absoluteCollectionUrl}': No datasets found.`
+      );
+    }
     const collectionData: Map<string, CollectionEntry> = new Map();
-    for (const entry of json) {
+    for (const entry of collection.datasets) {
       collectionData.set(entry.name, entry);
     }
 
@@ -244,7 +247,7 @@ export default class Collection {
       collectionData.set(key, newEntry);
     });
 
-    return new Collection(collectionData, absoluteCollectionUrl);
+    return new Collection(collectionData, absoluteCollectionUrl, collection.metadata);
   }
 
   /**
@@ -260,6 +263,7 @@ export default class Collection {
     }
     const collectionData: CollectionData = new Map([[datasetUrl, { path: datasetUrl, name: datasetUrl }]]);
 
+    // TODO: Should the dummy collection copy the dataset's metadata?
     return new Collection(collectionData, null);
   }
 

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -47,6 +47,7 @@ export default class Collection {
     this.entries = entries;
     this.url = url ? Collection.formatAbsoluteCollectionPath(url) : url;
     this.metadata = metadata;
+    console.log("Collection metadata: ", this.metadata);
 
     // Check that all entry paths are JSON urls.
     this.entries.forEach((value, key) => {

--- a/src/colorizer/utils/collection_utils.ts
+++ b/src/colorizer/utils/collection_utils.ts
@@ -25,6 +25,7 @@ export type CollectionFileMetadata = {
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
+// v1.0.0 uses an array of collection entries.
 type CollectionFileV1_0_0 = CollectionEntry[];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -33,6 +34,7 @@ function isV1_0_0(collection: AnyCollectionFile): collection is CollectionFileV1
 }
 // ^ future versions will be able to use the metadata's writerVersion + semver to check!
 
+// v1.1.0 turns collections into an object with a `datasets` field and a `metadata` field.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type CollectionFileV1_1_0 = {
   datasets: CollectionEntry[];

--- a/src/colorizer/utils/collection_utils.ts
+++ b/src/colorizer/utils/collection_utils.ts
@@ -24,8 +24,8 @@ export type CollectionFileMetadata = {
   writerVersion: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 // v1.0.0 uses an array of collection entries.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type CollectionFileV1_0_0 = CollectionEntry[];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -46,7 +46,7 @@ export type CollectionFile = CollectionFileV1_1_0;
 type AnyCollectionFile = CollectionFileV1_0_0 | CollectionFileV1_1_0;
 
 /**
- * Converts potentially outdated collections to the latest manifest format.
+ * Converts potentially outdated collections to the latest schema.
  * @param collection Collection object, as parsed from a JSON file.
  * @returns An object with fields reflecting the most recent CollectionFile spec.
  */

--- a/src/colorizer/utils/collection_utils.ts
+++ b/src/colorizer/utils/collection_utils.ts
@@ -1,0 +1,64 @@
+// Defines types for working with dataset manifests, and methods for
+// updating manifests from one version to another.
+
+/**
+ * Dataset properties in a collection. Collections are defined as .json files containing an array of objects
+ * with the following properties:
+ *
+ * - `path`: a relative path from the base directory of the collection URL, or a URL to a dataset.
+ * - `name`: the display name for the dataset.
+ */
+export type CollectionEntry = {
+  path: string;
+  name: string;
+};
+
+export type CollectionFileMetadata = {
+  name: string;
+  description: string;
+  author: string;
+  collectionVersion: string;
+  lastModified: string;
+  dateCreated: string;
+  revision: number;
+  writerVersion: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type CollectionFileV1_0_0 = CollectionEntry[];
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function isV1_0_0(collection: AnyCollectionFile): collection is CollectionFileV1_0_0 {
+  return Array.isArray(collection);
+}
+// ^ future versions will be able to use the metadata's writerVersion + semver to check!
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type CollectionFileV1_1_0 = {
+  datasets: CollectionEntry[];
+  metadata: Partial<CollectionFileMetadata>;
+};
+
+export type CollectionFile = CollectionFileV1_1_0;
+
+type AnyCollectionFile = CollectionFileV1_0_0 | CollectionFileV1_1_0;
+
+/**
+ * Converts potentially outdated collections to the latest manifest format.
+ * @param collection Collection object, as parsed from a JSON file.
+ * @returns An object with fields reflecting the most recent CollectionFile spec.
+ */
+export const updateCollectionVersion = (collection: AnyCollectionFile): CollectionFile => {
+  if (isV1_0_0(collection)) {
+    return {
+      datasets: collection,
+      metadata: {},
+    };
+  }
+
+  if (collection.metadata === undefined) {
+    collection.metadata = {};
+  }
+
+  return collection;
+};

--- a/tests/Collection.test.ts
+++ b/tests/Collection.test.ts
@@ -70,7 +70,7 @@ describe("Collection", () => {
     it("should substitute default collection filename if URL is not a JSON", async () => {
       const url = "https://e.com";
       // Will only allow this exact fetch URL
-      const mockFetch = makeMockFetchMethod("https://e.com/" + DEFAULT_COLLECTION_FILENAME, []);
+      const mockFetch = makeMockFetchMethod("https://e.com/" + DEFAULT_COLLECTION_FILENAME, [{ name: "", path: "" }]);
 
       await Collection.loadCollection(url, mockFetch);
     });

--- a/tests/Collection.test.ts
+++ b/tests/Collection.test.ts
@@ -1,3 +1,4 @@
+import semver from "semver";
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_DATASET_FILENAME } from "../src/constants";
@@ -108,20 +109,22 @@ describe("Collection", () => {
           const mockFetch = makeMockFetchMethod(url, collectionJson);
           const collection = await Collection.loadCollection(url, mockFetch);
 
-          if (version === "v0.0.0") {
+          if (semver.lte(version, "v0.0.0")) {
             expect(collection.metadata).deep.equals({});
             return;
           }
 
-          // Test that all properties can be retrieved as stored
-          expect(collection.metadata.name).to.equal("c_name");
-          expect(collection.metadata.description).to.equal("c_description");
-          expect(collection.metadata.author).to.equal("c_author");
-          expect(collection.metadata.collectionVersion).to.equal("c_collectionVersion");
-          expect(collection.metadata.lastModified).to.equal("2024-01-01T00:00:00Z");
-          expect(collection.metadata.dateCreated).to.equal("2023-01-01T00:00:00Z");
-          expect(collection.metadata.revision).to.equal(15);
-          expect(collection.metadata.writerVersion).to.equal(version);
+          if (semver.gte(version, "v1.1.0")) {
+            // Test that all properties can be retrieved as stored
+            expect(collection.metadata.name).to.equal("c_name");
+            expect(collection.metadata.description).to.equal("c_description");
+            expect(collection.metadata.author).to.equal("c_author");
+            expect(collection.metadata.collectionVersion).to.equal("c_collectionVersion");
+            expect(collection.metadata.lastModified).to.equal("2024-01-01T00:00:00Z");
+            expect(collection.metadata.dateCreated).to.equal("2023-01-01T00:00:00Z");
+            expect(collection.metadata.revision).to.equal(15);
+            expect(collection.metadata.writerVersion).to.equal(version);
+          }
         });
       });
     }


### PR DESCRIPTION
Problem
=======
Closes #248 and closes #220! Updates the collection loader to handle the new v1.1.0 collection JSON schema, as described in https://github.com/allen-cell-animated/colorizer-data/pull/37, and shows the collection names (if provided) on the interface.

*Estimated size: small, 20 minutes*

Solution
========
- Adds a `collection_utils` file similar to the one that exists for datasets, which updates older legacy JSON files and updates them to the current format.
- Adds unit tests for the new collection and dataset JSON files.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

## Testing
1. Open this preview link and open the developer console: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-270/#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Ftest_v1.1.0%2Fcollection.json
2. You should see the name of the collection in the top header, and the collection metadata should include additional information about the collection.

Displayed name:
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/8468da13-a42a-4d15-b4c2-8f5e2632c43f)


Collection metadata:
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/67e0c182-ac05-4afd-9154-e657cd7e918c)
