### PR TITLE
refactor: Ran `zizmor` on workflows

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -76,7 +76,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       # Setup variables based on the staging or production environment
-      - name: Set ECS variables based on environment
+      - name: Set AWS (S3/CloudFront) variables based on environment
         run: |
           if [ "${GITHUB_EVENT_INPUTS_ENVIRONMENT}" == "production" ]; then
             echo "S3_BUCKET=${PRODUCTION_S3_BUCKET}" >> $GITHUB_ENV

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -29,7 +29,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
         with:
           persist-credentials: false
 
@@ -91,7 +91,7 @@ jobs:
           GITHUB_EVENT_INPUTS_ENVIRONMENT: ${{ github.event.inputs.environment }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: aws-deploy-files
           path: ./dist

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -13,6 +13,8 @@ on:
         required: true
         type: choice
 
+permissions: {}
+
 env:
   AWS_ACCOUNT_ID: ${{ vars.AWS_PUBLIC_DATA_RELEASES_ACCOUNT_ID }}
   AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
@@ -21,10 +23,6 @@ env:
   PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID }}
   PRODUCTION_S3_BUCKET: s3://timelapse.allencell.org
 
-permissions:
-  id-token: write # Required for requesting the JWT and OIDC
-  contents: write # Required for actions/checkout and OIDC tokens
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 #v6.0.0
@@ -55,6 +55,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for requesting the JWT and OIDC
+      contents: write # Required for actions/checkout and OIDC tokens
 
     # Dynamically set the environment variable based on the input above:
     environment: ${{ github.event.inputs.environment }}
@@ -74,16 +77,18 @@ jobs:
       # Setup variables based on the staging or production environment
       - name: Set ECS variables based on environment
         run: |
-          if [ "${{ github.event.inputs.environment }}" == "production" ]; then
-            echo "S3_BUCKET=${{ env.PRODUCTION_S3_BUCKET }}" >> $GITHUB_ENV
-            echo "CLOUDFRONT_DISTRIBUTION_ID=${{ env.PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID }}" >> $GITHUB_ENV
-          elif [ "${{ github.event.inputs.environment }}" == "staging" ]; then
-            echo "S3_BUCKET=${{ env.STAGING_S3_BUCKET }}" >> $GITHUB_ENV
-            echo "CLOUDFRONT_DISTRIBUTION_ID=${{ env.STAGING_CLOUDFRONT_DISTRIBUTION_ID }}" >> $GITHUB_ENV
+          if [ "${GITHUB_EVENT_INPUTS_ENVIRONMENT}" == "production" ]; then
+            echo "S3_BUCKET=${PRODUCTION_S3_BUCKET}" >> $GITHUB_ENV
+            echo "CLOUDFRONT_DISTRIBUTION_ID=${PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID}" >> $GITHUB_ENV
+          elif [ "${GITHUB_EVENT_INPUTS_ENVIRONMENT}" == "staging" ]; then
+            echo "S3_BUCKET=${STAGING_S3_BUCKET}" >> $GITHUB_ENV
+            echo "CLOUDFRONT_DISTRIBUTION_ID=${STAGING_CLOUDFRONT_DISTRIBUTION_ID}" >> $GITHUB_ENV
           else
             echo "Invalid environment specified"
             exit 1
           fi
+        env:
+          GITHUB_EVENT_INPUTS_ENVIRONMENT: ${{ github.event.inputs.environment }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -94,7 +99,7 @@ jobs:
       # Note that the command below will copy the files to the root of the S3 bucket e.g., s3://timelapse.allencell.org/
       # If you want to copy files to a S3 prefix / subdirectory, you would want something like ${{ env.S3_BUCKET }}/your_prefix below
       - name: Copy build files to S3 root
-        run: aws s3 sync ./dist ${{ env.S3_BUCKET }}
+        run: aws s3 sync ./dist ${S3_BUCKET}
 
       - name: Invalidate CloudFront cache
-        run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/*"

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -30,7 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -59,7 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for requesting the JWT and OIDC
-      contents: write # Required for actions/checkout and OIDC tokens
 
     # Dynamically set the environment variable based on the input above:
     environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -17,7 +17,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 
@@ -48,7 +49,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -14,6 +14,8 @@ permissions: {}
 jobs:
   pages-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency: pages-build-deployment-${{ github.ref }}
+permissions: {}
 
 jobs:
   pages-build:
@@ -16,7 +17,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 #v6.0.0
@@ -32,7 +35,7 @@ jobs:
         run: npx vite build --base=/timelapse-colorizer/
 
       - name: Upload build files
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b #v4.5.0
         with:
           name: production-files
           path: ./dist
@@ -40,19 +43,23 @@ jobs:
   pages-deploy:
     needs: pages-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required for pushing to gh-pages branch
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Download artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: production-files
           path: ./dist
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@049a95c516cd5723d8cfde79dc7a79fcdcbd6c97 #v4.0.0
         with:
           folder: ./dist
           # Leave existing PR preview deployments in place

--- a/.github/workflows/deploy-public-build.yml
+++ b/.github/workflows/deploy-public-build.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 
@@ -50,7 +49,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 
@@ -61,7 +59,7 @@ jobs:
           path: ./dist
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@049a95c516cd5723d8cfde79dc7a79fcdcbd6c97 #v4.0.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f #v4.8.0
         with:
           folder: ./dist
           # Leave existing PR preview deployments in place

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,14 +10,20 @@ on:
       - closed
 
 concurrency: preview-${{ github.ref }}
+permissions: {}
 
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     needs: [deploy-preview-internal]
+    permissions:
+      contents: write # Required for pushing to gh-pages branch
+
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 #v6.0.0
@@ -32,7 +38,9 @@ jobs:
       # Must override default vite build base so that assets can still be accessed
       # when not placed in the root directory of gh-pages branch.
       - name: Build
-        run: npx vite build --base=/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+        run: npx vite build --base=/${GITHUB_EVENT_REPOSITORY_NAME}/pr-preview/pr-${{ github.event.number }}/
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
@@ -41,9 +49,14 @@ jobs:
 
   deploy-preview-internal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required for pushing to gh-pages branch
+
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 #v6.0.0
@@ -56,7 +69,9 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npx vite build --base=/${{ github.event.repository.name }}/pr-preview-internal/pr-${{ github.event.number }}/ --config config/vite.internal-build.config.js
+        run: npx vite build --base=/${GITHUB_EVENT_REPOSITORY_NAME}/pr-preview-internal/pr-${{ github.event.number }}/ --config config/vite.internal-build.config.js
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Deploy internal preview
         uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy-preview-internal]
     permissions:
+      pull-requests: write # Required to comment on PR with preview link
       contents: write # Required for pushing to gh-pages branch
 
     steps:
@@ -44,19 +45,19 @@ jobs:
           GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
+        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1 #v1.4.8
         with:
           source-dir: ./dist/
 
   deploy-preview-internal:
     runs-on: ubuntu-latest
     permissions:
+      pull-requests: write # Required to comment on PR with preview link
       contents: write # Required for pushing to gh-pages branch
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 
@@ -76,7 +77,7 @@ jobs:
           GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
       - name: Deploy internal preview
-        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
+        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1 #v1.4.8
         with:
           source-dir: ./dist/
           umbrella-dir: pr-preview-internal

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -23,7 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,7 +21,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 
@@ -54,7 +55,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,5 @@ jobs:
       - name: Create release
         run: gh release create ${VERSION_TAG} --draft tfe-${VERSION_TAG}.zip
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,19 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 #v6.0.0
@@ -40,13 +46,11 @@ jobs:
         run: mv dist viewer
 
       - name: Zip build artifact
-        run: zip -r tfe-${{ steps.get_version.outputs.VERSION }}.zip viewer/*
+        run: zip -r tfe-${VERSION_TAG}.zip viewer/*
+        env:
+          VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
 
       - name: Create release
-        # v2.4.1 10/14/25
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090
+        run: gh release create ${VERSION_TAG} --draft tfe-${VERSION_TAG}.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          draft: true
-          files: tfe-${{ steps.get_version.outputs.VERSION }}.zip
+          VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to create release and upload artifacts
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,11 @@ jobs:
       - name: Zip build artifact
         run: zip -r tfe-${VERSION_TAG}.zip viewer/*
         env:
+          # Version tag without the `v` prefix, e.g. `1.0.0`
           VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}
 
       - name: Create release
-        run: gh release create ${VERSION_TAG} --draft tfe-${VERSION_TAG}.zip
+        run: gh release create v${VERSION_TAG} --draft tfe-${VERSION_TAG}.zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_TAG: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+
         with:
           persist-credentials: false
 
@@ -40,3 +41,18 @@ jobs:
 
       - name: Vitest coverage report
         uses: davelosert/vitest-coverage-report-action@123077f0e59cbc2e9afd2c454dbc14ae36737874 #v2.1.1
+
+  static-workflow-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+
+      # Run zizmor for static workflow analysis
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -2,17 +2,17 @@ name: run-static-checks
 run-name: ✅ Checking '#${{github.ref_name}}' on branch '${{github.head_ref}}'
 on: pull_request
 
-permissions:
-  pull-requests: write
-  contents: read
+permissions: {}
 
 jobs:
   static-checks:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required to comment on PR with check results
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-
         with:
           persist-credentials: false
 

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -1,5 +1,5 @@
 name: run-static-checks
-run-name: ✅ Checking '#${{github.ref_name}}' on branch '${{github.head_ref}}'
+run-name: Checking '#${{github.event.number}}' on branch '${{github.head_ref}}'
 on: pull_request
 
 permissions: {}

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -1,12 +1,19 @@
 name: run-static-checks
-run-name: ✅ Checking '${{'#'}}${{github.ref_name}}' on branch '${{github.head_ref}}'
+run-name: ✅ Checking '#${{github.ref_name}}' on branch '${{github.head_ref}}'
 on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   static-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 #v6.0.0
@@ -32,4 +39,4 @@ jobs:
         run: npx vitest run --coverage
 
       - name: Vitest coverage report
-        uses: davelosert/vitest-coverage-report-action@v2.1.1
+        uses: davelosert/vitest-coverage-report-action@123077f0e59cbc2e9afd2c454dbc14ae36737874 #v2.1.1

--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -8,6 +8,7 @@ jobs:
   static-checks:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # Required to comment on PR with check results
 
     steps:
@@ -45,6 +46,7 @@ jobs:
   static-workflow-checks:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     steps:


### PR DESCRIPTION
Problem
=======
Added `zizmor` to the repository for static workflow analysis after reading about it after the Tanstack security incident: https://tanstack.com/blog/incident-followup

Zizmor scans for common security issues in GitHub action workflows, and has already flagged several issues in this PR that I've fixed! You can find more information about the tool here: https://docs.zizmor.sh/

*Estimated review size: small, 10-15 minutes*

Solution
========
- Updated existing workflows:
  - Workflows now have narrowly-scoped permissions per-job.
  - Added hash pinning to all actions.
  - Disabled credential persistence on all usage of `actions/checkout`: https://docs.zizmor.sh/audits/#artipacked
  - Updated `actions/checkout` to `v6.0.2`.
  - Bumped several other actions to their newest versions.
- Added `zizmorcore/zizmor-action` for static workflow analysis.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. See actions are passing.

