### PR TITLE
refactor: Removed styling overrides on cookie banner

### DIFF
--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -8,6 +8,9 @@
 }
 
 body {
-  /* Prevents layout shift when the banner cookie settings are clicked. */
+  /* 
+   * Prevents layout shift when the banner cookie settings are clicked;
+   * the onetrust banner tries to set this to hidden.
+   */
   overflow: auto !important;
 }

--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -3,6 +3,11 @@
   font-family: Lato, LatoExtended, sans-serif;
 }
 
-#onetrust-consent-sdk #onetrust-banner-sdk #onetrust-pc-btn-handler {
-  font-weight: 400;
+#onetrust-consent-sdk #ot-pc-content #ot-pc-title {
+  margin-top: 20px;
+}
+
+body {
+  /* Prevents layout shift when the banner cookie settings are clicked. */
+  overflow: auto !important;
 }

--- a/src/styles/cookie-banner.css
+++ b/src/styles/cookie-banner.css
@@ -3,43 +3,6 @@
   font-family: Lato, LatoExtended, sans-serif;
 }
 
-#onetrust-consent-sdk #onetrust-banner-sdk {
-  height: fit-content !important;
-  box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.3) !important;
-  border-radius: 5px;
-  /* Fixes visual bug where shadows would be misaligned */
-  background-color: #e7e2f7;
-}
-
-#onetrust-consent-sdk #onetrust-banner-sdk .ot-sdk-container {
-  box-shadow: none;
-}
-
 #onetrust-consent-sdk #onetrust-banner-sdk #onetrust-pc-btn-handler {
   font-weight: 400;
-  padding: 12px 10px;
-}
-
-#onetrust-consent-sdk .ot-sdk-container {
-  height: 100% !important;
-}
-
-#onetrust-consent-sdk h1,
-#onetrust-consent-sdk h2,
-#onetrust-consent-sdk h3,
-#onetrust-consent-sdk h4,
-#onetrust-consent-sdk p,
-#onetrust-consent-sdk #onetrust-policy-text {
-  /** Darken font color for contrast accessibility */
-  color: #323233 !important;
-}
-
-#onetrust-consent-sdk #ot-pc-content #ot-pc-title {
-  margin-top: 20px;
-}
-
-#onetrust-consent-sdk #accept-recommended-btn-handler,
-#onetrust-consent-sdk #onetrust-accept-btn-handler,
-#onetrust-consent-sdk .save-preference-btn-handler {
-  border-radius: 6px;
 }


### PR DESCRIPTION
Problem
=======
Fixed some broken styling on the cookie banner by removing style overrides.

*Estimated review size: tiny, 2 minutes*

| Before | After |
| -- | -- |
| <img width="891" height="296" alt="image" src="https://github.com/user-attachments/assets/83792d34-fc5a-446b-a0e6-ed67b3c6991b" /> | <img width="910" height="282" alt="image" src="https://github.com/user-attachments/assets/684a1ece-6ff3-4719-845c-b72e91091718" /> |

