### PR TITLE
refactor: Added styled wrapper for the static modal API

### DIFF
--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -9,9 +9,9 @@ import { FlexRow } from "../styles/utils";
 import CanvasRecorder, { RecordingOptions } from "../colorizer/recorders/CanvasRecorder";
 import ImageSequenceRecorder from "../colorizer/recorders/ImageSequenceRecorder";
 import Mp4VideoRecorder, { VideoBitrate } from "../colorizer/recorders/Mp4VideoRecorder";
-import { AppThemeContext, DocumentContext } from "./AppStyle";
+import { AppThemeContext } from "./AppStyle";
 import TextButton from "./Buttons/TextButton";
-import StyledModal from "./Modals/StyledModal";
+import StyledModal, { useStyledModal } from "./Modals/StyledModal";
 import { SettingsContainer, SettingsItem } from "./SettingsContainer";
 import SpinBox from "./SpinBox";
 
@@ -99,7 +99,6 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   const props = { ...defaultProps, ...inputProps } as Required<ExportButtonProps>;
 
   const theme = useContext(AppThemeContext);
-  const { modalContainerRef } = useContext(DocumentContext);
 
   const enum RangeMode {
     ALL,
@@ -116,7 +115,8 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   // Used here for the cancel modal and the success notification.
   // Note: notification API seems to only place notifications at the top-level under the
   // <body> tag, which causes some issues with styling.
-  const { modal, notification } = App.useApp();
+  const { notification } = App.useApp();
+  const modal = useStyledModal();
 
   const originalFrameRef = useRef(props.currentFrame);
   const [isModalOpen, _setIsModalOpen] = useState(false);
@@ -219,12 +219,11 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
       cancelText: "Back",
       centered: true,
       icon: null,
-      getContainer: modalContainerRef || undefined,
       onOk: () => {
         stopRecording(true);
       },
     });
-  }, [isRecording, modalContainerRef, stopRecording]);
+  }, [isRecording, stopRecording]);
 
   /**
    * Stop the recording without closing the modal.

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -211,6 +211,7 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
       return;
     }
 
+    // TODO: Close the modal if the recording is done, but the modal is still open.
     // Currently recording; user must be prompted to confirm
     modal.confirm({
       title: "Cancel export",

--- a/src/components/Modals/StyledModal.tsx
+++ b/src/components/Modals/StyledModal.tsx
@@ -43,7 +43,7 @@ const addContainerToUpdateMethodProps = (
  * Wrapper for Ant's static modal functions. The wrapper injects the modal container reference
  * into the props for both the static modal function and its returned updater method.
  */
-const wrappedStaticModalFunctionFactory = (
+const wrapStaticModalFunction = (
   modalContainerRef: ContainerRef,
   modalFunction: AntModalApiFunction
 ): AntModalApiFunction => {
@@ -66,6 +66,7 @@ const wrappedStaticModalFunctionFactory = (
  * @example
  * ```
  * const MyButton = (): ReactElement => {
+ *   // before: const { modal } = App.useApp();
  *   const modal = useStyledModal();
  *   return <Button
  *      onClick={() => modal.info({title: "An info modal", content: "Some information here"})}
@@ -81,11 +82,11 @@ export const useStyledModal = (): AntModalApi => {
   const { modalContainerRef } = useContext(DocumentContext);
   const { modal } = App.useApp();
   return {
-    confirm: wrappedStaticModalFunctionFactory(modalContainerRef, modal.confirm),
-    info: wrappedStaticModalFunctionFactory(modalContainerRef, modal.info),
-    success: wrappedStaticModalFunctionFactory(modalContainerRef, modal.success),
-    error: wrappedStaticModalFunctionFactory(modalContainerRef, modal.error),
-    warning: wrappedStaticModalFunctionFactory(modalContainerRef, modal.warning),
+    confirm: wrapStaticModalFunction(modalContainerRef, modal.confirm),
+    info: wrapStaticModalFunction(modalContainerRef, modal.info),
+    success: wrapStaticModalFunction(modalContainerRef, modal.success),
+    error: wrapStaticModalFunction(modalContainerRef, modal.error),
+    warning: wrapStaticModalFunction(modalContainerRef, modal.warning),
   };
 };
 

--- a/src/components/Modals/StyledModal.tsx
+++ b/src/components/Modals/StyledModal.tsx
@@ -1,8 +1,94 @@
-import { ModalProps } from "antd";
+import { App, ModalFuncProps, ModalProps } from "antd";
+import { useAppProps } from "antd/es/app/context";
 import Modal from "antd/es/modal/Modal";
 import React, { PropsWithChildren, ReactElement, useContext } from "react";
 
 import { DocumentContext } from "../AppStyle";
+
+type AppModal = useAppProps["modal"];
+type StaticModalFunction = useAppProps["modal"]["info"];
+// Extract parameter types from update method
+type StaticModalUpdateProps = Parameters<ReturnType<StaticModalFunction>["update"]>[0];
+
+/**
+ * Injects a modal container into the updater props if `getContainer` doesn't exist.
+ * Handles case where prop can either be an update method or an object.
+ */
+const addContainerToUpdaterProps = (
+  modalContainerRef: HTMLDivElement | null,
+  props: StaticModalUpdateProps
+): StaticModalUpdateProps => {
+  // Props can either be an object or a function that takes in the old object and returns a new one
+  if (props instanceof Function) {
+    // Wrap the function
+    const propFunction = props; // Rename for clarity
+    return (oldProps) => {
+      const updatedProps = propFunction(oldProps);
+      if (!updatedProps.getContainer) {
+        return { ...updatedProps, getContainer: modalContainerRef || undefined };
+      }
+      return updatedProps;
+    };
+  } else {
+    const newProps = { ...props };
+    if (!newProps.getContainer) {
+      newProps.getContainer = modalContainerRef || undefined;
+    }
+    return newProps;
+  }
+};
+
+/**
+ * Wraps Ant's static modal functions and injects the modal container ref into the props for both
+ * the function and its returned updater method.
+ */
+const wrappedStaticModalFunctionFactory = (
+  modalContainerRef: HTMLDivElement | null,
+  modalFunction: StaticModalFunction
+): StaticModalFunction => {
+  return (props: ModalFuncProps) => {
+    const newProps = { ...props };
+    if (!newProps.getContainer) {
+      newProps.getContainer = modalContainerRef || undefined;
+    }
+    const { destroy, update } = modalFunction(newProps);
+    const wrappedUpdate: typeof update = (props: StaticModalUpdateProps) => {
+      return update(addContainerToUpdaterProps(modalContainerRef, props));
+    };
+    return { destroy, update: wrappedUpdate };
+  };
+};
+
+/**
+ * Drop-in replacement for Ant's static modal API (the `App.useApp().modal` hook).
+ * Fixes a bug where modals are placed outside of styling rules by providing a default container.
+ * Components that use this must be placed within an `AppStyle` component.
+ *
+ * @example
+ * ```
+ * const MyButton = (): ReactElement => {
+ *   const modal = useStyledModal();
+ *   return <Button
+ *      onClick={() => modal.info({title: "An info modal", content: "Some information here"})}
+ *   >
+ *      Open modal
+ *   </Button>;
+ * }
+ *
+ * export default MyButton;
+ * ```
+ */
+export const useStyledModal = (): AppModal => {
+  const { modalContainerRef } = useContext(DocumentContext);
+  const { modal } = App.useApp();
+  return {
+    confirm: wrappedStaticModalFunctionFactory(modalContainerRef, modal.confirm),
+    info: wrappedStaticModalFunctionFactory(modalContainerRef, modal.info),
+    success: wrappedStaticModalFunctionFactory(modalContainerRef, modal.success),
+    error: wrappedStaticModalFunctionFactory(modalContainerRef, modal.error),
+    warning: wrappedStaticModalFunctionFactory(modalContainerRef, modal.warning),
+  };
+};
 
 /**
  * Wrapper around Antd's Modal component, fixing a bug where modals are placed outside of

--- a/src/components/Modals/StyledModal.tsx
+++ b/src/components/Modals/StyledModal.tsx
@@ -7,8 +7,8 @@ import { DocumentContext } from "../AppStyle";
 
 type AntModalApi = useAppProps["modal"];
 type AntModalApiFunction = AntModalApi["info"];
-// The Ant Modal API returns a tuple with a destroy method and an updater method.
-// Get the type of the updater method's props, so we can wrap it.
+// The Ant Modal API functions return a tuple with `destroy` and `update` callbacks.
+// Get the type of the update method's arguments, so we can wrap it.
 type ModalUpdateMethodProps = Parameters<ReturnType<AntModalApiFunction>["update"]>[0];
 type ContainerRef = HTMLDivElement | null;
 


### PR DESCRIPTION
Problem
=======
A comment Cameron made on the previous PR (#280) inspired this change! He had suggested I add a nice wrapper component for Ant Modals to hide the dependency on `useContext(DocumentContext)`. This worked great, but it didn't handle the use of Ant's static modal API elsewhere in the codebase.

This makes the same change but this time for Ant's static modal API! I'm using the static API in a couple places (including the upcoming #289) so this will make those PRs cleaner!

*Estimated review size: small, 15-20 minutes*

Solution
========
- Adds a drop-in replacement for `App.useApp().modal` through the new hook `useStyledModal()`.
  - The returned static methods wrap Ant's existing modal API, but inject a reference to a container for the modals if there isn't one provided.
  - This allows static methods to be called cleanly without running into the bug previously fixed in #280 where modals would render out of order.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-290/#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json
2. Open the Export menu, and start exporting an MP4 video. Immediately click `Cancel`, and a static modal will appear! You should be able to dismiss it and interact with it as normal.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/54cc291e-63ea-4919-8b6a-76bb7acbcd78)

