### PR TITLE
feature: Removed `#` from URL paths

### DIFF
--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           folder: ./dist
           # Leave existing PR preview deployments in place
-          clean-exclude: pr-preview/ main/
+          clean-exclude: pr-preview/
           branch: gh-pages

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -1,11 +1,12 @@
 # Adapted from https://github.com/marketplace/actions/deploy-pr-preview and
 # https://github.com/sitek94/vite-deploy-demo
-name: Deploy Public Build
+name: Deploy GH Pages Build
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency: pages-build-deployment-${{ github.ref }}
 
@@ -43,8 +44,9 @@ jobs:
           path: ./dist
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: main
+          folder: ./dist
+          # Leave existing PR preview deployments in place
+          clean-exclude: pr-preview/ main/
+          branch: gh-pages

--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Timelapse Colorizer</title>
+    <title>Timelapse Feature Explorer</title>
     <style>
       html {
         box-sizing: border-box;
@@ -16,7 +16,7 @@
         padding: 0;
         background-color: #ffffff;
         color: #323233;
-        font-family: Lato, sans-serif;
+        font-family: Lato, Arial, sans-serif;
       }
 
       #error-page-404 {
@@ -44,7 +44,7 @@
   <body>
     <div id="error-page-404">
       <h1>Rerouting...</h1>
-      <p>Timelapse Colorizer encountered a 404 error when attempting to load this page.</p>
+      <p>Timelapse Feature Explorer encountered a 404 error when attempting to load this page.</p>
       <p>
         You should automatically be redirected to a working page. (If this doesn't work, your browser may have
         JavaScript disabled, which the viewer needs to run.)

--- a/404.html
+++ b/404.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Timelapse Colorizer</title>
+    <style>
+      html {
+        box-sizing: border-box;
+      }
+      html,
+      body,
+      main {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        background-color: #ffffff;
+        color: #323233;
+        font-family: Lato, sans-serif;
+      }
+
+      #error-page-404 {
+        margin-top: 20px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+
+        a {
+          color: #0099ff;
+
+          &:hover,
+          &:focus-within {
+            text-decoration: underline;
+          }
+        }
+      }
+    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet" />
+    <script type="module" src="/src/routes/gh_404.tsx"></script>
+  </head>
+  <body>
+    <div id="error-page-404">
+      <h1>Rerouting...</h1>
+      <p>Timelapse Colorizer encountered a 404 error when attempting to load this page.</p>
+      <p>
+        You should automatically be redirected to a working page. (If this doesn't work, your browser may have
+        JavaScript disabled, which the viewer needs to run.)
+      </p>
+      <br />
+      <p>
+        Return to our GitHub repository:
+        <a href="https://github.com/allen-cell-animated/nucmorph-colorizer" target="_self" rel="noreferrer noopener"
+          >https://github.com/allen-cell-animated/nucmorph-colorizer</a
+        >
+      </p>
+    </div>
+  </body>
+</html>

--- a/404.html
+++ b/404.html
@@ -52,9 +52,9 @@
       <br />
       <p>
         Return to our GitHub repository:
-        <a href="https://github.com/allen-cell-animated/nucmorph-colorizer" target="_self" rel="noreferrer noopener"
-          >https://github.com/allen-cell-animated/nucmorph-colorizer</a
-        >
+        <a href="https://github.com/allen-cell-animated/nucmorph-colorizer" target="_self" rel="noreferrer noopener">
+          https://github.com/allen-cell-animated/nucmorph-colorizer
+        </a>
       </p>
     </div>
   </body>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for more details about potential future features!
 
 **Stable build: [timelapse.allencell.org](https://timelapse.allencell.org)**
 
-**Latest (`main` branch): [https://allen-cell-animated.github.io/nucmorph-colorizer/main/](https://allen-cell-animated.github.io/nucmorph-colorizer/main/)**
+**Latest (`main` branch): [https://allen-cell-animated.github.io/nucmorph-colorizer/](https://allen-cell-animated.github.io/nucmorph-colorizer/)**
 
 ![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/81130299-7e75-4fc2-a344-19aba7aae8a5)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest",
     "checks": "npm run lint & npm run typeCheck & npx vitest run",
     "build": "vite build",
-    "build-internal": "vite build --base=/nucmorph-colorizer/dist/",
+    "build-internal": "vite build --base=/nucmorph-colorizer/",
     "preview": "vite preview",
     "deploy": "vite build --base=/nucmorph-colorizer/ && gh-pages -d dist",
     "lint": "eslint --config ./.eslintrc --ext .ts --ext .tsx --ext .js --ext .jsx .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "build-internal": "vite build --base=/nucmorph-colorizer/",
     "preview": "vite preview",
-    "deploy": "vite build --base=/nucmorph-colorizer/ && gh-pages -d dist",
+    "deploy": "vite build --base=/nucmorph-colorizer/ && gh-pages -d dist -a -m \"New gh-pages build; deployed via `deploy` script in `package.json`.\"",
     "lint": "eslint --config ./.eslintrc --ext .ts --ext .tsx --ext .js --ext .jsx .",
     "lint-fix": "eslint --fix --config ./.eslintrc --ext .ts --ext .tsx --ext .js --ext .jsx .",
     "typeCheck": "tsc -p tsconfig.json --noEmit"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest",
     "checks": "npm run lint & npm run typeCheck & npx vitest run",
     "build": "vite build",
-    "build-internal": "vite build --base=/nucmorph-colorizer/",
+    "build-internal": "vite build --base=/nucmorph-colorizer/dist/",
     "preview": "vite preview",
     "deploy": "vite build --base=/nucmorph-colorizer/ && gh-pages -d dist -a -m \"New gh-pages build; deployed via `deploy` script in `package.json`.\"",
     "lint": "eslint --config ./.eslintrc --ext .ts --ext .tsx --ext .js --ext .jsx .",

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,2 +1,2 @@
-export * from "./hooks";
 export * from "./AlertBanner";
+export * from "./hooks";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,15 +3,16 @@ import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { ErrorPage, LandingPage } from "./routes";
-import { decodeUrlAndRemoveHashRouting, isEncodedPathUrl } from "./utils/gh_routing";
+import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "./utils/gh_routing";
 
 import AppStyle from "./components/AppStyle";
 import Viewer from "./Viewer";
 
+// Decode URL path if it was encoded for GitHub pages or uses hash routing.
 const locationUrl = new URL(window.location.toString());
 if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
-  const url = decodeUrlAndRemoveHashRouting(locationUrl);
-  const newRelativePath = url.pathname + url.search + url.hash;
+  const decodedUrl = tryRemoveHashRouting(decodeGitHubPagesUrl(locationUrl));
+  const newRelativePath = decodedUrl.pathname + decodedUrl.search + decodedUrl.hash;
   console.log("Redirecting to " + newRelativePath);
   // Replaces the query string path with the original path now that the
   // single-page app has loaded. This lets routing work as normal below.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,25 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { createHashRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { ErrorPage, LandingPage } from "./routes";
+import { decodeUrlAndRemoveHashRouting, isEncodedPathUrl } from "./utils/gh_routing";
 
 import AppStyle from "./components/AppStyle";
 import Viewer from "./Viewer";
 
+const locationUrl = new URL(window.location.toString());
+if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
+  const url = decodeUrlAndRemoveHashRouting(locationUrl);
+  const newRelativePath = url.pathname + url.search + url.hash;
+  console.log("Redirecting to " + newRelativePath);
+  // Replaces the query string path with the original path now that the
+  // single-page app has loaded. This lets routing work as normal below.
+  window.history.replaceState(null, "", newRelativePath);
+}
+
 // Set up react router
-// Use HashRouter for GitHub Pages support, so additional paths are routed to
-// the base app instead of trying to open pages that don't exist.
-const router = createHashRouter([
+const router = createBrowserRouter([
   {
     path: "/",
     element: <LandingPage />,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,18 +20,21 @@ if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
 }
 
 // Set up react router
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <LandingPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: "viewer",
-    element: <Viewer />,
-    errorElement: <ErrorPage />,
-  },
-]);
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <LandingPage />,
+      errorElement: <ErrorPage />,
+    },
+    {
+      path: "viewer",
+      element: <Viewer />,
+      errorElement: <ErrorPage />,
+    },
+  ],
+  { basename: import.meta.env.BASE_URL }
+);
 
 // Render React component
 const container = document.getElementById("root");

--- a/src/routes/gh_404.tsx
+++ b/src/routes/gh_404.tsx
@@ -1,0 +1,15 @@
+// Hide the default 404 page content and just show a blank screen.
+import { encodeGitHubPagesUrl } from "../utils/gh_routing";
+
+// The content should only be shown if the browser doesn't support JavaScript.
+window.onload = () => {
+  document.body.innerHTML = "";
+};
+
+// This script is used in the 404.html page to redirect the browser to the correct URL.
+// Convert the current URL to a query string path and redirect the browser.
+const location = window.location;
+const locationUrl = new URL(location.toString());
+const newUrl = encodeGitHubPagesUrl(locationUrl);
+location.replace(newUrl);
+console.log("Redirecting to " + newUrl.toString());

--- a/src/routes/gh_404.tsx
+++ b/src/routes/gh_404.tsx
@@ -1,6 +1,6 @@
-// Hide the default 404 page content and just show a blank screen.
 import { encodeGitHubPagesUrl } from "../utils/gh_routing";
 
+// Hide the default 404 page content and just show a blank screen.
 // The content should only be shown if the browser doesn't support JavaScript.
 window.onload = () => {
   document.body.innerHTML = "";

--- a/src/utils/gh_routing.ts
+++ b/src/utils/gh_routing.ts
@@ -39,10 +39,6 @@ export function encodeUrlPathAsQueryString(url: URL, basePathSegments: number = 
   return new URL(newUrl);
 }
 
-export function isEncodedPathUrl(url: URL): boolean {
-  return url.search !== "" && url.search.startsWith("?/");
-}
-
 /**
  * Converts a query string back into a complete URL. Used in combination with `convertUrlToQueryStringPath()`.
  * to redirect the browser for single-page apps when the server cannot be configured, e.g. GitHub pages.
@@ -65,6 +61,14 @@ export function decodeUrlQueryStringPath(url: URL): URL {
   return new URL(`${url.origin}${url.pathname}${newPathAndQueryString}${url.hash}`);
 }
 
+export function isEncodedPathUrl(url: URL): boolean {
+  return url.search !== "" && url.search.startsWith("?/");
+}
+
+/**
+ * Encodes a URL for GitHub pages by converting the path to a query string.
+ * See `encodeUrlPathAsQueryString()` for more details.
+ */
 export function encodeGitHubPagesUrl(url: URL): URL {
   if (url.hostname === "allen-cell-animated.github.io") {
     if (url.pathname.toString().includes("pr-preview")) {
@@ -80,8 +84,19 @@ export function encodeGitHubPagesUrl(url: URL): URL {
   return url;
 }
 
-export function decodeUrlAndRemoveHashRouting(url: URL): URL {
-  url = decodeUrlQueryStringPath(url);
+/**
+ * Decodes a URL that was encoded for GitHub pages, e.g. by `encodeGitHubPagesUrl()`.
+ * See `decodeUrlQueryStringPath()` for more details.
+ */
+export function decodeGitHubPagesUrl(url: URL): URL {
+  return decodeUrlQueryStringPath(url);
+}
+
+/**
+ * Changes URLs with hash-based routing to path-based routing by removing the hash from
+ * the URL. Does nothing to URLs that do not use hash-based routing.
+ */
+export function tryRemoveHashRouting(url: URL): URL {
   // Remove #/ from the URL path
   if (url.hash.startsWith("#/")) {
     const hashContents = url.hash.slice(2);

--- a/src/utils/gh_routing.ts
+++ b/src/utils/gh_routing.ts
@@ -70,6 +70,7 @@ export function isEncodedPathUrl(url: URL): boolean {
  * See `encodeUrlPathAsQueryString()` for more details.
  */
 export function encodeGitHubPagesUrl(url: URL): URL {
+  url = new URL(url); // Clone the URL to avoid modifying the original
   if (url.hostname === "allen-cell-animated.github.io") {
     if (url.pathname.toString().includes("pr-preview")) {
       return encodeUrlPathAsQueryString(url, 3);

--- a/src/utils/gh_routing.ts
+++ b/src/utils/gh_routing.ts
@@ -1,0 +1,94 @@
+const ESCAPED_AMPERSAND = "~and~";
+
+/**
+ * Encodes the path component of a URL into a query string. Used to redirect the browser
+ * for single-page apps when the server is not configured to serve the app for all paths,
+ * e.g. GitHub pages.
+ *
+ * Adapted from https://github.com/rafgraph/spa-github-pages.
+ *
+ * The original path will be converted into a query string, and the original query string will be
+ * escaped and separated with an `&` character.
+ *
+ * @example
+ * ```
+ * const url = "https://www.example.com/one/two?a=b&c=d#qwe";
+ * //                               Original: "https://www.example.com/one/two?a=b&c=d#qwe"
+ * convertUrlToQueryStringPath(url, 0); // => "https://www.example.com/?/one/two&a=b~and~c=d#qwe"
+ * convertUrlToQueryStringPath(url, 1); // => "https://www.example.com/one/?/two&a=b~and~c=d#qwe"
+ * ```
+ *
+ * @param url - The URL to convert.
+ * @param basePathSegments - The number of path segments to keep in the URL. 0 by default.
+ *
+ * @returns The URL with the path converted to a query string, and the original query string escaped.
+ */
+export function encodeUrlPathAsQueryString(url: URL, basePathSegments: number = 0): URL {
+  const pathSegments = url.pathname.split("/");
+  const basePath = pathSegments.slice(0, basePathSegments + 1).join("/");
+  const remainingPath = pathSegments.slice(basePathSegments + 1).join("/");
+  // Remove the "?" and replace with an "&" to separate the path from the original query string.
+  // Escape existing ampersands with "~and~" so "&" is preserved as our path/query separator.
+  const queryPath = remainingPath.replace(/&/g, ESCAPED_AMPERSAND);
+  const queryString = url.search ? url.search.slice(1).replace(/&/g, ESCAPED_AMPERSAND) : "";
+
+  let newUrl = `${url.origin}${basePath}/?/${queryPath}`;
+  newUrl += queryString ? `&${queryString}` : "";
+  newUrl += url.hash;
+
+  return new URL(newUrl);
+}
+
+export function isEncodedPathUrl(url: URL): boolean {
+  return url.search !== "" && url.search.startsWith("?/");
+}
+
+/**
+ * Converts a query string back into a complete URL. Used in combination with `convertUrlToQueryStringPath()`.
+ * to redirect the browser for single-page apps when the server cannot be configured, e.g. GitHub pages.
+ * Adapted from https://github.com/rafgraph/spa-github-pages.
+ *
+ * @param url - The URL with a path converted to a query string, and the original query string escaped.
+ * @returns The original URL, with path instead of a query string.
+ */
+export function decodeUrlQueryStringPath(url: URL): URL {
+  if (!url.search || !url.search.startsWith("?/")) {
+    return url;
+  }
+
+  const newPathAndQueryString = url.search
+    .slice(2) // Remove first ? character and slash
+    .split("&") // Split the original path [idx 0] and query string [idx 1]
+    .map((s) => s.replace(new RegExp(ESCAPED_AMPERSAND, "g"), "&")) // Restore escaped ampersands
+    .join("?"); // Rejoin the path and query string
+
+  return new URL(`${url.origin}${url.pathname}${newPathAndQueryString}${url.hash}`);
+}
+
+export function encodeGitHubPagesUrl(url: URL): URL {
+  if (url.hostname === "allen-cell-animated.github.io") {
+    if (url.pathname.toString().includes("pr-preview")) {
+      return encodeUrlPathAsQueryString(url, 3);
+    }
+    // Redirect `/main` paths back to root `/`
+    if (url.pathname.toString().includes("main")) {
+      url.pathname = url.pathname.replace("/main", "");
+    }
+    return encodeUrlPathAsQueryString(url, 1);
+  }
+
+  return url;
+}
+
+export function decodeUrlAndRemoveHashRouting(url: URL): URL {
+  url = decodeUrlQueryStringPath(url);
+  // Remove #/ from the URL path
+  if (url.hash.startsWith("#/")) {
+    const hashContents = url.hash.slice(2);
+    const [path, queryParams] = hashContents.split("?");
+    url.pathname += path;
+    url.search = queryParams ? `?${queryParams}` : "";
+    url.hash = "";
+  }
+  return url;
+}

--- a/tests/gh_routing.test.ts
+++ b/tests/gh_routing.test.ts
@@ -66,7 +66,7 @@ describe("Route utils", () => {
   });
 
   describe("URL encoding and decoding", () => {
-    function testUrlEncodingAndDecoding(urls: string[][]) {
+    function testUrlEncodingAndDecoding(urls: string[][]): void {
       for (const [input, encoded, decoded] of urls) {
         const url = new URL(input);
 

--- a/tests/gh_routing.test.ts
+++ b/tests/gh_routing.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeUrlAndRemoveHashRouting,
+  decodeUrlQueryStringPath,
+  encodeGitHubPagesUrl,
+  encodeUrlPathAsQueryString,
+} from "../src/utils/gh_routing";
+
+describe("Route utils", () => {
+  describe("convertUrlToQueryStringPath", () => {
+    it("converts paths to query string", () => {
+      const url = new URL("https://www.example.com/one/two");
+      const convertedUrl = encodeUrlPathAsQueryString(url, 0);
+      expect(convertedUrl.toString()).toEqual("https://www.example.com/?/one/two");
+    });
+
+    it("handles extra slashes", () => {
+      const url = new URL("https://www.example.com/one/two/");
+      const convertedUrl = encodeUrlPathAsQueryString(url, 0);
+      expect(convertedUrl.toString()).toEqual("https://www.example.com/?/one/two/");
+    });
+
+    it("handles original query params and hashes", () => {
+      const url = new URL("https://www.example.com/one/two?a=0&b=1#hash");
+      const convertedUrl = encodeUrlPathAsQueryString(url, 0);
+      expect(convertedUrl.toString()).toEqual("https://www.example.com/?/one/two&a=0~and~b=1#hash");
+    });
+
+    it("handles base path segments", () => {
+      const url = new URL("https://www.example.com/one/two/");
+      const convertedUrl1 = encodeUrlPathAsQueryString(url, 1);
+      expect(convertedUrl1.toString()).toEqual("https://www.example.com/one/?/two/");
+
+      const convertedUrl2 = encodeUrlPathAsQueryString(url, 2);
+      expect(convertedUrl2.toString()).toEqual("https://www.example.com/one/two/?/");
+    });
+  });
+
+  describe("convertQueryStringPathToUrl", () => {
+    it("returns original url", () => {
+      const url = new URL("https://www.example.com/one/two/");
+      const convertedUrl = encodeUrlPathAsQueryString(url, 0);
+      const restoredUrl = decodeUrlQueryStringPath(convertedUrl);
+      expect(restoredUrl.toString()).toEqual(url.toString());
+    });
+
+    it("ignores normal urls", () => {
+      const url = new URL("https://www.example.com/one/two/");
+      const restoredUrl = decodeUrlQueryStringPath(url);
+      expect(restoredUrl.toString()).toEqual(url.toString());
+    });
+
+    it("ignores normal urls with query parameters", () => {
+      const url = new URL("https://www.example.com/one/two/?a=0");
+      const restoredUrl = decodeUrlQueryStringPath(url);
+      expect(restoredUrl.toString()).toEqual(url.toString());
+    });
+
+    it("handles converted query params and hashes", () => {
+      const url = new URL("https://www.example.com/one/two?a=0&b=1#hash");
+      const convertedUrl = encodeUrlPathAsQueryString(url, 0);
+      const restoredUrl = decodeUrlQueryStringPath(convertedUrl);
+      expect(restoredUrl.toString()).toEqual(url.toString());
+    });
+  });
+
+  describe("URL encoding and decoding", () => {
+    function testUrlEncodingAndDecoding(urls: string[][]) {
+      for (const [input, encoded, decoded] of urls) {
+        const url = new URL(input);
+
+        const encodedInput = encodeGitHubPagesUrl(url);
+        expect(encodedInput.toString()).toEqual(encoded);
+        expect(decodeUrlAndRemoveHashRouting(encodedInput).toString()).toEqual(decoded);
+      }
+    }
+
+    it("handles basic viewer links", () => {
+      testUrlEncodingAndDecoding([
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer?collection=https://example.com/collection.json",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/viewer&collection=https://example.com/collection.json",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer?collection=https://example.com/collection.json",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer?collection=https://example.com/collection.json&dataset=example",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/viewer&collection=https://example.com/collection.json~and~dataset=example",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer?collection=https://example.com/collection.json&dataset=example",
+        ],
+      ]);
+    });
+
+    it("removes hash routing", () => {
+      testUrlEncodingAndDecoding([
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/#/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/#/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/main/#/viewer?url=https://example.com",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/#/viewer?url=https://example.com",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/viewer?url=https://example.com",
+        ],
+      ]);
+    });
+
+    it("reroutes from main to root", () => {
+      testUrlEncodingAndDecoding([
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/main/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/main",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/?/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/",
+        ],
+      ]);
+    });
+
+    it("keeps pr-preview basepaths", () => {
+      testUrlEncodingAndDecoding([
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/?/",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/?/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/viewer",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/#/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/?/#/viewer",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/viewer",
+        ],
+        [
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/#/viewer?collection=https://example.com/collection.json&dataset=example",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/?/#/viewer?collection=https://example.com/collection.json&dataset=example",
+          "https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-100/viewer?collection=https://example.com/collection.json&dataset=example",
+        ],
+      ]);
+    });
+
+    it("handles hash removal when decoding dev server links", () => {
+      const urlsToTest = [
+        ["https://example-server.com/nucmorph-colorizer/", "https://example-server.com/nucmorph-colorizer/"],
+        [
+          "https://example-server.com/nucmorph-colorizer/#/viewer",
+          "https://example-server.com/nucmorph-colorizer/viewer",
+        ],
+        [
+          "https://example-server.com/nucmorph-colorizer/#/viewer?collection=https://example.com/collection.json&dataset=example",
+          "https://example-server.com/nucmorph-colorizer/viewer?collection=https://example.com/collection.json&dataset=example",
+        ],
+      ];
+
+      for (const [input, expected] of urlsToTest) {
+        const url = new URL(input);
+        expect(decodeUrlAndRemoveHashRouting(url).toString()).toEqual(expected);
+      }
+    });
+  });
+});

--- a/tests/gh_routing.test.ts
+++ b/tests/gh_routing.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  decodeUrlAndRemoveHashRouting,
+  decodeGitHubPagesUrl,
   decodeUrlQueryStringPath,
   encodeGitHubPagesUrl,
   encodeUrlPathAsQueryString,
+  tryRemoveHashRouting,
 } from "../src/utils/gh_routing";
 
 describe("Route utils", () => {
@@ -72,7 +73,7 @@ describe("Route utils", () => {
 
         const encodedInput = encodeGitHubPagesUrl(url);
         expect(encodedInput.toString()).toEqual(encoded);
-        expect(decodeUrlAndRemoveHashRouting(encodedInput).toString()).toEqual(decoded);
+        expect(tryRemoveHashRouting(decodeGitHubPagesUrl(encodedInput)).toString()).toEqual(decoded);
       }
     }
 
@@ -171,7 +172,7 @@ describe("Route utils", () => {
 
       for (const [input, expected] of urlsToTest) {
         const url = new URL(input);
-        expect(decodeUrlAndRemoveHashRouting(url).toString()).toEqual(expected);
+        expect(tryRemoveHashRouting(decodeGitHubPagesUrl(url)).toString()).toEqual(expected);
       }
     });
   });

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,9 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
+        // TODO: Currently 404.html imports all of the same JS chunks as index.html.
+        // Can we make it so that 404.html only imports `gh_404.js` chunks?
+        
         // eslint-disable-next-line no-undef
         main: resolve(__dirname, 'index.html'),
         // eslint-disable-next-line no-undef

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import glsl from 'vite-plugin-glsl';
 import svgr from 'vite-plugin-svgr';
@@ -8,7 +8,9 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
+        // eslint-disable-next-line no-undef
         main: resolve(__dirname, 'index.html'),
+        // eslint-disable-next-line no-undef
         "404": resolve(__dirname, '404.html')
       }
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,17 @@
+import { resolve } from 'path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import glsl from 'vite-plugin-glsl';
 import svgr from 'vite-plugin-svgr';
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        "404": resolve(__dirname, '404.html')
+      }
+    }
+  },
   plugins: [svgr(), glsl(), react()],
 });


### PR DESCRIPTION
Problem
=======
Closes #323, removing hash routing and switching to browser-based routing!

*Estimated review size: large, ~30 minutes (faster if comparing with copied files)*

Solution
========
GH pages doesn't allow us to edit the server configuration, so we have to get clever to support single-page applications. We're using a custom 404.html page that redirects to the correct root `index.html`, just like in website-3d-cell-viewer.

This time I've added in some extra checks so we can handle traffic for subdirectories (like the `pr-preview` builds).

- Changes GitHub actions to build to root (instead of using the `/main` subdirectory)
- Copies over the `gh_routing` utility methods and the 404 error HTML template from website-3d-cell-viewer.
- Edits vite configuration to build both the `index.html` and `404.html` pages.
- Adds unit tests to validate fixups for GitHub pages links.
- Switches project to browser routing instead of hash routing.

## Type of change
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

Steps to Verify:
----------------
1. Open the following link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-341/
2. Go to the viewer and start changing settings.
3. Refresh the page (or paste the link into an incognito window). After being briefly redirected, you should see the exact same view as before.

### Additional test links:
All of these links will be redirected to working pages. You can try refreshing after they're loaded to verify that the links are still valid.

| Screenshot | Link |
| --- | --- |
| ![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/05cda8be-421f-421f-ba5a-9871c67d6c33) | https://allen-cell-animated.github.io/nucmorph-colorizer/main/#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Fcollection.json&dataset=Goldilocks&feature=volume&color=matplotlib-viridis&t=400 |
| ![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/6e226c2f-4314-4e7d-a316-2cb42bebf0d8) | https://allen-cell-animated.github.io/nucmorph-colorizer/main#/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fassay-dev%2Fcomputational%2Fdata%2Fendothileal_cell_data%2FTimelapse_20x_dataset%2Fcolorizer_outputs%2Fflow_change_movie%2Fcollections_all.json&dataset=JohnPaul_20240305_flow_change_endo_combined_model_nuclei&feature=x_centroid&t=381&color=matplotlib-turbo |
