### PR TITLE
feature: Handle v1.1.0 dataset JSON schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "gh-pages": "^5.0.0",
         "jsdom": "^22.1.0",
         "prettier": "^2.8.7",
+        "semver": "^7.6.0",
         "typescript": "^4.9.5",
         "vite": "^4.2.0",
         "vite-plugin-glsl": "^1.1.2",
@@ -316,6 +317,14 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
@@ -375,6 +384,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -402,6 +419,14 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
@@ -416,6 +441,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -1994,6 +2027,14 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -3347,21 +3388,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.59.11",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
@@ -3502,21 +3528,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.59.11",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.11.tgz",
@@ -3563,21 +3574,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -4443,6 +4439,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
@@ -6054,6 +6058,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-simple-import-sort": {
@@ -7675,21 +7688,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
@@ -8254,6 +8252,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8658,23 +8665,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/normalize-path": {
@@ -10892,11 +10882,18 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-error": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gh-pages": "^5.0.0",
     "jsdom": "^22.1.0",
     "prettier": "^2.8.7",
+    "semver": "^7.6.0",
     "typescript": "^4.9.5",
     "vite": "^4.2.0",
     "vite-plugin-glsl": "^1.1.2",

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -319,6 +319,7 @@ export default class Dataset {
     this.frameFiles = manifest.frames;
     this.outlierFile = manifest.outliers;
     this.metadata = { ...defaultMetadata, ...manifest.metadata };
+    console.log("Dataset metadata:", this.metadata);
 
     this.tracksFile = manifest.tracks;
     this.timesFile = manifest.times;

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -2,6 +2,7 @@
 // updating manifests from one version to another.
 import { Spread } from "./type_utils";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileMetadataV0_0_0 = {
   /** Dimensions of the frame, in scale units. Default width and height are 0. */
   frameDims: {
@@ -14,6 +15,7 @@ type ManifestFileMetadataV0_0_0 = {
   startTimeSeconds: number;
 };
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileMetadataV1_1_0 = ManifestFileMetadataV0_0_0 &
   Partial<{
     name: string;
@@ -68,6 +70,7 @@ type ManifestFileV1_0_0 = Spread<
 >;
 
 // v1.1.0 adds additional optional metadata fields.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileV1_1_0 = Spread<
   ManifestFileV1_0_0 & {
     metadata?: Partial<ManifestFileMetadataV1_1_0>;

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -2,6 +2,14 @@
 // updating manifests from one version to another.
 
 export type ManifestFileMetadata = {
+  name?: string;
+  description?: string;
+  author?: string;
+  datasetVersion?: string;
+  lastModified?: string;
+  dateCreated?: string;
+  revision?: number;
+  writerVersion?: string;
   /** Dimensions of the frame, in scale units. Default width and height are 0. */
   frameDims: {
     width: number;
@@ -13,7 +21,8 @@ export type ManifestFileMetadata = {
   startTimeSeconds: number;
 };
 
-type ManifestFileV1 = {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type ManifestFileV0_0_0 = {
   frames: string[];
   /** Map from feature name to relative path */
   features: Record<string, string>;
@@ -34,9 +43,10 @@ type ManifestFileV1 = {
   metadata?: Partial<ManifestFileMetadata>;
 };
 
-// V2 removes the featureMetadata field, replaces the features map with an ordered
+// v1.0.0 removes the featureMetadata field, replaces the features map with an ordered
 // array of metadata objects.
-type ManifestFileV2 = Omit<ManifestFileV1, "features" | "featureMetadata"> & {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata"> & {
   features: {
     name: string;
     data: string;
@@ -50,9 +60,9 @@ type ManifestFileV2 = Omit<ManifestFileV1, "features" | "featureMetadata"> & {
 };
 
 /** Type definition for the dataset manifest JSON file. */
-export type ManifestFile = ManifestFileV2;
+export type ManifestFile = ManifestFileV1_0_0;
 /** Any manifest version, including deprecated manifests. Call `update_manifest_version` to transform to an up-to-date version. */
-export type AnyManifestFile = ManifestFileV1 | ManifestFileV2;
+export type AnyManifestFile = ManifestFileV0_0_0 | ManifestFileV1_0_0;
 
 ///////////// Conversion functions /////////////////////
 
@@ -60,7 +70,8 @@ export type AnyManifestFile = ManifestFileV1 | ManifestFileV2;
  * Returns whether the dataset is using the older, deprecated manifest format, where feature metadata
  * was stored in a separate object from the `feature` file path declaration.
  */
-function isV1(manifest: AnyManifestFile): manifest is ManifestFileV1 {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function isV0_0_0(manifest: AnyManifestFile): manifest is ManifestFileV0_0_0 {
   return typeof Object.values(manifest.features)[0] === "string";
 }
 
@@ -70,7 +81,7 @@ function isV1(manifest: AnyManifestFile): manifest is ManifestFileV1 {
  * @returns An object with fields reflecting the most recent ManifestFile spec.
  */
 export const updateManifestVersion = (manifest: AnyManifestFile): ManifestFile => {
-  if (isV1(manifest)) {
+  if (isV0_0_0(manifest)) {
     // Parse feature metadata into the new features format
     const features: ManifestFile["features"] = [];
     for (const [featureName, featurePath] of Object.entries(manifest.features)) {

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -64,14 +64,20 @@ type ManifestFileV1_0_0 = Spread<
     }[];
     /** Optional list of backdrop/overlay images. */
     backdrops?: { name: string; key: string; frames: string[] }[];
+  }
+>;
+
+// v1.1.0 adds additional optional metadata fields.
+type ManifestFileV1_1_0 = Spread<
+  ManifestFileV1_0_0 & {
     metadata?: Partial<ManifestFileMetadataV1_1_0>;
   }
 >;
 
 /** Type definition for the dataset manifest JSON file. */
-export type ManifestFile = ManifestFileV1_0_0;
+export type ManifestFile = ManifestFileV1_1_0;
 /** Any manifest version, including deprecated manifests. Call `update_manifest_version` to transform to an up-to-date version. */
-export type AnyManifestFile = ManifestFileV0_0_0 | ManifestFileV1_0_0;
+export type AnyManifestFile = ManifestFileV0_0_0 | ManifestFileV1_0_0 | ManifestFileV1_1_0;
 
 ///////////// Conversion functions /////////////////////
 

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -1,15 +1,8 @@
 // Defines types for working with dataset manifests, and methods for
 // updating manifests from one version to another.
+import { Spread } from "./type_utils";
 
-export type ManifestFileMetadata = {
-  name?: string;
-  description?: string;
-  author?: string;
-  datasetVersion?: string;
-  lastModified?: string;
-  dateCreated?: string;
-  revision?: number;
-  writerVersion?: string;
+type ManifestFileMetadataV0_0_0 = {
   /** Dimensions of the frame, in scale units. Default width and height are 0. */
   frameDims: {
     width: number;
@@ -20,6 +13,20 @@ export type ManifestFileMetadata = {
   /* Optional offset for the timestamp. */
   startTimeSeconds: number;
 };
+
+type ManifestFileMetadataV1_1_0 = ManifestFileMetadataV0_0_0 &
+  Partial<{
+    name: string;
+    description: string;
+    author: string;
+    datasetVersion: string;
+    lastModified: string;
+    dateCreated: string;
+    revision: number;
+    writerVersion: string;
+  }>;
+
+export type ManifestFileMetadata = Spread<ManifestFileMetadataV1_1_0>;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 type ManifestFileV0_0_0 = {
@@ -40,24 +47,26 @@ type ManifestFileV0_0_0 = {
   times?: string;
   centroids?: string;
   bounds?: string;
-  metadata?: Partial<ManifestFileMetadata>;
+  metadata?: Partial<ManifestFileMetadataV0_0_0>;
 };
 
 // v1.0.0 removes the featureMetadata field, replaces the features map with an ordered
 // array of metadata objects.
 // eslint-disable-next-line @typescript-eslint/naming-convention
-type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata"> & {
-  features: {
-    name: string;
-    data: string;
-    units?: string;
-    type?: string;
-    categories?: string[];
-  }[];
-  /** Optional list of backdrop/overlay images. */
-  backdrops?: { name: string; key: string; frames: string[] }[];
-  version: "2.0.0";
-};
+type ManifestFileV1_0_0 = Spread<
+  Omit<ManifestFileV0_0_0, "features" | "featureMetadata" | "metadata"> & {
+    features: {
+      name: string;
+      data: string;
+      units?: string;
+      type?: string;
+      categories?: string[];
+    }[];
+    /** Optional list of backdrop/overlay images. */
+    backdrops?: { name: string; key: string; frames: string[] }[];
+    metadata?: Partial<ManifestFileMetadataV1_1_0>;
+  }
+>;
 
 /** Type definition for the dataset manifest JSON file. */
 export type ManifestFile = ManifestFileV1_0_0;
@@ -98,7 +107,6 @@ export const updateManifestVersion = (manifest: AnyManifestFile): ManifestFile =
     return {
       ...manifest,
       features,
-      version: "2.0.0",
     };
   }
   return manifest;

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -55,19 +55,17 @@ type ManifestFileV0_0_0 = {
 // v1.0.0 removes the featureMetadata field, replaces the features map with an ordered
 // array of metadata objects.
 // eslint-disable-next-line @typescript-eslint/naming-convention
-type ManifestFileV1_0_0 = Spread<
-  Omit<ManifestFileV0_0_0, "features" | "featureMetadata" | "metadata"> & {
-    features: {
-      name: string;
-      data: string;
-      units?: string;
-      type?: string;
-      categories?: string[];
-    }[];
-    /** Optional list of backdrop/overlay images. */
-    backdrops?: { name: string; key: string; frames: string[] }[];
-  }
->;
+type ManifestFileV1_0_0 = Omit<ManifestFileV0_0_0, "features" | "featureMetadata" | "metadata"> & {
+  features: {
+    name: string;
+    data: string;
+    units?: string;
+    type?: string;
+    categories?: string[];
+  }[];
+  /** Optional list of backdrop/overlay images. */
+  backdrops?: { name: string; key: string; frames: string[] }[];
+};
 
 // v1.1.0 adds additional optional metadata fields.
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/colorizer/utils/type_utils.ts
+++ b/src/colorizer/utils/type_utils.ts
@@ -9,3 +9,10 @@
  * ```
  */
 export type RecordValue<T extends Record<any, any>> = T extends Record<any, infer U> ? U : never;
+
+/**
+ * Remaps types that are compound types so the keys are exposed at a top-level.
+ * This is primarily useful for use with Intellisense and other type-aware tools.
+ * https://dev.to/kirkcodes/revealing-compound-types-in-typescript-2ic8
+ */
+export type Spread<Type> = { [Key in keyof Type]: Type[Key] };

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -65,6 +65,7 @@ describe("Dataset", () => {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   const manifestV0_0_0: AnyManifestFile = {
     frames: ["frame0.json"],
     features: {
@@ -83,6 +84,7 @@ describe("Dataset", () => {
     },
   };
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   const manifestV1_0_0: AnyManifestFile = {
     ...manifestV0_0_0,
     features: [
@@ -104,6 +106,7 @@ describe("Dataset", () => {
     },
   };
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   const manifestV1_1_0: ManifestFile = {
     ...manifestV1_0_0,
     metadata: {

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -1,3 +1,4 @@
+import semver from "semver";
 import { DataTexture, RGBAFormat, Texture, UnsignedByteType, Vector2 } from "three";
 import { describe, expect, it } from "vitest";
 
@@ -64,19 +65,7 @@ describe("Dataset", () => {
     }
   }
 
-  const defaultManifest: ManifestFile = {
-    frames: ["frame0.json"],
-    features: [
-      { name: "feature1", data: "feature1.json", units: "meters", type: "continuous" },
-      { name: "feature2", data: "feature2.json", units: "(m)", type: "discrete" },
-      { name: "feature3", data: "feature3.json", units: "μm/s", type: "bad-type" },
-      { name: "feature4", data: "feature4.json" },
-      { name: "feature5", data: "feature4.json", type: "categorical", categories: ["small", "medium", "large"] },
-    ],
-    version: "2.0.0",
-  };
-
-  const manifestV1: AnyManifestFile = {
+  const manifestV0_0_0: AnyManifestFile = {
     frames: ["frame0.json"],
     features: {
       feature1: "feature1.json",
@@ -94,14 +83,51 @@ describe("Dataset", () => {
     },
   };
 
+  const manifestV1_0_0: AnyManifestFile = {
+    ...manifestV0_0_0,
+    features: [
+      { name: "feature1", data: "feature1.json", units: "meters", type: "continuous" },
+      { name: "feature2", data: "feature2.json", units: "(m)", type: "discrete" },
+      { name: "feature3", data: "feature3.json", units: "μm/s", type: "bad-type" },
+      { name: "feature4", data: "feature4.json" },
+      { name: "feature5", data: "feature4.json", type: "categorical", categories: ["small", "medium", "large"] },
+    ],
+    metadata: {
+      frameDims: {
+        width: 10,
+        height: 11,
+        units: "um",
+      },
+      frameDurationSeconds: 12,
+      /* Optional offset for the timestamp. */
+      startTimeSeconds: 13,
+    },
+  };
+
+  const manifestV1_1_0: ManifestFile = {
+    ...manifestV1_0_0,
+    metadata: {
+      ...manifestV1_0_0.metadata,
+      name: "d_name",
+      description: "d_description",
+      author: "d_author",
+      datasetVersion: "d_datasetVersion",
+      lastModified: "2024-01-01T00:00:00Z",
+      dateCreated: "2023-01-01T00:00:00Z",
+      revision: 14,
+      writerVersion: "v1.1.0",
+    },
+  };
+
   const manifestsToTest: [string, AnyManifestFile][] = [
-    ["Default Manifest", defaultManifest],
-    ["Deprecated Manifest V1", manifestV1],
+    ["v0.0.0", manifestV0_0_0],
+    ["v1.0.0", manifestV1_0_0],
+    ["v1.1.0", manifestV1_1_0],
   ];
 
   // Test both normal and deprecated manifests
-  for (const [name, manifest] of manifestsToTest) {
-    describe(name, () => {
+  for (const [version, manifest] of manifestsToTest) {
+    describe(version, () => {
       it("retrieves feature units", async () => {
         const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
         const mockFetch = makeMockFetchMethod(defaultPath, manifest);
@@ -208,6 +234,46 @@ describe("Dataset", () => {
           expect(dataset.frameResolution).to.deep.equal(new Vector2(1, 1));
           await dataset.open(mockFetch);
           expect(dataset.frameResolution).to.deep.equal(new Vector2(width, height));
+        }
+      });
+
+      it("Loads metadata", async () => {
+        const dataset = new Dataset(defaultPath, new MockFrameLoader(), new MockArrayLoader());
+        const mockFetch = makeMockFetchMethod(defaultPath, manifest);
+        await dataset.open(mockFetch);
+
+        // Default metadata should be auto-filled with default values
+        if (semver.lt(version, "1.0.0")) {
+          expect(dataset.metadata).to.deep.equal({
+            frameDims: {
+              width: 0,
+              height: 0,
+              units: "",
+            },
+            frameDurationSeconds: 0,
+            startTimeSeconds: 0,
+          });
+          return;
+        }
+
+        if (semver.gte(version, "1.0.0")) {
+          expect(dataset.metadata.frameDims).to.deep.equal({
+            width: 10,
+            height: 11,
+            units: "um",
+          });
+          expect(dataset.metadata.frameDurationSeconds).to.equal(12);
+          expect(dataset.metadata.startTimeSeconds).to.equal(13);
+        }
+        if (semver.gte(version, "1.1.0")) {
+          expect(dataset.metadata.name).to.equal("d_name");
+          expect(dataset.metadata.description).to.equal("d_description");
+          expect(dataset.metadata.author).to.equal("d_author");
+          expect(dataset.metadata.datasetVersion).to.equal("d_datasetVersion");
+          expect(dataset.metadata.lastModified).to.equal("2024-01-01T00:00:00Z");
+          expect(dataset.metadata.dateCreated).to.equal("2023-01-01T00:00:00Z");
+          expect(dataset.metadata.revision).to.equal(14);
+          expect(dataset.metadata.writerVersion).to.equal("v1.1.0");
         }
       });
     });


### PR DESCRIPTION
Problem
=======
Adds additional dataset metadata as part of the fix for #248.

*Estimated size: small, 15 minutes (please turn off whitespace changes)*

Solution
========
- Renames manifest versions using their semantic versioning counterparts
- Adds unit tests for loading the new metadata fields from the dataset manifest JSON file.

### Testing:
- Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-272/#/viewer?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Ftest_v1.1.0%2F3500005807_1%2Fmanifest.json
- In the developer console, you should see additional metadata exported with the dataset:
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/59e23075-7029-4f34-8850-31f494aa1624)
