### PR TITLE
Fix/viewport aspect ratio

### DIFF
--- a/src/Viewer.module.css
+++ b/src/Viewer.module.css
@@ -5,9 +5,7 @@
 .contentPanels {
   display: flex;
   gap: 20px;
-  /* Allow the content panels to take up all available space */
-  width: 100%;
-  --content-width: calc(min(100vw - 75px, 732px));
+  --canvas-width: 500px;
 
   flex-direction: row;
 }
@@ -22,7 +20,8 @@
 .canvasTopAndCanvasContainer {
   border: 1px solid var(--color-borders);
   border-radius: 5px 5px 0 0;
-  flex-basis: 732px;
+  flex-basis: var(--canvas-width);
+  flex-grow: 1;
 }
 
 .canvasControlsContainer {
@@ -33,7 +32,6 @@
 }
 
 .canvasTopContainer {
-  max-width: var(--content-width);
   padding: 14px 16px;
   overflow: hidden;
   border-bottom: 1px solid var(--color-borders);
@@ -52,7 +50,8 @@
 }
 
 .canvasPanel {
-  width: var(--content-width);
+  flex-basis: var(--canvas-width);
+  flex-grow: 1;
 }
 
 .canvasPanel .bottomControls {
@@ -90,9 +89,9 @@
 
 .sidePanels {
   gap: 10px;
-  flex-grow: 1;
+  flex-grow: 2;
+  flex-basis: 300px;
   min-width: 300px;
-  max-width: 100%;
 
   --height: 550px;
   height: var(--height);

--- a/src/Viewer.module.css
+++ b/src/Viewer.module.css
@@ -22,6 +22,7 @@
 .canvasTopAndCanvasContainer {
   border: 1px solid var(--color-borders);
   border-radius: 5px 5px 0 0;
+  flex-basis: 732px;
 }
 
 .canvasControlsContainer {

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -143,8 +143,7 @@ vec4 getBackdropColor(vec2 sUv) {
 vec4 getObjectColor(vec2 sUv) {
   // This pixel is background if, after scaling uv, it is outside the frame
   if (isOutsideBounds(sUv)) {
-    // TODO: Make this configurable.
-    return vec4(0.96, 0.96, 0.96, 1.0);
+    return TRANSPARENT;
   }
 
   // Get the segmentation id at this pixel

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -143,7 +143,8 @@ vec4 getBackdropColor(vec2 sUv) {
 vec4 getObjectColor(vec2 sUv) {
   // This pixel is background if, after scaling uv, it is outside the frame
   if (isOutsideBounds(sUv)) {
-    return TRANSPARENT;
+    // TODO: Make this configurable.
+    return vec4(0.96, 0.96, 0.96, 1.0);
   }
 
   // Get the segmentation id at this pixel

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -10,7 +10,6 @@ import { FlexColumnAlignCenter } from "../styles/utils";
 import { AppThemeContext } from "./AppStyle";
 import { AlertBannerProps } from "./Banner";
 
-const CANVAS_BORDER_OFFSET_PX = 4;
 const ASPECT_RATIO = 14 / 10;
 
 const MissingFileIconContainer = styled(FlexColumnAlignCenter)`
@@ -57,8 +56,8 @@ type CanvasWrapperProps = {
 
   showAlert?: (props: AlertBannerProps) => void;
 
-  maxWidth?: number;
-  maxHeight?: number;
+  maxWidthPx?: number;
+  maxHeightPx?: number;
 };
 
 const defaultProps: Partial<CanvasWrapperProps> = {
@@ -66,8 +65,8 @@ const defaultProps: Partial<CanvasWrapperProps> = {
   onMouseLeave() {},
   onTrackClicked: () => {},
   inRangeLUT: new Uint8Array(0),
-  maxWidth: 730,
-  maxHeight: 500,
+  maxWidthPx: 1400,
+  maxHeightPx: 1000,
 };
 
 /**
@@ -78,6 +77,8 @@ const defaultProps: Partial<CanvasWrapperProps> = {
  */
 export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElement {
   const props = { ...defaultProps, ...inputProps } as Required<CanvasWrapperProps>;
+
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const canv = props.canv;
   const canvasRef = useRef<HTMLDivElement>(null);
@@ -263,7 +264,11 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
       // I've fixed this for now by setting the breakpoint to 1250 pixels, but it's not a robust solution.
 
       // TODO: Calculate aspect ratio based on the current frame?
-      const width = Math.min(window.innerWidth - 75 - CANVAS_BORDER_OFFSET_PX, props.maxWidth);
+      const width = Math.min(
+        containerRef.current?.clientWidth ?? props.maxWidthPx,
+        props.maxWidthPx,
+        props.maxHeightPx * ASPECT_RATIO
+      );
       const height = Math.floor(width / ASPECT_RATIO);
       canv.setSize(width, height);
     };
@@ -284,7 +289,14 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
 
   canv.render();
   return (
-    <div style={{ position: "relative" }}>
+    <FlexColumnAlignCenter
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+      }}
+      ref={containerRef}
+    >
       <div ref={canvasRef}></div>
       <MissingFileIconContainer style={{ visibility: showMissingFileIcon ? "visible" : "hidden" }}>
         <NoImageSVG aria-labelledby="no-image" style={{ width: "50px" }} />
@@ -292,6 +304,6 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
           <b>Missing image data</b>
         </p>
       </MissingFileIconContainer>
-    </div>
+    </FlexColumnAlignCenter>
   );
 }


### PR DESCRIPTION
Problem
=======
Closes #317 (canvas getting squished on resize) and closes #318 (prioritize the canvas over the side panel)!

The canvas area is now larger by default, and should take priority over the side panel when the window width shrinks. It can also become much larger than before (max 1400x1000 pixels), which should solve some problems our scientists have been encountering.

*Estimated review size: small, 10 minutes*

Solution
========
- Adds CSS properties `flex-basis` and `flex-grow` on the canvas area and the side panels.
  - Basis values were chosen so the view looks good at standard HD monitor size (1920x1080) and half-sized for docked windows (~960x1080). 
- Changes canvas resizing logic in `CanvasWrapper` to get width values from a div container ref, which makes it less dependent on magic numbers.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link and load a dataset:
2. Resize the window.

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

