### PR TITLE
fix: Fix GH pages build (again)

### DIFF
--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "18"
 
       - name: Install and Build
-        run: npm ci && npx vite build --base=/nucmorph-colorizer/main/
+        run: npm ci && npx vite build --base=/nucmorph-colorizer/
 
       - name: Upload build files
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes a bug where assets were expected at the wrong path for the new GH pages build action. 

*Estimated review size: tiny, 1 minute*

## Verification: 
- Open the GH page build, which was built off of this branch: https://allen-cell-animated.github.io/nucmorph-colorizer