### PR TITLE
fix: Tweaked theme color slightly to pass WebAIM Contrast Checker

### DIFF
--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -9,7 +9,7 @@ type AppStyleProps = {
 };
 
 const palette = {
-  theme: "#8962d3",
+  theme: "#8860d2",
   themeDark: "#5f369f",
   themeLight: "#aa88ed",
   themeGray: "#f7f0ff",


### PR DESCRIPTION
Problem
=======

Changes the theme color slightly to pass accessibility standards. 
Requested by @lynwilhelm.

*Estimated review size: tiny, 1 minute*

| Old | New |
| --- | --- |
|  ![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/eb9caa42-db3f-42e4-a39a-1b5d7777f38c) | ![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/145e1fa3-55dc-445b-af64-13f1f97c0339) |

Solution
========
- Changed theme color from #8962d3 to #8860d2.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link. Everything should look more or less the same. https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-328/

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/cdc3108d-a907-4791-a0f4-40e789e6a478)


