### PR TITLE
feat: Controls for 3D path transparency

### DIFF
--- a/src/colorizer/utils/data_utils.ts
+++ b/src/colorizer/utils/data_utils.ts
@@ -635,6 +635,7 @@ const LINE_MATERIAL_DEPS: (keyof TrackPathParams)[] = [
   "trackPathColorRamp",
   "outlineColor",
   "trackPathWidthPx",
+  "trackPathOverlayOpacity",
 ];
 
 /** Dependencies that will trigger a re-render of the track path on change. */

--- a/src/colorizer/utils/url_utils.ts
+++ b/src/colorizer/utils/url_utils.ts
@@ -62,6 +62,7 @@ export enum UrlParam {
   SHOW_PATH_BREAKS = "path-breaks",
   PATH_STEPS = "path-steps",
   PATH_PERSIST_OUT_OF_RANGE = "path-persist",
+  PATH_OVERLAY_OPACITY = "path-overlay",
   SHOW_SCALEBAR = "scalebar",
   SHOW_TIMESTAMP = "timestamp",
   KEEP_RANGE = "keep-range",

--- a/src/colorizer/viewport/ColorizeCanvas3D.ts
+++ b/src/colorizer/viewport/ColorizeCanvas3D.ts
@@ -543,7 +543,7 @@ export class ColorizeCanvas3D implements IInnerRenderCanvas {
     // Update all track paths
     this.trackPaths.forEach((trackPath, trackId) => {
       const track = params.tracks.get(trackId) ?? null;
-      const outlineColor = getTrackPathColor(track, params).clone().convertLinearToSRGB();
+      const outlineColor = getTrackPathColor(track, params);
       const prevTrackParams = prevParams ? { ...prevParams, track: trackPath.track } : null;
       const didUpdate = trackPath.setParams({ ...params, track, outlineColor }, prevTrackParams);
       didTrackParametersUpdate = didTrackParametersUpdate || didUpdate;

--- a/src/colorizer/viewport/tracks/TrackPath3D.ts
+++ b/src/colorizer/viewport/tracks/TrackPath3D.ts
@@ -53,7 +53,14 @@ export default class TrackPath3D {
     if (!this.params) {
       return;
     }
-    const { trackPathColorMode, trackPathColorRamp, outlineColor, trackPathColor, trackPathWidthPx } = this.params;
+    const {
+      trackPathColorMode,
+      trackPathColorRamp,
+      outlineColor,
+      trackPathColor,
+      trackPathWidthPx,
+      trackPathOverlayOpacity,
+    } = this.params;
     const modeToColor = {
       [TrackPathColorMode.USE_FEATURE_COLOR]: FEATURE_BASE_COLOR,
       [TrackPathColorMode.USE_OUTLINE_COLOR]: outlineColor,
@@ -69,6 +76,7 @@ export default class TrackPath3D {
       lineObject.setColorRamp(colorRampHexStrings, useColorRamp);
       lineObject.setLineWidth(trackPathWidthPx);
     }
+    this.lineOverlayObject.setOpacity(trackPathOverlayOpacity / 100);
   }
 
   public setVolumePhysicalSize(volumePhysicalSize: Vector3): void {

--- a/src/colorizer/viewport/tracks/TrackPath3D.ts
+++ b/src/colorizer/viewport/tracks/TrackPath3D.ts
@@ -72,10 +72,11 @@ export default class TrackPath3D {
     const useColorRamp = trackPathColorMode === TrackPathColorMode.USE_COLOR_MAP;
     const colorRampHexStrings = trackPathColorRamp.colorStops.map((c) => "#" + c.getHexString());
     for (const lineObject of [this.lineObject, this.lineOverlayObject]) {
-      lineObject.setColor(color, useVertexColors || useColorRamp);
       lineObject.setColorRamp(colorRampHexStrings, useColorRamp);
       lineObject.setLineWidth(trackPathWidthPx);
     }
+    this.lineObject.setColor(color.clone().convertLinearToSRGB(), useVertexColors || useColorRamp);
+    this.lineOverlayObject.setColor(color, useVertexColors || useColorRamp);
     this.lineOverlayObject.setOpacity(trackPathOverlayOpacity / 100);
   }
 

--- a/src/colorizer/viewport/tracks/types.ts
+++ b/src/colorizer/viewport/tracks/types.ts
@@ -30,4 +30,5 @@ export type TrackPathParams = {
   showAllTrackPathPastSteps: boolean;
   showAllTrackPathFutureSteps: boolean;
   persistTrackPathWhenOutOfRange: boolean;
+  trackPathOverlayOpacity: number;
 };

--- a/src/colorizer/viewport/types.ts
+++ b/src/colorizer/viewport/types.ts
@@ -84,6 +84,7 @@ export type RenderCanvasStateParams = {
   showAllTrackPathPastSteps: boolean;
   showAllTrackPathFutureSteps: boolean;
   persistTrackPathWhenOutOfRange: boolean;
+  trackPathOverlayOpacity: number;
   outlierDrawSettings: DrawSettings;
   outOfRangeDrawSettings: DrawSettings;
   inRangeLUT: Uint8Array;

--- a/src/components/Tabs/Settings/TrackPathSettings.tsx
+++ b/src/components/Tabs/Settings/TrackPathSettings.tsx
@@ -107,7 +107,7 @@ export default function TrackPathSettings(): ReactElement {
           />
         </SettingsItem>
         {viewMode === ViewMode.VIEW_3D && (
-          <SettingsItem label="X-ray mode" htmlFor={TrackPathSettingsHtmlIds.TRACK_PATH_OVERLAY_OPACITY_SLIDER}>
+          <SettingsItem label="Opacity" htmlFor={TrackPathSettingsHtmlIds.TRACK_PATH_OVERLAY_OPACITY_SLIDER}>
             <div style={{ maxWidth: MAX_SETTINGS_SLIDER_WIDTH, width: "100%" }}>
               <LabeledSlider
                 id={TrackPathSettingsHtmlIds.TRACK_PATH_OVERLAY_OPACITY_SLIDER}
@@ -119,7 +119,7 @@ export default function TrackPathSettings(): ReactElement {
                 maxInputBound={100}
                 value={trackPathOverlayOpacity}
                 onChange={setTrackPathOverlayOpacity}
-                marks={[20]}
+                marks={[30]}
                 numberFormatter={(value) => `${value}%`}
               />
             </div>

--- a/src/components/Tabs/Settings/TrackPathSettings.tsx
+++ b/src/components/Tabs/Settings/TrackPathSettings.tsx
@@ -1,7 +1,12 @@
 import { Checkbox, Tooltip } from "antd";
 import React, { type ReactElement, useMemo } from "react";
 
-import { DISPLAY_COLOR_RAMP_DIVERGING_KEYS, DISPLAY_COLOR_RAMP_LINEAR_KEYS, TrackPathColorMode } from "src/colorizer";
+import {
+  DISPLAY_COLOR_RAMP_DIVERGING_KEYS,
+  DISPLAY_COLOR_RAMP_LINEAR_KEYS,
+  TrackPathColorMode,
+  ViewMode,
+} from "src/colorizer";
 import DropdownWithColorPicker from "src/components/Dropdowns/DropdownWithColorPicker";
 import type { SelectItem } from "src/components/Dropdowns/types";
 import LabeledSlider from "src/components/Inputs/LabeledSlider";
@@ -23,6 +28,7 @@ const enum TrackPathSettingsHtmlIds {
   TRACK_PATH_PAST_STEPS_SLIDER = "track-path-past-steps-slider",
   TRACK_PATH_FUTURE_STEPS_SLIDER = "track-path-future-steps-slider",
   TRACK_PATH_PERSIST_OUT_OF_RANGE_CHECKBOX = "track-path-persist-out-of-range-checkbox",
+  TRACK_PATH_OVERLAY_OPACITY_SLIDER = "track-path-overlay-opacity-slider",
 }
 
 const TRACK_MODE_ITEMS: SelectItem[] = [
@@ -46,6 +52,8 @@ export default function TrackPathSettings(): ReactElement {
   const showAllTrackPathPastSteps = useViewerStateStore((state) => state.showAllTrackPathPastSteps);
   const showAllTrackPathFutureSteps = useViewerStateStore((state) => state.showAllTrackPathFutureSteps);
   const persistTrackPathWhenOutOfRange = useViewerStateStore((state) => state.persistTrackPathWhenOutOfRange);
+  const trackPathOverlayOpacity = useViewerStateStore((state) => state.trackPathOverlayOpacity);
+  const viewMode = useViewerStateStore((state) => state.viewMode);
   const setShowTrackPath = useViewerStateStore((state) => state.setShowTrackPath);
   const setTrackPathColor = useViewerStateStore((state) => state.setTrackPathColor);
   const setTrackPathColorRampKey = useViewerStateStore((state) => state.setTrackPathColorRampKey);
@@ -58,6 +66,7 @@ export default function TrackPathSettings(): ReactElement {
   const setShowAllTrackPathPastSteps = useViewerStateStore((state) => state.setShowAllTrackPathPastSteps);
   const setShowAllTrackPathFutureSteps = useViewerStateStore((state) => state.setShowAllTrackPathFutureSteps);
   const setPersistTrackPathWhenOutOfRange = useViewerStateStore((state) => state.setPersistTrackPathWhenOutOfRange);
+  const setTrackPathOverlayOpacity = useViewerStateStore((state) => state.setTrackPathOverlayOpacity);
 
   const maxTrackPathSteps = useMemo(() => dataset?.getMaxTrackLength() ?? 0, [dataset]);
 
@@ -97,6 +106,25 @@ export default function TrackPathSettings(): ReactElement {
             }}
           />
         </SettingsItem>
+        {viewMode === ViewMode.VIEW_3D && (
+          <SettingsItem label="X-ray mode" htmlFor={TrackPathSettingsHtmlIds.TRACK_PATH_OVERLAY_OPACITY_SLIDER}>
+            <div style={{ maxWidth: MAX_SETTINGS_SLIDER_WIDTH, width: "100%" }}>
+              <LabeledSlider
+                id={TrackPathSettingsHtmlIds.TRACK_PATH_OVERLAY_OPACITY_SLIDER}
+                type="value"
+                minSliderBound={0}
+                maxSliderBound={100}
+                step={10}
+                minInputBound={0}
+                maxInputBound={100}
+                value={trackPathOverlayOpacity}
+                onChange={setTrackPathOverlayOpacity}
+                marks={[20]}
+                numberFormatter={(value) => `${value}%`}
+              />
+            </div>
+          </SettingsItem>
+        )}
         <SettingsItem label="Width" htmlFor={TrackPathSettingsHtmlIds.TRACK_PATH_WIDTH_SLIDER}>
           <div style={{ maxWidth: MAX_SETTINGS_SLIDER_WIDTH, width: "100%" }}>
             <LabeledSlider

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -31,6 +31,7 @@ export const renderCanvasStateParamsSelector = (state: ViewerStoreState): Render
   showAllTrackPathPastSteps: state.showAllTrackPathPastSteps,
   showAllTrackPathFutureSteps: state.showAllTrackPathFutureSteps,
   persistTrackPathWhenOutOfRange: state.persistTrackPathWhenOutOfRange,
+  trackPathOverlayOpacity: state.trackPathOverlayOpacity,
   outlierDrawSettings: state.outlierDrawSettings,
   outOfRangeDrawSettings: state.outOfRangeDrawSettings,
   inRangeLUT: state.inRangeLUT,

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -207,7 +207,7 @@ export const createConfigSlice: StateCreator<ConfigSlice, [], [], ConfigSlice> =
   showAllTrackPathFutureSteps: false,
   showAllTrackPathPastSteps: true,
   persistTrackPathWhenOutOfRange: false,
-  trackPathOverlayOpacity: 20,
+  trackPathOverlayOpacity: 30,
   showScaleBar: true,
   showTimestamp: true,
   showLegendDuringExport: true,

--- a/src/state/slices/config_slice.ts
+++ b/src/state/slices/config_slice.ts
@@ -72,6 +72,8 @@ export type ConfigSliceState = {
   trackPathPastSteps: number;
   showAllTrackPathFutureSteps: boolean;
   showAllTrackPathPastSteps: boolean;
+  /** Opacity of the track path overlay, as an integer percentage in the `[0, 100]` range */
+  trackPathOverlayOpacity: number;
 
   /**
    * Whether track paths should be shown when all past/future steps are enabled,
@@ -133,6 +135,7 @@ export type ConfigSliceSerializableState = Pick<
   | "showAllTrackPathPastSteps"
   | "trackPathPastSteps"
   | "persistTrackPathWhenOutOfRange"
+  | "trackPathOverlayOpacity"
   | "showScaleBar"
   | "showTimestamp"
   | "outOfRangeDrawSettings"
@@ -160,6 +163,7 @@ export type ConfigSliceActions = {
   setShowAllTrackPathFutureSteps: (showAllTrackPathFutureSteps: boolean) => void;
   setShowAllTrackPathPastSteps: (showAllTrackPathPastSteps: boolean) => void;
   setPersistTrackPathWhenOutOfRange: (persistTrackPathWhenOutOfRange: boolean) => void;
+  setTrackPathOverlayOpacity: (trackPathOverlayOpacity: number) => void;
   setShowScaleBar: (showScaleBar: boolean) => void;
   setShowTimestamp: (showTimestamp: boolean) => void;
   setShowLegendDuringExport: (showLegendDuringExport: boolean) => void;
@@ -203,6 +207,7 @@ export const createConfigSlice: StateCreator<ConfigSlice, [], [], ConfigSlice> =
   showAllTrackPathFutureSteps: false,
   showAllTrackPathPastSteps: true,
   persistTrackPathWhenOutOfRange: false,
+  trackPathOverlayOpacity: 20,
   showScaleBar: true,
   showTimestamp: true,
   showLegendDuringExport: true,
@@ -249,7 +254,8 @@ export const createConfigSlice: StateCreator<ConfigSlice, [], [], ConfigSlice> =
   setShowAllTrackPathFutureSteps: (showAllTrackPathFutureSteps) => set({ showAllTrackPathFutureSteps }),
   setShowAllTrackPathPastSteps: (showAllTrackPathPastSteps) => set({ showAllTrackPathPastSteps }),
   setPersistTrackPathWhenOutOfRange: (persistTrackPathWhenOutOfRange) => set({ persistTrackPathWhenOutOfRange }),
-
+  setTrackPathOverlayOpacity: (trackPathOverlayOpacity) =>
+    set({ trackPathOverlayOpacity: clamp(Math.round(trackPathOverlayOpacity), 0, 100) }),
   setShowScaleBar: (showScaleBar) => set({ showScaleBar }),
   setShowTimestamp: (showTimestamp) => set({ showTimestamp }),
   setShowLegendDuringExport: (showLegendDuringExport) => set({ showLegendDuringExport }),
@@ -298,6 +304,7 @@ export const serializeConfigSlice = (slice: Partial<ConfigSliceSerializableState
       slice.showAllTrackPathFutureSteps
     ),
     [UrlParam.PATH_PERSIST_OUT_OF_RANGE]: encodeMaybeBoolean(slice.persistTrackPathWhenOutOfRange),
+    [UrlParam.PATH_OVERLAY_OPACITY]: encodeMaybeNumber(slice.trackPathOverlayOpacity),
     [UrlParam.SHOW_SCALEBAR]: encodeMaybeBoolean(slice.showScaleBar),
     [UrlParam.SHOW_TIMESTAMP]: encodeMaybeBoolean(slice.showTimestamp),
     // Export settings are currently not serialized.
@@ -331,6 +338,7 @@ export const selectConfigSliceSerializationDeps = (slice: ConfigSlice): ConfigSl
   showAllTrackPathFutureSteps: slice.showAllTrackPathFutureSteps,
   showAllTrackPathPastSteps: slice.showAllTrackPathPastSteps,
   persistTrackPathWhenOutOfRange: slice.persistTrackPathWhenOutOfRange,
+  trackPathOverlayOpacity: slice.trackPathOverlayOpacity,
   outOfRangeDrawSettings: slice.outOfRangeDrawSettings,
   outlierDrawSettings: slice.outlierDrawSettings,
   outlineColor: slice.outlineColor,
@@ -406,6 +414,11 @@ export const loadConfigSliceFromParams = (slice: ConfigSlice, params: URLSearchP
     slice.setTrackPathFutureSteps(trackPathStepsParam.futureSteps);
     slice.setShowAllTrackPathPastSteps(trackPathStepsParam.showAllPastSteps);
     slice.setShowAllTrackPathFutureSteps(trackPathStepsParam.showAllFutureSteps);
+  }
+
+  const trackPathOverlayOpacityParam = decodeFloat(params.get(UrlParam.PATH_OVERLAY_OPACITY));
+  if (trackPathOverlayOpacityParam !== undefined) {
+    slice.setTrackPathOverlayOpacity(trackPathOverlayOpacityParam);
   }
 
   const edgeColorParam = decodeHexAlphaColor(params.get(UrlParam.EDGE_COLOR));

--- a/tests/state/ViewerState/config_slice.test.ts
+++ b/tests/state/ViewerState/config_slice.test.ts
@@ -24,6 +24,7 @@ const EXAMPLE_SLICE_1: Partial<ConfigSlice> = {
   showAllTrackPathPastSteps: false,
   showAllTrackPathFutureSteps: true,
   persistTrackPathWhenOutOfRange: false,
+  trackPathOverlayOpacity: 15,
   showScaleBar: false,
   showTimestamp: false,
   outOfRangeDrawSettings: { color: new Color(0xff0000), mode: DrawMode.USE_COLOR },
@@ -46,6 +47,7 @@ const EXAMPLE_SLICE_1_PARAMS: SerializedStoreData = {
   [UrlParam.SHOW_PATH_BREAKS]: "0",
   [UrlParam.PATH_STEPS]: "70,100!",
   [UrlParam.PATH_PERSIST_OUT_OF_RANGE]: "0",
+  [UrlParam.PATH_OVERLAY_OPACITY]: "15",
   [UrlParam.SHOW_SCALEBAR]: "0",
   [UrlParam.SHOW_TIMESTAMP]: "0",
   [UrlParam.FILTERED_COLOR]: "ff0000",
@@ -73,6 +75,7 @@ const EXAMPLE_SLICE_2: Partial<ConfigSlice> = {
   showAllTrackPathPastSteps: true,
   showAllTrackPathFutureSteps: false,
   persistTrackPathWhenOutOfRange: true,
+  trackPathOverlayOpacity: 85,
   showScaleBar: true,
   showTimestamp: true,
   outOfRangeDrawSettings: { color: new Color(0xffff00), mode: DrawMode.HIDE },
@@ -95,6 +98,7 @@ const EXAMPLE_SLICE_2_PARAMS: SerializedStoreData = {
   [UrlParam.SHOW_PATH_BREAKS]: "1",
   [UrlParam.PATH_STEPS]: "25!,0",
   [UrlParam.PATH_PERSIST_OUT_OF_RANGE]: "1",
+  [UrlParam.PATH_OVERLAY_OPACITY]: "85",
   [UrlParam.SHOW_SCALEBAR]: "1",
   [UrlParam.SHOW_TIMESTAMP]: "1",
   [UrlParam.FILTERED_COLOR]: "ffff00",
@@ -118,6 +122,7 @@ describe("ConfigSlice", () => {
       result.current.setTrackPathWidthPx(2);
       result.current.setTrackPathColorMode(TrackPathColorMode.USE_CUSTOM_COLOR);
       result.current.setShowTrackPathBreaks(false);
+      result.current.setTrackPathOverlayOpacity(15);
       result.current.setShowScaleBar(false);
       result.current.setShowTimestamp(false);
       result.current.setShowLegendDuringExport(false);
@@ -136,6 +141,7 @@ describe("ConfigSlice", () => {
     expect(result.current.trackPathWidthPx).toBe(2);
     expect(result.current.trackPathColorMode).toBe(TrackPathColorMode.USE_CUSTOM_COLOR);
     expect(result.current.showTrackPathBreaks).toBe(false);
+    expect(result.current.trackPathOverlayOpacity).toBe(15);
     expect(result.current.showScaleBar).toBe(false);
     expect(result.current.showTimestamp).toBe(false);
     expect(result.current.showLegendDuringExport).toBe(false);
@@ -155,6 +161,7 @@ describe("ConfigSlice", () => {
       result.current.setTrackPathWidthPx(3);
       result.current.setTrackPathColorMode(TrackPathColorMode.USE_OUTLINE_COLOR);
       result.current.setShowTrackPathBreaks(true);
+      result.current.setTrackPathOverlayOpacity(85);
       result.current.setShowScaleBar(true);
       result.current.setShowTimestamp(true);
       result.current.setShowLegendDuringExport(true);
@@ -172,6 +179,7 @@ describe("ConfigSlice", () => {
     expect(result.current.trackPathWidthPx).toBe(3);
     expect(result.current.trackPathColorMode).toBe(TrackPathColorMode.USE_OUTLINE_COLOR);
     expect(result.current.showTrackPathBreaks).toBe(true);
+    expect(result.current.trackPathOverlayOpacity).toBe(85);
     expect(result.current.showScaleBar).toBe(true);
     expect(result.current.showTimestamp).toBe(true);
     expect(result.current.showLegendDuringExport).toBe(true);

--- a/tests/state/store_io.test.ts
+++ b/tests/state/store_io.test.ts
@@ -104,6 +104,7 @@ const EXAMPLE_STORE: ViewerStoreSerializableState = {
   showAllTrackPathFutureSteps: true,
   showAllTrackPathPastSteps: false,
   persistTrackPathWhenOutOfRange: false,
+  trackPathOverlayOpacity: 35,
   vectorVisible: true,
   vectorKey: VECTOR_KEY_MOTION_DELTA,
   vectorMotionTimeIntervals: 11,
@@ -169,6 +170,7 @@ const EXAMPLE_STORE_EXPECTED_PARAMS: ExpectedParamType = {
   "path-breaks": "1",
   "path-steps": "10,25!",
   "path-persist": "0",
+  "path-overlay": "35",
   vc: "1",
   "vc-key": VECTOR_KEY_MOTION_DELTA,
   "vc-color": "ff00ff",
@@ -190,7 +192,7 @@ const EXAMPLE_STORE_EXPECTED_QUERY_STRING =
   "collection=https%3A%2F%2Fsome-url.com%2Fcollection.json&dataset=some-dataset" +
   "&feature=feature1&bg-key=backdrop2&track=0%3A3&t=2&color=matplotlib-inferno%21&keep-range=1&range=21.433%2C89.400" +
   "&palette-key=matplotlib_paired&filters=f1%3Am%3A0%3A0%2Cf2%3Aum%3ANaN%3ANaN%2Cf3%3Akm%3A0%3A1%2Cf4%3Amm%3A0.501%3A1000.485%2Cf5%3A%3Afff%2Cf6%3A%3A11" +
-  "&path=1&path-color=ff0000&path-width=1.500&path-ramp=esri-blue_red_8%21&path-mode=1&path-breaks=1&path-steps=10%2C25%21&path-persist=0&scalebar=1&timestamp=0&filter-color=ff0000&filter-mode=0&outlier-color=00ff00" +
+  "&path=1&path-color=ff0000&path-width=1.500&path-ramp=esri-blue_red_8%21&path-mode=1&path-breaks=1&path-steps=10%2C25%21&path-persist=0&path-overlay=35&scalebar=1&timestamp=0&filter-color=ff0000&filter-mode=0&outlier-color=00ff00" +
   "&outlier-mode=1&outline-color=0000ff&outline-mode=0&outline-palette-key=matplotlib_paired" +
   "&edge=1&edge-color=8090a0b0" +
   "&tab=filters&interpolate=1&scatter-x=feature3&scatter-y=feature2&scatter-range=all" +


### PR DESCRIPTION
Problem
=======
I got a request from Dan and Alex to make it easier to see the 3D track path line through objects.

This change adds a slider to control the opacity of the line overlay in 3D, which was previously locked at 25%. The line overlay allows the track path to be shown through objects; lower opacity means that the line is only visible when it's not occluded (blocked) by the volume.

*Estimated review size: small, <10 minutes*

Solution
========
- Added the `trackPathOverlayOpacity` field to state and added serialization/deserialization.
- Added the new "Opacity" slider to the track path settings.
- Set the 3D line opacity using the `trackPathOverlayOpacity` state field.
- Updated unit tests.

## Type of change
* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-905/viewer?dataset=https%3A%2F%2Fvast-files.int.allencell.org%2Fusers%2Fpeyton.lee%2Ftest-data%2Ftfe_H2B_640_CAAX_488_BF_20250826%2Fmanifest.json&feature=area&track=183%3A0%2C156%3A1%2C117%3A2%2C94%3A3%2C24%3A4%2C14%3A5%2C470%3A6%2C62%3A7%2C26%3A8%2C218%3A10%2C160%3A11%2C99%3A0%2C193%3A1&t=57&path-width=2.300&tab=settings
3. Adjust the **Track Path > Opacity** slider in the right settings tab to adjust how the track path shows through objects.

Screenshots (optional):
-----------------------

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/6c8f9780-e5b4-4fbd-9ef5-6551bed963bf
