### PR TITLE
fix: Plot tab search bar responds to enter, updates with track number

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -280,7 +280,7 @@ function Viewer(): ReactElement {
       if (seekToFrame) {
         setFrame(newTrack.times[0]);
       }
-      setFindTrackInput("" + trackId);
+      setFindTrackInput(trackId.toString());
     },
     [canv, dataset, featureKey, currentFrame]
   );
@@ -879,7 +879,7 @@ function Viewer(): ReactElement {
                   selectedTrack={selectedTrack}
                   config={config}
                   onTrackClicked={(track) => {
-                    setFindTrackInput("");
+                    setFindTrackInput(track?.trackId.toString() || "");
                     setSelectedTrack(track);
                   }}
                   inRangeLUT={inRangeLUT}

--- a/src/components/Tabs/PlotTab.tsx
+++ b/src/components/Tabs/PlotTab.tsx
@@ -36,6 +36,10 @@ type PlotTabProps = {
 };
 
 export default function PlotTab(props: PlotTabProps): ReactElement {
+  const searchForTrack = (): void => {
+    props.findTrack(parseInt(props.findTrackInputText, 10));
+  };
+
   return (
     <>
       <TrackTitleBar>
@@ -51,13 +55,9 @@ export default function PlotTab(props: PlotTabProps): ReactElement {
               onChange={(event) => {
                 props.setFindTrackInputText(event.target.value);
               }}
+              onPressEnter={searchForTrack}
             />
-            <IconButton
-              disabled={props.disabled}
-              onClick={() => {
-                props.findTrack(parseInt(props.findTrackInputText, 10));
-              }}
-            >
+            <IconButton disabled={props.disabled} onClick={searchForTrack}>
               <SearchOutlined />
             </IconButton>
           </TrackSearch>

--- a/src/components/Tabs/PlotTab.tsx
+++ b/src/components/Tabs/PlotTab.tsx
@@ -37,6 +37,9 @@ type PlotTabProps = {
 
 export default function PlotTab(props: PlotTabProps): ReactElement {
   const searchForTrack = (): void => {
+    if (props.findTrackInputText === "") {
+      return;
+    }
     props.findTrack(parseInt(props.findTrackInputText, 10));
   };
 


### PR DESCRIPTION
Problem
=======
Closes #316!

*Estimated review size: tiny, <5 minutes*

Solution
========
- Adds support for enter keypress to search.
- Search box stays up to date with current track number.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/0d5396d7-89a8-43c7-9fa9-c38e1cdf6559

