### PR TITLE
fix: Fix gh-pages build

### DIFF
--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -37,6 +37,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -34,7 +34,6 @@ jobs:
   pages-deploy:
     needs: pages-build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Should fix a bug with the main GitHub pages deployment where the `JamesIves/github-pages-deploy-action@v4` was expecting to be run inside of a repo. Also allow the action to be run off of any branch for testing purposes.

*Estimated review size: tiny, <5 minutes*