### PR TITLE
fix: Fixed bug where PR previews would infinitely redirect

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,9 +32,7 @@ jobs:
       # Must override default vite build base so that assets can still be accessed
       # when not placed in the root directory of gh-pages branch.
       - name: Build
-        run: npx vite build --base=/timelapse-colorizer/pr-preview/pr-${PR_NUMBER}/
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+        run: npx vite build --base=/${{ github.repository.name }}/pr-preview/pr-${{ github.event.number }}/
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
@@ -58,9 +56,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npx vite build --base=/timelapse-colorizer/pr-preview-internal/pr-${PR_NUMBER}/ --config config/vite.internal-build.config.js
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+        run: npx vite build --base=/${{ github.repository.name }}/pr-preview-internal/pr-${{ github.event.number }}/ --config config/vite.internal-build.config.js
 
       - name: Deploy internal preview
         uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,7 +32,7 @@ jobs:
       # Must override default vite build base so that assets can still be accessed
       # when not placed in the root directory of gh-pages branch.
       - name: Build
-        run: npx vite build --base=/${{ github.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+        run: npx vite build --base=/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
@@ -56,7 +56,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npx vite build --base=/${{ github.repository.name }}/pr-preview-internal/pr-${{ github.event.number }}/ --config config/vite.internal-build.config.js
+        run: npx vite build --base=/${{ github.event.repository.name }}/pr-preview-internal/pr-${{ github.event.number }}/ --config config/vite.internal-build.config.js
 
       - name: Deploy internal preview
         uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1

--- a/404.html
+++ b/404.html
@@ -46,8 +46,8 @@
       <h1>Rerouting...</h1>
       <p>Timelapse Feature Explorer encountered a 404 error when attempting to load this page.</p>
       <p>
-        You should automatically be redirected to a working page. (If this doesn't work, your browser may have
-        JavaScript disabled, which the viewer needs to run.)
+        If it exists, you should automatically be redirected to a working page. (If this doesn't work, your browser may
+        have JavaScript disabled, which the viewer needs to run.)
       </p>
       <br />
       <p>

--- a/src/routes/gh_404.tsx
+++ b/src/routes/gh_404.tsx
@@ -1,15 +1,16 @@
 import { encodeGitHubPagesUrl } from "src/utils/gh_routing";
 
-// Hide the default 404 page content and just show a blank screen.
-// The content should only be shown if the browser doesn't support JavaScript.
-window.onload = () => {
-  document.body.innerHTML = "";
-};
-
 // This script is used in the 404.html page to redirect the browser to the correct URL.
 // Convert the current URL to a query string path and redirect the browser.
 const location = window.location;
 const locationUrl = new URL(location.toString());
 const newUrl = encodeGitHubPagesUrl(locationUrl);
-location.replace(newUrl);
-console.log("Redirecting to " + newUrl.toString());
+
+if (newUrl.toString() !== locationUrl.toString()) {
+  // Hide the default 404 page content and just show a blank screen if
+  // redirecting.
+  document.body.innerHTML = "";
+
+  location.replace(newUrl);
+  console.log("Redirecting to " + newUrl.toString());
+}

--- a/src/utils/gh_routing.ts
+++ b/src/utils/gh_routing.ts
@@ -71,6 +71,11 @@ export function isEncodedPathUrl(url: URL): boolean {
  */
 export function encodeGitHubPagesUrl(url: URL): URL {
   url = new URL(url); // Clone the URL to avoid modifying the original
+  if (url.toString().includes(ESCAPED_AMPERSAND)) {
+    // If the URL is already escaped, assume it has already been encoded and
+    // return it as-is to avoid double-encoding.
+    return url;
+  }
   if (url.hostname === "allen-cell-animated.github.io") {
     if (url.pathname.toString().includes("pr-preview")) {
       return encodeUrlPathAsQueryString(url, 3);

--- a/src/utils/gh_routing.ts
+++ b/src/utils/gh_routing.ts
@@ -76,7 +76,8 @@ export function encodeGitHubPagesUrl(url: URL): URL {
     // return it as-is to avoid double-encoding.
     return url;
   }
-  if (url.hostname === "allen-cell-animated.github.io") {
+  // ex: allen-cell-animated.github.io
+  if (url.hostname.endsWith(".github.io")) {
     if (url.pathname.toString().includes("pr-preview")) {
       return encodeUrlPathAsQueryString(url, 3);
     }


### PR DESCRIPTION
Problem
=======
Closes #392, "GH 404 redirect fails when the page actually doesn't exist".

*Estimated review size: tiny, 5 minutes*

Solution
========
- Adds a check to prevent redirects on a 404 page if the page has already been redirected.
- Updated PR preview action to use GitHub action-native variables

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)