### PR TITLE
fix: Render to pick buffer in render step (points pt. 1)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -106,7 +106,6 @@ function Viewer(): ReactElement {
   // required for this component.
   // Get viewer state:
   const collection = useViewerStateStore((state) => state.collection);
-  const currentFrame = useViewerStateStore((state) => state.currentFrame);
   const dataset = useViewerStateStore((state) => state.dataset);
   const datasetKey = useViewerStateStore((state) => state.datasetKey);
   const featureKey = useViewerStateStore((state) => state.featureKey);
@@ -368,7 +367,7 @@ function Viewer(): ReactElement {
       console.log("Dataset metadata:", newDataset.metadata);
       console.log("Num Items:" + newDataset?.numObjects);
     },
-    [dataset, featureKey, canv, currentFrame, featureThresholds]
+    [dataset, featureKey, canv, featureThresholds]
   );
 
   // INITIAL SETUP  ////////////////////////////////////////////////////////////////
@@ -610,7 +609,6 @@ function Viewer(): ReactElement {
               setFrame={setFrame}
               canvas={canv}
               onClick={onClickExport}
-              currentFrame={currentFrame}
               defaultImagePrefix={datasetKey + "-" + featureKey}
               disabled={dataset === null}
               setIsRecording={setIsRecording}

--- a/src/colorizer/viewport/ColorizeCanvas2D.ts
+++ b/src/colorizer/viewport/ColorizeCanvas2D.ts
@@ -801,7 +801,15 @@ export default class ColorizeCanvas2D implements IInnerRenderCanvas {
     this.checkPixelRatio();
     this.syncTrackPathLine();
 
+    // Render main scene
     this.renderer.render(this.scene, this.camera);
+
+    // Render to pick buffer
+    const previousRenderTarget = this.renderer.getRenderTarget();
+    this.renderer.setRenderTarget(this.pickRenderTarget);
+    this.renderer.render(this.pickScene, this.camera);
+    this.renderer.setRenderTarget(previousRenderTarget);
+
     this.onRenderCallback?.();
   }
 
@@ -818,16 +826,8 @@ export default class ColorizeCanvas2D implements IInnerRenderCanvas {
     if (!dataset) {
       return null;
     }
-
-    const rt = this.renderer.getRenderTarget();
-
-    this.renderer.setRenderTarget(this.pickRenderTarget);
-    this.renderer.render(this.pickScene, this.camera);
-
     const pixbuf = new Uint8Array(4);
     this.renderer.readRenderTargetPixels(this.pickRenderTarget, x, this.pickRenderTarget.height - y, 1, 1, pixbuf);
-    // restore main render target
-    this.renderer.setRenderTarget(rt);
 
     // get 32bit value from 4 8bit values
     const segId = pixbuf[0] | (pixbuf[1] << 8) | (pixbuf[2] << 16) | (pixbuf[3] << 24);

--- a/src/colorizer/viewport/ColorizeCanvas2D.ts
+++ b/src/colorizer/viewport/ColorizeCanvas2D.ts
@@ -304,8 +304,6 @@ export default class ColorizeCanvas2D implements IInnerRenderCanvas {
     this.renderer.setSize(width, height);
     this.canvas.width = Math.round(width * this.renderer.getPixelRatio());
     this.canvas.height = Math.round(height * this.renderer.getPixelRatio());
-    // TODO: either make this a 1x1 target and draw it with a new camera every time we pick,
-    // or keep it up to date with the canvas on each redraw (and don't draw to it when we pick!)
     this.pickRenderTarget.setSize(width, height);
 
     this.canvasResolution = new Vector2(width, height);

--- a/src/colorizer/viewport/ColorizeCanvas2D.ts
+++ b/src/colorizer/viewport/ColorizeCanvas2D.ts
@@ -801,12 +801,14 @@ export default class ColorizeCanvas2D implements IInnerRenderCanvas {
 
     // Render main scene
     this.renderer.render(this.scene, this.camera);
+    const mainRenderTarget = this.renderer.getRenderTarget();
 
-    // Render to pick buffer
-    const previousRenderTarget = this.renderer.getRenderTarget();
+    // Render pick scene to pick buffer
     this.renderer.setRenderTarget(this.pickRenderTarget);
     this.renderer.render(this.pickScene, this.camera);
-    this.renderer.setRenderTarget(previousRenderTarget);
+
+    // Restore original render target
+    this.renderer.setRenderTarget(mainRenderTarget);
 
     this.onRenderCallback?.();
   }

--- a/src/colorizer/viewport/overlays/elements/annotations.ts
+++ b/src/colorizer/viewport/overlays/elements/annotations.ts
@@ -154,11 +154,6 @@ function drawAnnotationMarker(
   const pos = new Vector2(pos3d.x, pos3d.y);
   const { scale, clipOpacity } = params.depthToScale(pos3d.z);
 
-  // TODO: getIdAtPixel is very expensive and can cause performance issues when
-  // annotations are being updated without the view moving (like when a user is
-  // editing a value or is adding annotations). Turn annotation rendering into a
-  // class and cache the getIdAtPixel result for the current frame, invalidating
-  // it whenever the transform matrix or current frame changes.
   if (params.getIdAtPixel !== null) {
     const pixelIdInfo = params.getIdAtPixel(pos.x, pos.y);
     const isObscured = pixelIdInfo !== null && pixelIdInfo.globalId !== id;

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -52,7 +52,6 @@ type ExportButtonProps = {
   canvas: CanvasOverlay;
   /** Callback, called whenever the button is clicked. Can be used to stop playback. */
   onClick: () => void;
-  currentFrame: number;
   /** Callback, called whenever the recording process starts or stops. */
   setIsRecording: (recording: boolean) => void;
   defaultImagePrefix: string;
@@ -171,6 +170,7 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   const { notification } = App.useApp();
   const modal = useStyledModal();
 
+  const currentFrame = useViewerStateStore((state) => state.currentFrame);
   const showHeaderDuringExport = useViewerStateStore((state) => state.showHeaderDuringExport);
   const setShowHeaderDuringExport = useViewerStateStore((state) => state.setShowHeaderDuringExport);
   const showLegendDuringExport = useViewerStateStore((state) => state.showLegendDuringExport);
@@ -178,7 +178,7 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   const dataset = useViewerStateStore((state) => state.dataset);
   const viewMode = useViewerStateStore((state) => state.viewMode);
 
-  const originalFrameRef = useRef(props.currentFrame);
+  const originalFrameRef = useRef(currentFrame);
   const exportModalRef = useRef<HTMLDivElement>(null);
   const [isModalOpen, _setIsModalOpen] = useState(false);
   const [isRecording, _setIsRecording] = useState(false);
@@ -282,7 +282,7 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
   // This is so we can reset to it when the modal is closed.
   const setIsModalOpen = (isOpen: boolean): void => {
     if (isOpen) {
-      originalFrameRef.current = props.currentFrame;
+      originalFrameRef.current = currentFrame;
       setErrorText(null);
     }
     _setIsModalOpen(isOpen);
@@ -393,8 +393,8 @@ export default function Export(inputProps: ExportButtonProps): ReactElement {
         max = props.totalFrames - 1;
         break;
       case RangeMode.CURRENT:
-        min = props.currentFrame;
-        max = props.currentFrame;
+        min = currentFrame;
+        max = currentFrame;
         break;
       case RangeMode.CUSTOM:
         // Clamp range values in case of unsafe input

--- a/tests/Export.test.tsx
+++ b/tests/Export.test.tsx
@@ -22,7 +22,6 @@ describe("ExportButton", () => {
             throw new Error("Function not implemented.");
           }}
           canvas={mockCanvas}
-          currentFrame={0}
           onClick={vi.fn()}
           setIsRecording={vi.fn()}
           disabled={false}


### PR DESCRIPTION
Problem
=======
Fixes a bug where each call to `getIdAtPixel` would cause a re-render of the pick buffer (eek!). Certain features like annotations would call `getIdAtPixel` for each onscreen object, potentially causing hundreds of re-renders each frame.

Now, the pick buffer is rendered to once during the `render` step. (I also threw in one more fix and changed some state dependencies.)

*Estimated review size: tiny, 5 minutes*

Solution
========
- The pick buffer is now updated once on render instead of on every call to `getIdAtPixel()`.
- `Viewer` no longer re-renders on every frame change (removed dependency on `currentFrame`).

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Download this CSV: [Exploratory dataset-annotations (8).csv](https://github.com/user-attachments/files/26521387/Exploratory.dataset-annotations.8.csv)
2. Open https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-902/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fbaseline_colonies_dataset%2Fcollection.json&t=15&tab=annotation and import the CSV annotations.
3. Play through time. (It may be slightly choppy on first playback but will be much faster on subsequent runs.)


