### PR TITLE
feat: Remove Nucmorph as the default dataset, add banner popup for missing dataset

### DIFF
--- a/src/components/Banner/hooks.tsx
+++ b/src/components/Banner/hooks.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useMemo, useRef, useState } from "react";
+import React, { DependencyList, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import AlertBanner, { AlertBannerProps } from "./AlertBanner";
 
@@ -12,12 +12,13 @@ export type ClearBannersCallback = () => void;
  * Banners that are closed with the "Do not show again" option checked will ignore any future alerts with identical
  * messages until the dependency list changes.
  *
- * @param deps Dependency list. When changed, clears all managed banners and resets the
- * "do not show again" behavior.
+ * @param deps Dependency list. When elements change, clears all managed banners and resets the
+ * "do not show again" behavior. Empty by default.
  *
  * @returns
  *   - bannerElement: A React element containing all the alert banners.
  *   - showAlert: A callback that adds a new alert banner (if it doesn't currently exist).
+ *   - clearBanners: A callback that clears all alert banners and resets the "do not show again" behavior.
  *
  * @example
  * ```
@@ -36,7 +37,9 @@ export type ClearBannersCallback = () => void;
  * }
  * ```
  */
-export const useAlertBanner = (): {
+export const useAlertBanner = (
+  deps: DependencyList = []
+): {
   bannerElement: ReactElement;
   showAlert: ShowAlertBannerCallback;
   clearBanners: ClearBannersCallback;
@@ -62,6 +65,11 @@ export const useAlertBanner = (): {
     setBannerProps((_previousBannerProps) => []);
     ignoredBannerMessages.current.clear();
   }, []);
+
+  // Automatically clear banners when the dependency list changes.
+  useEffect(() => {
+    clearBanners();
+  }, deps);
 
   const bannerElements = useMemo(
     () => (

--- a/src/components/Banner/hooks.tsx
+++ b/src/components/Banner/hooks.tsx
@@ -1,8 +1,9 @@
-import React, { DependencyList, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { ReactElement, useCallback, useMemo, useRef, useState } from "react";
 
 import AlertBanner, { AlertBannerProps } from "./AlertBanner";
 
 export type ShowAlertBannerCallback = (props: AlertBannerProps) => void;
+export type ClearBannersCallback = () => void;
 
 /**
  * A hook to manage a list of alert banners. When a new alert message is provided, a new banner is shown for it.
@@ -35,9 +36,11 @@ export type ShowAlertBannerCallback = (props: AlertBannerProps) => void;
  * }
  * ```
  */
-export const useAlertBanner = (
-  deps: DependencyList
-): { bannerElement: ReactElement; showAlert: ShowAlertBannerCallback } => {
+export const useAlertBanner = (): {
+  bannerElement: ReactElement;
+  showAlert: ShowAlertBannerCallback;
+  clearBanners: ClearBannersCallback;
+} => {
   // TODO: Additional calls to `showAlert` with different props/callbacks will be ignored; should we update the
   // banner or only ever show the first call?
   // TODO: Nice animations when banners appear or when all of them are cleared at once?
@@ -55,11 +58,10 @@ export const useAlertBanner = (
     [bannerProps, ignoredBannerMessages.current]
   );
 
-  useEffect(() => {
-    // Clear banner list
-    setBannerProps([]);
+  const clearBanners = useCallback(() => {
+    setBannerProps((_previousBannerProps) => []);
     ignoredBannerMessages.current.clear();
-  }, deps);
+  }, []);
 
   const bannerElements = useMemo(
     () => (
@@ -81,5 +83,5 @@ export const useAlertBanner = (
     [bannerProps]
   );
 
-  return { bannerElement: bannerElements, showAlert };
+  return { bannerElement: bannerElements, showAlert, clearBanners };
 };

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,4 +1,3 @@
-export const DEFAULT_COLLECTION_PATH = "https://dev-aics-dtp-001.int.allencell.org/dan-data/colorizer/data";
 /**
  * Default name for a collection descriptor JSON, which provides relative
  * filepaths to one or more datasets.


### PR DESCRIPTION
Problem
=======
Closes #228, removing nucmorph as the default dataset!

*Estimated size: small, 5-10 minutes*

Solution
========
- Removes the default nucmorph dataset that was used when datasets were missing.
- Adds an info banner for when only the empty viewer page is loaded.
- Fixes a bug where the banners would be immediately cleared on page load, leading to no banners being shown.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open the preview link: https://allen-cell-animated.github.io/nucmorph-colorizer/pr-preview/pr-344/#/viewer
2. You should see an empty page with the info banner at the top:

![image](https://github.com/allen-cell-animated/nucmorph-colorizer/assets/30200665/9d5f7992-b8b0-43d1-ae1d-80c683f3685a)
