### PR TITLE
fix: Recent datasets includes datasets loaded from URL

### DIFF
--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -200,6 +200,17 @@ export default class Collection {
     return this.formatDatasetPath(collectionDirectory + "/" + datasetPath);
   }
 
+  // TODO: Refactor how dummy collections store URLs? The URL should always be a valid resource maybe?
+  /**
+   * Returns a URL to the collection or dataset.
+   */
+  public getUrl(): string {
+    if (this.url === null) {
+      return this.entries.get(this.getDefaultDatasetKey())!.path;
+    }
+    return this.url;
+  }
+
   // ===================================================================================
   // Static Loader Methods
 

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -199,26 +199,22 @@ export function useScrollShadow(shadowColor: string = "#00000030"): {
 const RECENT_COLLECTIONS_STORAGE_KEY = "recentDatasets";
 const MAX_RECENT_COLLECTIONS = 10;
 
-export type StoredRecentCollection = {
+export type RecentCollection = {
   /** The absolute URL path of the collection resource. */
   url: string;
   /**
    * The user input for the collection resource.
    * If `undefined`, uses the existing label (if already in recent datasets) or reuses the URL (if new).
    */
-  label: string;
-};
-
-export type RecentCollection = Partial<StoredRecentCollection> & {
-  url: string;
+  label?: string;
 };
 
 /**
  * Wrapper around locally-stored recent collections.
  * @returns an array containing the list of recent collections and a function to add a new collection to the list.
  */
-export const useRecentCollections = (): [StoredRecentCollection[], (collection: RecentCollection) => void] => {
-  const [recentCollections, setRecentCollections] = useLocalStorage<StoredRecentCollection[]>(
+export const useRecentCollections = (): [RecentCollection[], (collection: RecentCollection) => void] => {
+  const [recentCollections, setRecentCollections] = useLocalStorage<RecentCollection[]>(
     RECENT_COLLECTIONS_STORAGE_KEY,
     []
   );
@@ -230,10 +226,7 @@ export const useRecentCollections = (): [StoredRecentCollection[], (collection: 
       if (collection.label === undefined) {
         collection.label = collection.url;
       }
-      setRecentCollections([
-        collection as StoredRecentCollection,
-        ...recentCollections.slice(0, MAX_RECENT_COLLECTIONS - 1),
-      ]);
+      setRecentCollections([collection as RecentCollection, ...recentCollections.slice(0, MAX_RECENT_COLLECTIONS - 1)]);
     } else {
       if (collection.label === undefined) {
         // Reuse existing label
@@ -241,7 +234,7 @@ export const useRecentCollections = (): [StoredRecentCollection[], (collection: 
       }
       // Move to front; this also updates the label if it changed.
       setRecentCollections([
-        collection as StoredRecentCollection,
+        collection as RecentCollection,
 
         ...recentCollections.slice(0, datasetIndex),
         ...recentCollections.slice(datasetIndex + 1),

--- a/src/colorizer/utils/react_utils.ts
+++ b/src/colorizer/utils/react_utils.ts
@@ -199,25 +199,38 @@ export function useScrollShadow(shadowColor: string = "#00000030"): {
 const RECENT_DATASETS_STORAGE_KEY = "recentDatasets";
 const MAX_RECENT_DATASETS = 10;
 
-export type RecentDataset = {
+export type RecentCollection = {
   /** The absolute URL path of the dataset resource. */
   url: string;
-  /** The user input for the dataset resource. */
+  /**
+   * The user input for the dataset resource.
+   * If `null`, uses the existing label (if already in recent datasets) or reuse the URL (if new).
+   */
   label: string;
 };
 
-export const useRecentDatasets = (): [RecentDataset[], (dataset: RecentDataset) => void] => {
-  const [recentDatasets, setRecentDatasets] = useLocalStorage<RecentDataset[]>(RECENT_DATASETS_STORAGE_KEY, []);
+/**
+ * Wrapper around locally-stored recent collections.
+ * @returns an array containing the list of recent collections and a function to add a new collection to the list.
+ */
+export const useRecentCollections = (): [RecentCollection[], (collection: RecentCollection) => void] => {
+  const [recentCollections, setRecentCollections] = useLocalStorage<RecentCollection[]>(
+    RECENT_DATASETS_STORAGE_KEY,
+    []
+  );
 
-  const addRecentDataset = (dataset: RecentDataset): void => {
-    const datasetIndex = recentDatasets.findIndex(({ url }) => url === dataset.url);
+  const addRecentCollection = (collection: RecentCollection): void => {
+    const datasetIndex = recentCollections.findIndex(({ url }) => url === collection.url);
     if (datasetIndex === -1) {
-      // New dataset, add to front while maintaining max length
-      setRecentDatasets([dataset, ...recentDatasets.slice(0, MAX_RECENT_DATASETS - 1)]);
+      setRecentCollections([collection, ...recentCollections.slice(0, MAX_RECENT_DATASETS - 1)]);
     } else {
       // Move to front; this also updates the label if it changed.
-      setRecentDatasets([dataset, ...recentDatasets.slice(0, datasetIndex), ...recentDatasets.slice(datasetIndex + 1)]);
+      setRecentCollections([
+        collection,
+        ...recentCollections.slice(0, datasetIndex),
+        ...recentCollections.slice(datasetIndex + 1),
+      ]);
     }
   };
-  return [recentDatasets, addRecentDataset];
+  return [recentCollections, addRecentCollection];
 };

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { useClickAnyWhere } from "usehooks-ts";
 
 import { Dataset } from "../colorizer";
-import { useRecentDatasets } from "../colorizer/utils/react_utils";
+import { useRecentCollections } from "../colorizer/utils/react_utils";
 import { convertAllenPathToHttps, isAllenPath } from "../colorizer/utils/url_utils";
 
 import Collection from "../colorizer/Collection";
@@ -78,7 +78,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     _setUrlInput(newUrl);
   }, []);
 
-  const [recentDatasets, registerDataset] = useRecentDatasets();
+  const [recentCollections, registerCollection] = useRecentCollections();
 
   const [isLoading, setIsLoading] = useState(false);
   const [errorText, setErrorText] = useState<string>("");
@@ -176,7 +176,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
           setIsLoadModalOpen(false);
           setIsLoading(false);
           // Add to recent datasets
-          registerDataset({
+          registerCollection({
             url: loadedUrl,
             label: urlInput, // Use raw url input for the label
           });
@@ -212,7 +212,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
 
   // RENDERING ////////////////////////////////////////////////////////
 
-  const datasetsDropdownItems: MenuItemType[] = recentDatasets.map(({ url, label }) => {
+  const datasetsDropdownItems: MenuItemType[] = recentCollections.map(({ url, label }) => {
     const isCurrentUrl = props.currentResourceUrl === url;
     return {
       key: url,
@@ -224,11 +224,11 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
   });
 
   // Get the URLs (keys) of any recent datasets that match the currently selected urlInput.
-  const matchingKeys = recentDatasets.filter(({ label }) => label === urlInput).map(({ url }) => url);
+  const matchingKeys = recentCollections.filter(({ label }) => label === urlInput).map(({ url }) => url);
   const datasetsDropdownProps: MenuProps = {
     onClick: (info) => {
       // Set the URL input to the label of the selected dataset
-      const dataset = recentDatasets.find(({ url }) => url === info.key);
+      const dataset = recentCollections.find(({ url }) => url === info.key);
       if (dataset) {
         setUrlInput(dataset.label);
       }

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -229,7 +229,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
       // Set the URL input to the label of the selected collection
       const collection = recentCollections.find(({ url }) => url === info.key);
       if (collection) {
-        setUrlInput(collection.label);
+        setUrlInput(collection.label ?? collection.url);
       }
     },
     items: collectionsDropdownItems,

--- a/src/components/LoadDatasetButton.tsx
+++ b/src/components/LoadDatasetButton.tsx
@@ -245,6 +245,8 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
     </DropdownContentContainer>
   );
 
+  const isRecentDropdownEmpty = recentCollections.length === 0;
+
   return (
     <div ref={modalContextRef}>
       <TextButton onClick={() => setIsLoadModalOpen(true)}>
@@ -274,7 +276,7 @@ export default function LoadDatasetButton(props: LoadDatasetButtonProps): ReactE
                   trigger={["click"]}
                   menu={collectionsDropdownProps}
                   placement="bottomLeft"
-                  open={showRecentDropdown}
+                  open={showRecentDropdown && !isRecentDropdownEmpty}
                   getPopupContainer={dropdownContextRef.current ? () => dropdownContextRef.current! : undefined}
                   dropdownRender={renderDropdown}
                 >


### PR DESCRIPTION
Problem
=======
Closes #229, "Opening dataset from URL does not update the recent datasets dropdown in Load menu". Also makes some other fixes to the `LoadDatasetButton` and dataset loading behaviors.

*Estimated review size: small, 20 minutes*

Solution
========
I did some other refactors as part of this change, so this PR is not as focused as I would have liked to be. I tried to comment everywhere I made changes to justify my reasoning!

- The viewer page now saves loaded URLs to the recent datasets dropdown.
- Adds improved error messaging when loading datasets from the URL fails.
- Hides the dropdown if there are no recent datasets.
- Made the currently loaded dataset clickable.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link **in incognito/private mode**: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-275/#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json
2. Click the Load button. The current collection should be visible in the recent datasets dropdown.
3. In the same incognito/private window, open this preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-275/#/viewer?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2F3500005828_25%2Fmanifest.json
4. **Click the Load button. Both datasets should appear in the Load button dropdown.** 
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/ff612eed-ed8a-4cdf-95bb-1c6a03bf3d6a)


Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/b4f2c464-460b-446f-8792-45fadb5cfd5d)
