### PR TITLE
refactor: Lowered default video export FPS to 12

### DIFF
--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -133,7 +133,7 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   const [imagePrefix, setImagePrefix] = useState(props.defaultImagePrefix);
   const [useDefaultImagePrefix, setUseDefaultImagePrefix] = useState(true);
   const [frameIncrement, setFrameIncrement] = useState(1);
-  const [fps, setFps] = useState(30);
+  const [fps, setFps] = useState(12);
   const [videoBitsPerSecond, setVideoBitsPerSecond] = useState(VideoBitrate.MEDIUM);
 
   const [percentComplete, setPercentComplete] = useState(0);


### PR DESCRIPTION
Problem
=======
Lowered default video export FPS because 30 FPS is generally too high for most use cases.

*Estimated review size: tiny, 1 minute*