### PR TITLE
Fix AWS deploy example

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -62,7 +62,7 @@ jobs:
               fi          
               
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync . ${{ env.S3_BUCKET }}
+            run: aws s3 sync src/assets ${{ env.S3_BUCKET }}  # the src/assets is an arbitrary directory chosen for demonstration purposes
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -14,7 +14,6 @@ on:
             type: choice
        
 env:
-  # TODO: Verify what these values are for the allen-cell-animated Github organization
   AWS_ACCOUNT_ID: ${{ vars.AWS_PUBLIC_DATA_RELEASES_ACCOUNT_ID }}
   AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
   STAGING_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.STAGING_CLOUDFRONT_DISTRIBUTION_ID }}
@@ -63,7 +62,7 @@ jobs:
               fi          
 
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync ./index.html ${{ env.S3_BUCKET }}
+            run: aws s3 sync index.html ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -64,9 +64,9 @@ jobs:
           # the src/assets directory below was chosen arbitrarily for demonstration purposes and should be replaced 
           # with the actual directory containing the files to be uploaded to S3
           # 
-          # Note that the below will copy the files to the root of the S3 bucket. If you want to copy them to a subdirectory,
-          # you would want something like ${{ env.S3_BUCKET }}/your_subdirectory below      
-          - name: Write an arbitrary file to S3 - just to demonstrate how. 
+          # Note that the command below will copy the files to the root of the S3 bucket e.g., s3://timelapse.allencell.org/ 
+          # If you want to copy files to a S3 prefix / subdirectory, you would want something like ${{ env.S3_BUCKET }}/your_prefix below      
+          - name: Sync an arbitrary directory to S3 - just to demonstrate how. 
             run: aws s3 sync src/assets ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -61,8 +61,11 @@ jobs:
                 exit 1
               fi          
 
+          - name: DEBUG - pwd
+            run: pwd
+            
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync index.html ${{ env.S3_BUCKET }}
+            run: aws s3 sync ../index.html ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -1,5 +1,5 @@
 ---
-name: Sample workflow to demonstrate AWS deployment including publishing data to S3 and invalidating a CloudFront distribution cache
+name: AWS Deploy Example
 
 on: 
   workflow_dispatch:
@@ -63,9 +63,12 @@ jobs:
 
           - name: DEBUG - pwd
             run: pwd
-            
+
+          - name: DEBUG - ls
+            run: ls -al
+
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync ../index.html ${{ env.S3_BUCKET }}
+            run: aws s3 sync .index.html ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -60,13 +60,7 @@ jobs:
                 echo "Invalid environment specified"
                 exit 1
               fi          
-
-          - name: DEBUG - pwd
-            run: pwd
-
-          - name: DEBUG - ls
-            run: ls -al
-
+              
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
             run: aws s3 sync . ${{ env.S3_BUCKET }}
 

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -61,8 +61,13 @@ jobs:
                 exit 1
               fi          
               
+          # the src/assets directory below was chosen arbitrarily for demonstration purposes and should be replaced 
+          # with the actual directory containing the files to be uploaded to S3
+          # 
+          # Note that the below will copy the files to the root of the S3 bucket. If you want to copy them to a subdirectory,
+          # you would want something like ${{ env.S3_BUCKET }}/your_subdirectory below      
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync src/assets ${{ env.S3_BUCKET }}  # the src/assets is an arbitrary directory chosen for demonstration purposes
+            run: aws s3 sync src/assets ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -68,7 +68,7 @@ jobs:
             run: ls -al
 
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync ./index.html ${{ env.S3_BUCKET }}
+            run: aws s3 sync . ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -68,7 +68,7 @@ jobs:
             run: ls -al
 
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync . ${{ env.S3_BUCKET }}
+            run: aws s3 sync ./index.html ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -68,7 +68,7 @@ jobs:
             run: ls -al
 
           - name: Write an arbitrary file to S3 - just to demonstrate how. 
-            run: aws s3 sync .index.html ${{ env.S3_BUCKET }}
+            run: aws s3 sync . ${{ env.S3_BUCKET }}
 
           - name: Invalidate CloudFront cache
             run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
Problem
=======
This PR fixes the AWS deploy example (wherein files are uploaded to S3 and a CloudFront cache is invalidated) where there is currently an error in the `aws s3 sync ...` command. 

* [#56382596](https://github.com/orgs/AllenCellSoftware/projects/10?pane=issue&itemId=56382596)

Solution
========
This is a fairly small change set to clarify some comments and fix the `aws s3 sync ...` command. 

## Type of change

* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Fix `aws s3 sync ...` command to correctly sync a directory to the S3 bucket 
* Update comments to guide future development 

Steps to Verify:
----------------

Manually running the [`AWS Deploy Example` Github Actions workflow](https://github.com/allen-cell-animated/nucmorph-colorizer/actions/workflows/aws-deploy.yml) and verifying that it finishes successfully and the result is files being available in [the S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/staging.timelapse.allencell.org?region=us-west-2&bucketType=general&tab=objects). 