### PR TITLE
feat: Show version number

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "env": {
     "es6": true,
-    "browser": true
+    "browser": true,
+    "node": true
   },
   "ignorePatterns": ["/dist/**"],
   "parser": "@typescript-eslint/parser",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ npm install
 npm run dev
 ```
 
-1. To do all code static analysis checks: (DO THIS BEFORE PUSHING COMMITS)
+2. To do all code static analysis checks: (DO THIS BEFORE PUSHING COMMITS)
 
 ```cmd
 npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,6 @@ npm run lint
 npm run typeCheck
 ```
 
-1. Currently `npm run build-internal` is the only code path that results in a working deployment,
-due to data being hosted only on internal servers.
-
 ## Project Documentation
 
 The `README` in the root of the repository should contain or link to
@@ -42,7 +39,7 @@ you'd like to see documented.
 
 2. Create a branch and make your edits on your branch, pushing back to your fork.
 
-3. Ensure that your changes are working, and that `npm run typeCheck`, `npm run test` and `npm run lint` all exit without errors. Add tests and documentation as needed.
+3. Ensure that your changes are working, and that `npm run typeCheck`, `npm run test` and `npm run lint` all exit without errors (`npm run checks` will perform all three for you). Add tests and documentation as needed.
 
 4. Submit a pull request back to `main` via GitHub using the provided template. Include screenshots for visual changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,18 +13,20 @@ Conduct][code_of_conduct].
 ## Getting Started
 
 1. To get up and running:
-```
+
+```cmd
 npm install
 npm run dev
 ```
 
-2. To do all code static analysis checks: (DO THIS BEFORE PUSHING COMMITS)
-```
+1. To do all code static analysis checks: (DO THIS BEFORE PUSHING COMMITS)
+
+```cmd
 npm run lint
 npm run typeCheck
 ```
 
-3. Currently `npm run build-internal` is the only code path that results in a working deployment,
+1. Currently `npm run build-internal` is the only code path that results in a working deployment,
 due to data being hosted only on internal servers.
 
 ## Project Documentation
@@ -36,15 +38,35 @@ you'd like to see documented.
 
 ## How to Contribute
 
-Typical steps to contribute:
-
 1. Fork the repo on GitHub.
 
 2. Create a branch and make your edits on your branch, pushing back to your fork.
 
-3. Ensure that your changes are working, pass any linting and tests in the project. Add tests and documentation as needed.
+3. Ensure that your changes are working, and that `npm run typeCheck`, `npm run test` and `npm run lint` all exit without errors. Add tests and documentation as needed.
 
-4. Submit a pull request to merge your fork's branch into this repository, via GitHub.
+4. Submit a pull request back to `main` via GitHub using the provided template. Include screenshots for visual changes.
+
+## Publishing
+
+1. Make a new version: `npm version [patch/minor/major]` -- this will give you the new tag, e.g., `2.7.1`
+2. Push the new package.json version: `git push origin main`
+3. Push the new tag: `git push origin [NEW_TAG]` -- e.g. `git push origin v2.7.1`
+4. Write up [release notes](https://github.com/allen-cell-animated/nucmorph-colorizer/releases).
+    - Select the tag
+    - Click "generate release notes"
+    - Use this template to summarize changes (delete any categories that aren't relevant). `## Pull requests included in this release` should be above the auto generated content:
+
+```Markdown
+## What's Changed
+
+### **🎉 New features**   
+    -
+### **🐞 Bug Fixes**
+    - 
+### **⛏ Maintenance** 
+    -
+## Pull requests included in this release
+```
 
 ## Questions or Thoughts?
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,1 @@
+declare const APP_VERSION: string;

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,9 +1,20 @@
-declare const APP_VERSION: string;
-declare const BUILD_TIME_UTC: number;
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  readonly VITE_APP_VERSION: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  readonly VITE_BUILD_TIME_UTC: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
 
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       readonly npm_package_version: string;
     }
   }

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,2 +1,10 @@
 declare const APP_VERSION: string;
 declare const BUILD_TIME_UTC: number;
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      readonly npm_package_version: string;
+    }
+  }
+}

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,2 @@
 declare const APP_VERSION: string;
+declare const BUILD_TIME_UTC: number;

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -100,3 +100,7 @@ export function getDisplayDateString(date: Date): string {
     return date.toISOString();
   }
 }
+
+export function getBuildTimeDisplayString(): string {
+  return getDisplayDateString(new Date(Number.parseInt(import.meta.env.VITE_BUILD_TIME_UTC, 10)));
+}

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -101,6 +101,6 @@ export function getDisplayDateString(date: Date): string {
   }
 }
 
-export function getBuildTimeDisplayString(): string {
+export function getBuildDisplayDateString(): string {
   return getDisplayDateString(new Date(Number.parseInt(import.meta.env.VITE_BUILD_TIME_UTC, 10)));
 }

--- a/src/colorizer/utils/math_utils.ts
+++ b/src/colorizer/utils/math_utils.ts
@@ -92,3 +92,11 @@ export function numberToSciNotation(input: number, significantFigures: number): 
   const coefficient = input / 10 ** exponent;
   return `${prefix}${coefficient.toFixed(significantFigures - 1)}×10${numberToUnicodeSuperscript(exponent)}`;
 }
+
+export function getDisplayDateString(date: Date): string {
+  try {
+    return date.toLocaleString("en-US", { timeZoneName: "short" });
+  } catch {
+    return date.toISOString();
+  }
+}

--- a/src/components/Dropdowns/HelpDropdown.tsx
+++ b/src/components/Dropdowns/HelpDropdown.tsx
@@ -2,7 +2,7 @@ import { Button } from "antd";
 import React, { ReactElement, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { getDisplayDateString } from "../../colorizer/utils/math_utils";
+import { getBuildTimeDisplayString } from "../../colorizer/utils/math_utils";
 import { VisuallyHidden } from "../../styles/utils";
 
 import StyledModal from "../Modals/StyledModal";
@@ -80,8 +80,8 @@ export default function HelpDropdown(): ReactElement {
         onCancel={() => setShowVersionModal(false)}
         footer={<Button onClick={() => setShowVersionModal(false)}>Close</Button>}
       >
-        <p>Timelapse Colorizer v{APP_VERSION}</p>
-        <p>Last built on {getDisplayDateString(new Date(BUILD_TIME_UTC))}</p>
+        <p>Timelapse Colorizer v{import.meta.env.VITE_APP_VERSION}</p>
+        <p>Last built on {getBuildTimeDisplayString()}</p>
       </StyledModal>
     </div>
   );

--- a/src/components/Dropdowns/HelpDropdown.tsx
+++ b/src/components/Dropdowns/HelpDropdown.tsx
@@ -1,17 +1,20 @@
-import React, { ReactElement } from "react";
-import styled from "styled-components";
+import { Button } from "antd";
+import React, { ReactElement, useState } from "react";
+import styled, { css } from "styled-components";
 
 import { VisuallyHidden } from "../../styles/utils";
 
+import StyledModal from "../Modals/StyledModal";
 import AccessibleDropdown from "./AccessibleDropdown";
 import DropdownItemList from "./DropdownItemList";
 
-const StyledLink = styled.a`
+const listButtonStyling = css`
   border-radius: 4px;
   padding: 3px 12px;
   color: var(--color-text-primary);
+  text-align: left;
 
-  &:hover,
+  &&&:hover,
   &:focus {
     background-color: var(--color-dropdown-hover);
     color: var(--color-text-primary);
@@ -22,9 +25,29 @@ const StyledLink = styled.a`
   }
 `;
 
+const StyledLink = styled.a`
+  ${listButtonStyling}
+`;
+
+const StyledButton = styled(Button)`
+  ${listButtonStyling}
+`;
+
 export default function HelpDropdown(): ReactElement {
+  const [showVersionModal, setShowVersionModal] = useState(false);
+
   const dropdownContent = (
     <DropdownItemList>
+      <StyledLink
+        className="button"
+        href="https://github.com/allen-cell-animated/nucmorph-colorizer"
+        rel="noopener noreferrer"
+        target="_blank"
+        role="link"
+      >
+        Visit GitHub repository
+        <VisuallyHidden>(opens in new tab)</VisuallyHidden>
+      </StyledLink>
       <StyledLink
         className="button"
         href="https://github.com/allen-cell-animated/nucmorph-colorizer/issues"
@@ -35,16 +58,29 @@ export default function HelpDropdown(): ReactElement {
         Report an issue
         <VisuallyHidden>(opens in new tab)</VisuallyHidden>
       </StyledLink>
+      <StyledButton type="text" onClick={() => setShowVersionModal(true)}>
+        Version info
+      </StyledButton>
     </DropdownItemList>
   );
 
   return (
-    <AccessibleDropdown
-      dropdownContent={dropdownContent}
-      buttonText={"Help"}
-      buttonType="default"
-      showTooltip={false}
-      buttonStyle={{ width: "fit-content" }}
-    />
+    <div>
+      <AccessibleDropdown
+        dropdownContent={dropdownContent}
+        buttonText={"Help"}
+        buttonType="default"
+        showTooltip={false}
+        buttonStyle={{ width: "fit-content" }}
+      />
+      <StyledModal
+        open={showVersionModal}
+        title="Version info"
+        onCancel={() => setShowVersionModal(false)}
+        footer={<Button onClick={() => setShowVersionModal(false)}>Close</Button>}
+      >
+        <p>Timelapse Colorizer v{APP_VERSION}</p>
+      </StyledModal>
+    </div>
   );
 }

--- a/src/components/Dropdowns/HelpDropdown.tsx
+++ b/src/components/Dropdowns/HelpDropdown.tsx
@@ -2,7 +2,7 @@ import { Button } from "antd";
 import React, { ReactElement, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { getBuildTimeDisplayString } from "../../colorizer/utils/math_utils";
+import { getBuildDisplayDateString } from "../../colorizer/utils/math_utils";
 import { VisuallyHidden } from "../../styles/utils";
 
 import StyledModal from "../Modals/StyledModal";
@@ -81,7 +81,7 @@ export default function HelpDropdown(): ReactElement {
         footer={<Button onClick={() => setShowVersionModal(false)}>Close</Button>}
       >
         <p>Timelapse Colorizer v{import.meta.env.VITE_APP_VERSION}</p>
-        <p>Last built on {getBuildTimeDisplayString()}</p>
+        <p>Last built on {getBuildDisplayDateString()}</p>
       </StyledModal>
     </div>
   );

--- a/src/components/Dropdowns/HelpDropdown.tsx
+++ b/src/components/Dropdowns/HelpDropdown.tsx
@@ -2,6 +2,7 @@ import { Button } from "antd";
 import React, { ReactElement, useState } from "react";
 import styled, { css } from "styled-components";
 
+import { getDisplayDateString } from "../../colorizer/utils/math_utils";
 import { VisuallyHidden } from "../../styles/utils";
 
 import StyledModal from "../Modals/StyledModal";
@@ -80,6 +81,7 @@ export default function HelpDropdown(): ReactElement {
         footer={<Button onClick={() => setShowVersionModal(false)}>Close</Button>}
       >
         <p>Timelapse Colorizer v{APP_VERSION}</p>
+        <p>Last built on {getDisplayDateString(new Date(BUILD_TIME_UTC))}</p>
       </StyledModal>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,10 @@ import { ErrorPage, LandingPage } from "./routes";
 import AppStyle from "./components/AppStyle";
 import Viewer from "./Viewer";
 
+const basename = import.meta.env.BASE_URL;
+console.log(`nucmorph-colorizer Version ${APP_VERSION}`);
+console.log(`nucmorph-colorizer Basename ${basename}`);
+
 // Set up react router
 // Use HashRouter for GitHub Pages support, so additional paths are routed to
 // the base app instead of trying to open pages that don't exist.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,14 +2,16 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
+import { getDisplayDateString } from "./colorizer/utils/math_utils";
 import { ErrorPage, LandingPage } from "./routes";
 
 import AppStyle from "./components/AppStyle";
 import Viewer from "./Viewer";
 
 const basename = import.meta.env.BASE_URL;
-console.log(`nucmorph-colorizer Version ${APP_VERSION}`);
-console.log(`nucmorph-colorizer Basename ${basename}`);
+console.log(`Timelapse Colorizer - Version ${APP_VERSION}`);
+console.log(`Timelapse Colorizer - Basename ${basename}`);
+console.log(`Timelapse Colorizer - Last built ${getDisplayDateString(new Date(BUILD_TIME_UTC))}`);
 
 // Set up react router
 // Use HashRouter for GitHub Pages support, so additional paths are routed to

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
-import { getBuildTimeDisplayString } from "./colorizer/utils/math_utils";
+import { getBuildDisplayDateString } from "./colorizer/utils/math_utils";
 import { ErrorPage, LandingPage } from "./routes";
 
 import AppStyle from "./components/AppStyle";
@@ -13,7 +13,7 @@ const basename = import.meta.env.BASE_URL;
 
 console.log(`Timelapse Colorizer - Version ${version}`);
 console.log(`Timelapse Colorizer - Basename ${basename}`);
-console.log(`Timelapse Colorizer - Last built ${getBuildTimeDisplayString()}`);
+console.log(`Timelapse Colorizer - Last built ${getBuildDisplayDateString()}`);
 
 // Set up react router
 // Use HashRouter for GitHub Pages support, so additional paths are routed to

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,16 +2,18 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
-import { getDisplayDateString } from "./colorizer/utils/math_utils";
+import { getBuildTimeDisplayString } from "./colorizer/utils/math_utils";
 import { ErrorPage, LandingPage } from "./routes";
 
 import AppStyle from "./components/AppStyle";
 import Viewer from "./Viewer";
 
+const version = import.meta.env.VITE_APP_VERSION;
 const basename = import.meta.env.BASE_URL;
-console.log(`Timelapse Colorizer - Version ${APP_VERSION}`);
+
+console.log(`Timelapse Colorizer - Version ${version}`);
 console.log(`Timelapse Colorizer - Basename ${basename}`);
-console.log(`Timelapse Colorizer - Last built ${getDisplayDateString(new Date(BUILD_TIME_UTC))}`);
+console.log(`Timelapse Colorizer - Last built ${getBuildTimeDisplayString()}`);
 
 // Set up react router
 // Use HashRouter for GitHub Pages support, so additional paths are routed to

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
-    "types": ["vite-plugin-svgr/client", "@types/dom-webcodecs"]
+    "types": ["vite-plugin-svgr/client", "@types/dom-webcodecs", "./env.d.ts"]
   },
   "include": ["src", "tests"],
   "exclude": ["dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,8 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
-    "types": ["vite-plugin-svgr/client", "@types/dom-webcodecs", "./env.d.ts"]
+    "types": ["vite-plugin-svgr/client", "@types/dom-webcodecs"]
   },
-  "include": ["src", "tests"],
+  "include": ["src", "tests", "env.d.ts"],
   "exclude": ["dist"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,14 @@
-import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
-import glsl from 'vite-plugin-glsl';
-import svgr from 'vite-plugin-svgr';
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import glsl from "vite-plugin-glsl";
+import svgr from "vite-plugin-svgr";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+process.env = {
+  ...process.env,
+  VITE_APP_VERSION: process.env.npm_package_version,
+  VITE_BUILD_TIME_UTC: Date.now().toString(),
+};
 export default defineConfig({
   plugins: [svgr(), glsl(), react()],
-  define: {
-    APP_VERSION: JSON.stringify(process.env.npm_package_version),
-    BUILD_TIME_UTC: Date.now(),
-  }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,12 +3,13 @@ import { defineConfig } from "vite";
 import glsl from "vite-plugin-glsl";
 import svgr from "vite-plugin-svgr";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
+// Add version number and build timestamp to the environment variables
 process.env = {
   ...process.env,
   VITE_APP_VERSION: process.env.npm_package_version,
   VITE_BUILD_TIME_UTC: Date.now().toString(),
 };
+
 export default defineConfig({
   plugins: [svgr(), glsl(), react()],
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
   plugins: [svgr(), glsl(), react()],
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
+    BUILD_TIME_UTC: Date.now(),
   }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,7 @@ import svgr from 'vite-plugin-svgr';
 
 export default defineConfig({
   plugins: [svgr(), glsl(), react()],
+  define: {
+    APP_VERSION: JSON.stringify(process.env.npm_package_version),
+  }
 });


### PR DESCRIPTION
Problem
=======
Closes #311, updating documentation around our versioning and printing the current version number in various places in the UI.

*Estimated review size: small, <10-15 minutes*

Solution
========
- Adds constants that are included during build for the app version and time of build.
  - Edits TS config to recognize these as legal env constants.
- Prints app version on startup.
- Updates the Help dropdown to include a link to the GitHub repo and the current build version.

## Type of change

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-343/
2. Open the console log. You should see the new version number and the basename of the webpage (should be something like `/nucmorph-colorizer/pr-preview/###`) appear.
3. Go to the help menu and click through the new **Visit GitHub repository** and **Version info** buttons.

Screenshots (optional):
-----------------------
![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/c2657199-6325-448d-b263-9573c9f61462)

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/d99a23bf-2201-44f7-a3d9-c503b5e552df)
