### PR TITLE
fix: Order dropdown search results correctly

### DIFF
--- a/src/components/Dropdowns/SelectionDropdown.tsx
+++ b/src/components/Dropdowns/SelectionDropdown.tsx
@@ -180,7 +180,7 @@ export default function SelectionDropdown(inputProps: React.PropsWithChildren<Se
         setFilteredItems(filteredItems);
       });
     }
-  }, [searchInput, props.items]);
+  }, [fuse, searchInput, props.items, setFilteredItems]);
 
   // Add tooltip so it only responds to interaction with the selected option in the control area.
   // Fixes a bug where the tooltip would show when hovering anywhere over the dropdown, including


### PR DESCRIPTION
Problem
=======
Fixes #852, "Dropdown search is buggy/does not list exact matches first."

This was caused by an implementation error, where the results of the search input were put into a Set and used to filter the dropdown options. That meant that the displayed options were not ordered by matching score.

*Estimated review size: tiny, 5 minutes*

Solution
========
- Fixed bug where dropdown search results would not be sorted by matching score.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open bugged public build. Select the Features dropdown and type "PC 3", and press **Enter**. "PC 1" will be selected. https://timelapse.allencell.org/viewer?collection=https://vast-files.int.allencell.org/endothelial/morphological_features/timelapse_feature_explorer/collection.json
2. Open the PR preview and repeat the above steps. The dropdown results will correctly filter to show PC 3. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-858/viewer?collection=https://vast-files.int.allencell.org/endothelial/morphological_features/timelapse_feature_explorer/collection.json

| Before | After |
| --- | --- |
| <img width="551" height="401" alt="image" src="https://github.com/user-attachments/assets/26b9a4bd-0a62-4076-9274-c1b79c73bf28" /> | <img width="549" height="163" alt="image" src="https://github.com/user-attachments/assets/86b7e56c-73f1-4d7f-8d3b-7db601ff92aa" /> |
