### PR TITLE
fix: Fixed bug where dropdowns were using incorrect style

### DIFF
--- a/src/components/Dropdowns/AccessibleDropdown.tsx
+++ b/src/components/Dropdowns/AccessibleDropdown.tsx
@@ -89,7 +89,6 @@ const MainButton = styled(Button)<{ $open: boolean }>`
   transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1), width 0s;
 
   // Override Ant styling for the outlined button style
-  // Double-specify class to ensure that this overrides Ant styling
   &.ant-btn${"." + OUTLINED_BUTTON_CLASS}:not(:disabled) {
     border-color: var(--color-borders);
     color: var(--color-text-primary);
@@ -112,7 +111,7 @@ const MainButton = styled(Button)<{ $open: boolean }>`
   ${(props) => {
     if (props.$open) {
       return css`
-        &.ant-btn:not(:disabled) {
+        &:not(:disabled) {
           border-color: var(--color-button-active) !important;
         }
       `;

--- a/src/components/Dropdowns/AccessibleDropdown.tsx
+++ b/src/components/Dropdowns/AccessibleDropdown.tsx
@@ -89,21 +89,22 @@ const MainButton = styled(Button)<{ $open: boolean }>`
   transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1), width 0s;
 
   // Override Ant styling for the outlined button style
-  &${"." + OUTLINED_BUTTON_CLASS}:not(:disabled) {
+  // Double-specify class to ensure that this overrides Ant styling
+  &.ant-btn${"." + OUTLINED_BUTTON_CLASS}:not(:disabled) {
     border-color: var(--color-borders);
-    color: var(--color-text);
+    color: var(--color-text-primary);
   }
 
-  &${"." + OUTLINED_BUTTON_CLASS}:not(:disabled):hover {
+  &.ant-btn${"." + OUTLINED_BUTTON_CLASS}:not(:disabled):hover {
     background-color: transparent;
     border-color: var(--color-button);
-    color: var(--color-text); // Repeated to override color changes
+    color: var(--color-text-primary); // Repeated to override color changes
   }
 
-  &${"." + OUTLINED_BUTTON_CLASS}:not(:disabled):active {
+  &.ant-btn${"." + OUTLINED_BUTTON_CLASS}:not(:disabled):active {
     background-color: transparent;
     border-color: var(--color-button-active);
-    color: var(--color-text);
+    color: var(--color-text-primary);
   }
 
   // When the modal is opened ("pinned") by clicking on it, show an
@@ -111,7 +112,7 @@ const MainButton = styled(Button)<{ $open: boolean }>`
   ${(props) => {
     if (props.$open) {
       return css`
-        &:not(:disabled) {
+        &.ant-btn:not(:disabled) {
           border-color: var(--color-button-active) !important;
         }
       `;


### PR DESCRIPTION
Problem
=======
Follow-up to #294! It turns out that I did not fix the dropdown styling, and that the styled-components override and the ant override both had the same level of specificity. (It only seemed fixed because hot-reload was causing styled-components to create a new CSS class that then took precedence over the ant override.)

*Estimated review size: tiny, 2 minutes*

Solution
========
- Increased the specificity of the styled-components override by one to fix a bug where the dropdowns were using the incorrect style.
- Fixed an incorrectly used CSS variable.

## Type of change
* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Open the preview link. The outlined dropdowns should be using a grey color instead of a purple: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-306/#/viewer
2. Bugged build for reference: https://allen-cell-animated.github.io/nucmorph-colorizer/main/

