### PR TITLE
fix: View updates when going to uncached time value

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -251,6 +251,7 @@ function Viewer(): ReactElement {
       await canv.setFrame(frame);
       setCurrentFrame(frame);
       setFrameInput(frame);
+      canv.render();
     },
     [canv]
   );


### PR DESCRIPTION
Problem
=======
Closes #254!

> When dragging the time slider, sometimes the viewport does not update until after the time slider is touched again. (May be a bug with the canvas not re-rendering after a time change, because triggering a re-render through other actions causes it to update.)

*Estimated review size: Tiny, 2 minutes*

Solution
========
- Forces re-render after frame is updated in the Viewer.

Steps to Verify:
----------------
Broken build: https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fmicroscopy%2FClusterOutput%2FH2B_Deliverable_AnalysisPipelineOutput%2FH2B_Deliverable_InputImages_123Timelapses_Composite_Output%2Fcolorizer%2Fcollection.json&bg-key=png_overlay_nucobjnum
Fixed build: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-274/#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fmicroscopy%2FClusterOutput%2FH2B_Deliverable_AnalysisPipelineOutput%2FH2B_Deliverable_InputImages_123Timelapses_Composite_Output%2Fcolorizer%2Fcollection.json&bg-key=png_overlay_nucobjnum

1. Grab the time slider and quickly slide to a different time value, then release immediately. In the broken build, this will cause the visible frame to freeze on the old time value instead of updating.