### PR TITLE
feat: Set canvas background color

### DIFF
--- a/src/colorizer/ColorizeCanvas.ts
+++ b/src/colorizer/ColorizeCanvas.ts
@@ -60,6 +60,7 @@ type ColorizeUniformTypes = {
   backdropSaturation: number;
   colorRamp: Texture;
   backgroundColor: Color;
+  canvasBackgroundColor: Color;
   outlierColor: Color;
   outOfRangeColor: Color;
   highlightedId: number;
@@ -99,6 +100,7 @@ const getDefaultUniforms = (): ColorizeUniforms => {
     highlightedId: new Uniform(-1),
     hideOutOfRange: new Uniform(false),
     backgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
+    canvasBackgroundColor: new Uniform(new Color(BACKGROUND_COLOR_DEFAULT)),
     outlierColor: new Uniform(new Color(OUTLIER_COLOR_DEFAULT)),
     outOfRangeColor: new Uniform(new Color(OUT_OF_RANGE_COLOR_DEFAULT)),
     outlierDrawMode: new Uniform(DrawMode.USE_COLOR),
@@ -365,6 +367,11 @@ export default class ColorizeCanvas {
 
   setBackgroundColor(color: Color): void {
     this.setUniform("backgroundColor", color);
+  }
+
+  /** Set the color of the area outside the frame in the canvas. */
+  setCanvasBackgroundColor(color: Color): void {
+    this.setUniform("canvasBackgroundColor", color);
   }
 
   setOutlierDrawMode(mode: DrawMode, color?: Color): void {

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -145,7 +145,6 @@ vec4 getBackdropColor(vec2 sUv) {
 vec4 getObjectColor(vec2 sUv) {
   // This pixel is background if, after scaling uv, it is outside the frame
   if (isOutsideBounds(sUv)) {
-    // TODO: Make this configurable.
     return vec4(canvasBackgroundColor, 1.0);
   }
 

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -23,6 +23,8 @@ uniform float backdropBrightness;
 uniform float objectOpacity;
 
 uniform vec3 backgroundColor;
+// Background color for the canvas, anywhere where the frame is not drawn.
+uniform vec3 canvasBackgroundColor;
 
 const vec4 TRANSPARENT = vec4(0.0, 0.0, 0.0, 0.0);
 
@@ -144,7 +146,7 @@ vec4 getObjectColor(vec2 sUv) {
   // This pixel is background if, after scaling uv, it is outside the frame
   if (isOutsideBounds(sUv)) {
     // TODO: Make this configurable.
-    return vec4(0.96, 0.96, 0.96, 1.0);
+    return vec4(canvasBackgroundColor, 1.0);
   }
 
   // Get the segmentation id at this pixel

--- a/src/colorizer/shaders/colorize_RGBA8U.frag
+++ b/src/colorizer/shaders/colorize_RGBA8U.frag
@@ -143,7 +143,8 @@ vec4 getBackdropColor(vec2 sUv) {
 vec4 getObjectColor(vec2 sUv) {
   // This pixel is background if, after scaling uv, it is outside the frame
   if (isOutsideBounds(sUv)) {
-    return TRANSPARENT;
+    // TODO: Make this configurable.
+    return vec4(0.96, 0.96, 0.96, 1.0);
   }
 
   // Get the segmentation id at this pixel

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -60,6 +60,9 @@ const theme = {
       borders: palette.gray20,
       modalOverlay: "rgba(0, 0, 0, 0.7)",
     },
+    viewport: {
+      background: palette.gray5,
+    },
     button: {
       backgroundPrimary: palette.theme,
       backgroundDisabled: palette.gray10,

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -16,6 +16,7 @@ const palette = {
   themeGrayDark: "#e7e4f2",
   gray0: "#ffffff",
   gray5: "#fafafa",
+  gray7: "#f7f7f7",
   gray10: "#f2f2f2",
   gray15: "#e7e7e7",
   gray20: "#cbcbcc",
@@ -61,7 +62,7 @@ const theme = {
       modalOverlay: "rgba(0, 0, 0, 0.7)",
     },
     viewport: {
-      background: "#f7f7f7",
+      background: palette.gray7,
     },
     button: {
       backgroundPrimary: palette.theme,

--- a/src/components/AppStyle.tsx
+++ b/src/components/AppStyle.tsx
@@ -61,7 +61,7 @@ const theme = {
       modalOverlay: "rgba(0, 0, 0, 0.7)",
     },
     viewport: {
-      background: palette.gray5,
+      background: "#f7f7f7",
     },
     button: {
       backgroundPrimary: palette.theme,

--- a/src/components/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
-import { Color } from "three";
+import { Color, ColorRepresentation } from "three";
 
 import { NoImageSVG } from "../assets";
 import { ColorizeCanvas, ColorRamp, Dataset, Track } from "../colorizer";
@@ -128,6 +128,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     canv.overlay.updateScaleBarOptions(defaultTheme);
     canv.overlay.updateTimestampOptions(defaultTheme);
     canv.overlay.updateBackgroundOptions({ stroke: theme.color.layout.borders });
+    canv.setCanvasBackgroundColor(new Color(theme.color.viewport.background as ColorRepresentation));
   }, [theme]);
 
   // Update canvas color ramp
@@ -294,6 +295,7 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
         position: "relative",
         width: "100%",
         height: "100%",
+        backgroundColor: theme.color.viewport.background,
       }}
       ref={containerRef}
     >


### PR DESCRIPTION
Problem
=======
Adds a grey backdrop behind the frame in the main canvas area to show where the edges of the frame are.

*Estimated review size: tiny, 5 minutes*

Solution
========
- Passes a variable down into the shader that can set the canvas background color.
- Canvas background color is now a very light grey.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview and load a dataset: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-336/
2. The edge of the canvas should be grey.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/e2d75cac-e4ae-4380-945b-4dfc1a0d6069)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/c495d9a0-0f7b-4277-90a1-a26737b75f2b)
