### PR TITLE
refactor: Separate dataset load function into class (single-file datasets pt. 1)

### DIFF
--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_DATASET_FILENAME } from "src/colorizer/constants";
 import JsonDatasetLoader from "src/colorizer/dataset_loaders/JsonDatasetLoader";
 
-import Dataset from "./Dataset";
+import type Dataset from "./Dataset";
 import type { IArrayLoader, ITextureImageLoader } from "./loaders/ILoader";
 import { FilePathResolver, type IPathResolver, UrlPathResolver } from "./path_resolvers";
 import { LoadErrorMessage, LoadTroubleshooting, type ReportWarningCallback } from "./types";

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -223,32 +223,34 @@ export default class Collection {
     const path = this.getAbsoluteDatasetPath(datasetKey);
     console.log(`Fetching dataset from path '${path}'`);
 
+    let result: DatasetLoadResult;
+    const datasetLoader = new JsonDatasetLoader(path, {
+      frameLoader: options.frameLoader,
+      arrayLoader: options.arrayLoader,
+      reportProgress: options.onLoadProgress,
+      reportWarning: options.reportWarning,
+      manifestLoader: options.manifestLoader,
+      pathResolver: this.pathResolver,
+    });
     try {
-      const datasetLoader = new JsonDatasetLoader(path, {
-        frameLoader: options.frameLoader,
-        arrayLoader: options.arrayLoader,
-        reportProgress: options.onLoadProgress,
-        reportWarning: options.reportWarning,
-        manifestLoader: options.manifestLoader,
-        pathResolver: this.pathResolver,
-      });
       const dataset = await datasetLoader.open();
-      datasetLoader.dispose();
       console.timeEnd("loadDataset");
-      return { loaded: true, dataset: dataset };
+      result = { loaded: true, dataset: dataset };
     } catch (e) {
       console.timeEnd("loadDataset");
       console.error(e);
       if (e instanceof Error) {
-        return {
+        result = {
           loaded: false,
           dataset: null,
           errorMessage: e.message,
         };
       } else {
-        return { loaded: false, dataset: null };
+        result = { loaded: false, dataset: null };
       }
     }
+    datasetLoader.dispose();
+    return result;
   }
 
   public dispose(): void {

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_DATASET_FILENAME } from "src/colorizer/constants";
+import JsonDatasetLoader from "src/colorizer/dataset_loaders/JsonDatasetLoader";
 
 import Dataset from "./Dataset";
 import type { IArrayLoader, ITextureImageLoader } from "./loaders/ILoader";
@@ -222,28 +223,16 @@ export default class Collection {
     const path = this.getAbsoluteDatasetPath(datasetKey);
     console.log(`Fetching dataset from path '${path}'`);
 
-    let totalLoadItems = 0;
-    let completedLoadItems = 0;
-    const onLoadStart = (): void => {
-      totalLoadItems++;
-    };
-    const onLoadComplete = (): void => {
-      completedLoadItems++;
-      options.onLoadProgress?.(completedLoadItems, totalLoadItems);
-    };
-
     try {
-      const dataset = new Dataset(path, {
+      const datasetLoader = new JsonDatasetLoader(path, {
         frameLoader: options.frameLoader,
         arrayLoader: options.arrayLoader,
-        pathResolver: this.pathResolver,
-      });
-      await dataset.open({
-        onLoadStart,
-        onLoadComplete,
+        reportProgress: options.onLoadProgress,
         reportWarning: options.reportWarning,
         manifestLoader: options.manifestLoader,
+        pathResolver: this.pathResolver,
       });
+      const dataset = await datasetLoader.open();
       console.timeEnd("loadDataset");
       return { loaded: true, dataset: dataset };
     } catch (e) {

--- a/src/colorizer/Collection.ts
+++ b/src/colorizer/Collection.ts
@@ -233,6 +233,7 @@ export default class Collection {
         pathResolver: this.pathResolver,
       });
       const dataset = await datasetLoader.open();
+      datasetLoader.dispose();
       console.timeEnd("loadDataset");
       return { loaded: true, dataset: dataset };
     } catch (e) {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -304,10 +304,7 @@ export default class Dataset {
 
   public get numObjects(): number {
     const featureData = this.getFeatureData(this.featureKeys[0]);
-    if (!featureData) {
-      throw new Error("Dataset.numObjects: The first feature could not be loaded. Is the dataset manifest file valid?");
-    }
-    return featureData.data.length;
+    return featureData?.data.length ?? this.times?.length ?? this.segIds?.length ?? 0;
   }
 
   /** Loads a single frame from the dataset */

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -192,7 +192,7 @@ export default class Dataset {
     // Cached data
     this.cachedTracks = new Map();
     this.maxTrackLength = null;
-    this.maxTime = Math.max(...(this.times ?? [0]));
+    this.maxTime = this.times?.reduce((max, t) => Math.max(max, t), 0) ?? 0;
 
     this.frameToGlobalIdLookup = buildFrameToGlobalIdLookup(
       this.times ?? new Uint32Array(),

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -81,12 +81,12 @@ const defaultMetadata: ManifestFileMetadata = {
 
 export default class Dataset {
   private frameLoader: ITextureImageLoader;
-  private frameFiles?: string[];
+  private frameFiles: (string | null)[] | null;
   private frames: DataCache<number, Texture>;
   private frameDimensions: Vector2 | null;
 
   // TODO: validate frames 3D data
-  public frames3d?: Frames3dData;
+  public frames3d: Frames3dData | null;
 
   /** Lookup from a global index of an object to the raw segmentation ID in the
    * frame/image where it appears. */
@@ -127,20 +127,20 @@ export default class Dataset {
   public centroids: Uint16Array | null;
   public bounds: Uint16Array | null;
 
-  public metadata: ManifestFileMetadata;
+  public readonly manifestUrl: string | undefined;
+  public readonly metadata: ManifestFileMetadata;
 
-  /**
-   * Constructs a new Dataset using the provided manifest path.
-   * @param manifestUrl Must be a path to a .json manifest file.
-   * @param frameLoader Optional.
-   * @param arrayLoader Optional.
-   */
   constructor(
     data: {
-      features: Map<string, FeatureData>;
-      frameFiles?: string[];
-      backdrops: Map<string, BackdropData>;
+      manifestUrl?: string;
       metadata?: ManifestFileMetadata;
+      // Image sources
+      frameFiles?: (string | null)[];
+      backdrops?: Map<string, BackdropData>;
+      frames3d?: Frames3dData;
+      frameResolution?: Vector2;
+      // Data arrays
+      features: Map<string, FeatureData>;
       segIds?: Uint32Array | null;
       times?: Uint32Array | null;
       trackIds?: Uint32Array | null;
@@ -150,15 +150,23 @@ export default class Dataset {
     },
     options: { frameLoader?: ITextureImageLoader }
   ) {
+    this.manifestUrl = data.manifestUrl;
+    this.metadata = defaultMetadata;
+
+    // Image sources
     this.frameLoader = options.frameLoader || new ImageFrameLoader(RGBAIntegerFormat);
+
     this.frames = new DataCache(MAX_CACHED_FRAME_BYTES);
-    this.frameFiles = data.frameFiles;
-    this.frameDimensions = null;
+    this.frameFiles = data.frameFiles || null;
+    this.frameDimensions = data.frameResolution ?? null;
 
     this.backdropLoader = options.frameLoader || new ImageFrameLoader(RGBAFormat);
     this.backdropFrames = new DataCache(MAX_CACHED_BACKDROPS_BYTES);
-    this.backdropData = data.backdrops;
+    this.backdropData = data.backdrops || new Map<string, BackdropData>();
 
+    this.frames3d = data.frames3d || null;
+
+    // Data arrays
     this.features = data.features;
     this.times = data.times || null;
     this.trackIds = data.trackIds || null;
@@ -167,9 +175,9 @@ export default class Dataset {
     this.bounds = data.bounds || null;
     this.outliers = data.outliers || null;
 
+    // Cached data
     this.cachedTracks = new Map();
     this.maxTrackLength = null;
-    this.metadata = defaultMetadata;
 
     this.frameToGlobalIdLookup = buildFrameToGlobalIdLookup(
       this.times ?? new Uint32Array(),
@@ -180,8 +188,8 @@ export default class Dataset {
     this.getSegmentationId = this.getSegmentationId.bind(this);
   }
 
-  public get frames2dPaths(): readonly string[] | undefined {
-    return this.frameFiles;
+  public get frames2dPaths(): readonly (string | null)[] | undefined {
+    return this.frameFiles ?? undefined;
   }
 
   public hasFeatureKey(key: string): boolean {
@@ -304,7 +312,7 @@ export default class Dataset {
 
   /** Loads a single frame from the dataset */
   public async loadFrame(index: number): Promise<Texture | undefined> {
-    if (index < 0 || this.frameFiles === undefined || index >= this.frameFiles.length) {
+    if (index < 0 || this.frameFiles === null || index >= this.frameFiles.length) {
       return undefined;
     }
 
@@ -312,11 +320,6 @@ export default class Dataset {
     if (cachedFrame) {
       this.frameDimensions = new Vector2(cachedFrame.image.width, cachedFrame.image.height);
       return cachedFrame;
-    }
-
-    // Allow for undefined or null frame files in the manifest
-    if (this.frameFiles[index] === undefined || this.frameFiles[index] === null) {
-      return undefined;
     }
 
     const fullUrl = this.frameFiles[index];
@@ -382,24 +385,27 @@ export default class Dataset {
    * structures for garbage collection.
    */
   public dispose(): void {
+    // Image sources
     this.frames.dispose();
     this.backdropFrames.dispose();
+    this.backdropData.clear();
+    this.frameFiles = null;
+    this.frames3d = null;
+    // Data arrays
     this.features.forEach((feature) => {
       feature.data = new Float32Array(0);
       feature.tex.dispose();
     });
     this.features.clear();
-    this.cachedTracks.clear();
-    this.frameToGlobalIdLookup?.clear();
     this.bounds = null;
     this.centroids = null;
     this.outliers = null;
     this.segIds = null;
     this.times = null;
     this.trackIds = null;
-    this.backdropData.clear();
-    this.frameFiles = undefined;
-    this.frames3d = undefined;
+    // Cached data
+    this.cachedTracks.clear();
+    this.frameToGlobalIdLookup?.clear();
   }
 
   /** get frame index of a given cell id */

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -17,9 +17,9 @@ import DataCache from "./DataCache";
 import type { ITextureImageLoader } from "./loaders/ILoader";
 import ImageFrameLoader from "./loaders/ImageFrameLoader";
 import Track from "./Track";
-import { type GlobalIdLookupInfo } from "./types";
+import type { GlobalIdLookupInfo } from "./types";
 import { buildFrameToGlobalIdLookup } from "./utils/data_utils";
-import { type ManifestFileMetadata } from "./utils/dataset_utils";
+import type { ManifestFileMetadata } from "./utils/dataset_utils";
 
 export const TRACK_FEATURE_KEY = "_track_";
 export const TIME_FEATURE_KEY = "_time_";

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -151,7 +151,7 @@ export default class Dataset {
     options: { frameLoader?: ITextureImageLoader }
   ) {
     this.manifestUrl = data.manifestUrl;
-    this.metadata = defaultMetadata;
+    this.metadata = data.metadata ?? defaultMetadata;
 
     // Image sources
     this.frameLoader = options.frameLoader || new ImageFrameLoader(RGBAIntegerFormat);
@@ -287,11 +287,11 @@ export default class Dataset {
   }
 
   public has2dFrames(): boolean {
-    return this.frameFiles !== undefined;
+    return this.frameFiles !== null;
   }
 
   public has3dFrames(): boolean {
-    return this.frames3d !== undefined;
+    return this.frames3d !== null;
   }
 
   public get numberOfFrames(): number {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -432,12 +432,17 @@ export default class Dataset {
 
   private getTotalFrames(): number {
     if (this.has2dFrames()) {
-      return this.frameFiles!.length;
+      const frameFilesLength = this.frameFiles?.length;
+      const firstBackdropFramesLength = this.backdropData.values().next().value?.frames.length;
+      if (frameFilesLength !== undefined) {
+        return frameFilesLength;
+      } else if (firstBackdropFramesLength !== undefined) {
+        return firstBackdropFramesLength;
+      }
     } else if (this.has3dFrames()) {
       return this.frames3d!.totalFrames;
-    } else {
-      return this.maxTime + 1;
     }
+    return this.maxTime + 1;
   }
 
   public isValidFrameIndex(index: number): boolean {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -52,7 +52,10 @@ type BackdropData = {
 };
 
 export type Backdrop3dData = {
-  /** Source for 3D data, resolved to http/https URLs. Expected to be a path to an OME-Zarr array.*/
+  /**
+   * Source for 3D data, resolved to http/https or blob URL. Expected to be a
+   * path to an OME-Zarr array.
+   */
   source: string;
   name: string;
   description?: string;
@@ -62,7 +65,10 @@ export type Backdrop3dData = {
 };
 
 export type Frames3dData = {
-  /** Source for 3D data, resolved to http/https URLs. Expected to be a path to an OME-Zarr array.*/
+  /**
+   * Source for 3D data, resolved to http/https or blob URL. Expected to be a
+   * path to an OME-Zarr array.
+   */
   source: string;
   /** Index of the segmentation channel in the source data. */
   segmentationChannel: number;
@@ -71,19 +77,20 @@ export type Frames3dData = {
 };
 
 export type DatasetInputData = {
+  //// Metadata ////
   manifestUrl: string;
   metadata: ManifestFileMetadata;
-  // Image sources
-  /** List of resolved URLs for each frame in the dataset. */
+  //// Image sources ////
+  /** List of resolved (http/https or blob) URLs for frames in the dataset. */
   frameFiles: (string | null)[];
   /**
    * Map of backdrop names to their data. Note that all backdrop paths must be
-   * resolved to URLs.
+   * resolved to http/https or blob URLs.
    */
   backdrops: Map<string, BackdropData>;
   frames3d: Frames3dData;
   frameResolution: Vector2;
-  // Data arrays
+  //// Data arrays ////
   features: Map<string, FeatureData>;
   segIds: Uint32Array | null;
   times: Uint32Array | null;
@@ -109,7 +116,7 @@ const defaultMetadata: ManifestFileMetadata = {
  */
 export default class Dataset {
   //// Metadata ////
-  public readonly manifestUrl: string | undefined;
+  public readonly manifestUrl: string | null;
   public readonly metadata: ManifestFileMetadata;
 
   //// Image sources ////
@@ -165,7 +172,7 @@ export default class Dataset {
     data: Partial<DatasetInputData>,
     options: { frameLoader?: ITextureImageLoader; backdropLoader?: ITextureImageLoader } = {}
   ) {
-    this.manifestUrl = data.manifestUrl;
+    this.manifestUrl = data.manifestUrl ?? null;
     this.metadata = data.metadata ?? defaultMetadata;
 
     // Image sources
@@ -302,7 +309,7 @@ export default class Dataset {
   }
 
   public has2dFrames(): boolean {
-    return this.frameFiles !== null;
+    return this.frameFiles !== null || this.backdropData.size > 0;
   }
 
   public has3dFrames(): boolean {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -148,7 +148,7 @@ export default class Dataset {
       bounds?: Uint16Array | null;
       outliers?: Uint8Array | null;
     },
-    options: { frameLoader?: ITextureImageLoader }
+    options: { frameLoader?: ITextureImageLoader; backdropLoader?: ITextureImageLoader } = {}
   ) {
     this.manifestUrl = data.manifestUrl;
     this.metadata = data.metadata ?? defaultMetadata;
@@ -160,7 +160,7 @@ export default class Dataset {
     this.frameFiles = data.frameFiles || null;
     this.frameDimensions = data.frameResolution ?? null;
 
-    this.backdropLoader = options.frameLoader || new ImageFrameLoader(RGBAFormat);
+    this.backdropLoader = options.backdropLoader || new ImageFrameLoader(RGBAFormat);
     this.backdropFrames = new DataCache(MAX_CACHED_BACKDROPS_BYTES);
     this.backdropData = data.backdrops || new Map<string, BackdropData>();
 

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -147,22 +147,22 @@ export default class Dataset {
   public outliers?: Uint8Array | null;
 
   private tracksFile?: string;
-  private timesFile?: string;
   public trackIds?: Uint32Array | null;
+  private timesFile?: string;
   public times?: Uint32Array | null;
   private cachedTracks: Map<number, Track | null>;
   private maxTrackLength: number | null;
 
-  public centroidsFile?: string;
+  private centroidsFile?: string;
   public centroids?: Uint16Array | null;
 
-  public boundsFile?: string;
+  private boundsFile?: string;
   public bounds?: Uint16Array | null;
 
   public metadata: ManifestFileMetadata;
 
-  public baseUrl: string;
-  public manifestUrl: string;
+  private baseUrl: string;
+  private manifestUrl: string;
   private hasOpened: boolean;
   private pathResolver: IPathResolver;
 

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -8,30 +8,18 @@ import {
   CSV_COL_SEG_ID,
   CSV_COL_TIME,
   CSV_COL_TRACK,
-  MAX_FEATURE_CATEGORIES,
+  MAX_CACHED_BACKDROPS_BYTES,
+  MAX_CACHED_FRAME_BYTES,
 } from "src/colorizer/constants";
 import type { CsvDataColumn } from "src/colorizer/utils/csv_utils";
 
 import DataCache from "./DataCache";
-import type { IArrayLoader, ITextureImageLoader } from "./loaders/ILoader";
+import type { ITextureImageLoader } from "./loaders/ILoader";
 import ImageFrameLoader from "./loaders/ImageFrameLoader";
-import UrlArrayLoader from "./loaders/UrlArrayLoader";
-import { type IPathResolver, UrlPathResolver } from "./path_resolvers";
 import Track from "./Track";
-import {
-  type FeatureArrayType,
-  FeatureDataType,
-  type GlobalIdLookupInfo,
-  LoadErrorMessage,
-  LoadTroubleshooting,
-  type ReportWarningCallback,
-} from "./types";
-import { AnalyticsEvent, triggerAnalyticsEvent } from "./utils/analytics";
-import { buildFrameToGlobalIdLookup, formatAsBulletList, getKeyFromName } from "./utils/data_utils";
-import { type ManifestFile, type ManifestFileMetadata, updateManifestVersion } from "./utils/dataset_utils";
-import { padCentroidsTo3d } from "./utils/math_utils";
-import { packDataTexture } from "./utils/texture_utils";
-import * as urlUtils from "./utils/url_utils";
+import { type GlobalIdLookupInfo } from "./types";
+import { buildFrameToGlobalIdLookup } from "./utils/data_utils";
+import { type ManifestFileMetadata } from "./utils/dataset_utils";
 
 export const TRACK_FEATURE_KEY = "_track_";
 export const TIME_FEATURE_KEY = "_time_";
@@ -60,7 +48,7 @@ export type FeatureData = {
 
 type BackdropData = {
   name: string;
-  frames: string[];
+  frames: (string | null)[];
 };
 
 export type Backdrop3dData = {
@@ -81,13 +69,6 @@ export type Frames3dData = {
   backdrops?: Backdrop3dData[];
 };
 
-type OpenOptions = Partial<{
-  manifestLoader: typeof urlUtils.fetchManifestJson;
-  onLoadStart?: () => void;
-  onLoadComplete?: () => void;
-  reportWarning?: ReportWarningCallback;
-}>;
-
 const defaultMetadata: ManifestFileMetadata = {
   frameDims: {
     width: 0,
@@ -98,22 +79,18 @@ const defaultMetadata: ManifestFileMetadata = {
   startTimeSeconds: 0,
 };
 
-const MAX_CACHED_FRAME_BYTES = 500_000_000; // 500 MB
-const MAX_CACHED_BACKDROPS_BYTES = 500_000_000; // 500 MB
-
 export default class Dataset {
   private frameLoader: ITextureImageLoader;
   private frameFiles?: string[];
-  private frames: DataCache<number, Texture> | null;
+  private frames: DataCache<number, Texture>;
   private frameDimensions: Vector2 | null;
 
   // TODO: validate frames 3D data
   public frames3d?: Frames3dData;
 
-  private segIdsFile?: string;
   /** Lookup from a global index of an object to the raw segmentation ID in the
    * frame/image where it appears. */
-  public segIds?: Uint32Array | null;
+  public segIds: Uint32Array | null;
 
   /**
    * Maps from a frame number to a lookup table used to get the global ID of a
@@ -131,40 +108,26 @@ export default class Dataset {
    *
    * See `GlobalIdLookupInfo` for more details.
    */
-  public frameToGlobalIdLookup: Map<number, GlobalIdLookupInfo> | null;
+  public frameToGlobalIdLookup: Map<number, GlobalIdLookupInfo>;
 
   private backdropLoader: ITextureImageLoader;
   private backdropData: Map<string, BackdropData>;
-  private backdropFrames: DataCache<string, Texture> | null;
+  private backdropFrames: DataCache<string, Texture>;
 
-  private arrayLoader: IArrayLoader;
-  private cleanupArrayLoaderOnDispose: boolean;
   // Use map to enforce ordering
   /** Ordered map from feature keys to feature data. */
   private features: Map<string, FeatureData>;
 
-  private outlierFile?: string;
-  public outliers?: Uint8Array | null;
-
-  private tracksFile?: string;
-  public trackIds?: Uint32Array | null;
-  private timesFile?: string;
-  public times?: Uint32Array | null;
+  public trackIds: Uint32Array | null;
+  public times: Uint32Array | null;
   private cachedTracks: Map<number, Track | null>;
   private maxTrackLength: number | null;
 
-  private centroidsFile?: string;
-  public centroids?: Uint16Array | null;
-
-  private boundsFile?: string;
-  public bounds?: Uint16Array | null;
+  public outliers: Uint8Array | null;
+  public centroids: Uint16Array | null;
+  public bounds: Uint16Array | null;
 
   public metadata: ManifestFileMetadata;
-
-  private baseUrl: string;
-  private manifestUrl: string;
-  private hasOpened: boolean;
-  private pathResolver: IPathResolver;
 
   /**
    * Constructs a new Dataset using the provided manifest path.
@@ -173,106 +136,52 @@ export default class Dataset {
    * @param arrayLoader Optional.
    */
   constructor(
-    manifestUrl: string,
-    options: { frameLoader?: ITextureImageLoader; arrayLoader?: IArrayLoader; pathResolver?: IPathResolver }
+    data: {
+      features: Map<string, FeatureData>;
+      frameFiles?: string[];
+      backdrops: Map<string, BackdropData>;
+      metadata?: ManifestFileMetadata;
+      segIds?: Uint32Array | null;
+      times?: Uint32Array | null;
+      trackIds?: Uint32Array | null;
+      centroids?: Uint16Array | null;
+      bounds?: Uint16Array | null;
+      outliers?: Uint8Array | null;
+    },
+    options: { frameLoader?: ITextureImageLoader }
   ) {
-    this.manifestUrl = manifestUrl;
-    this.pathResolver = options.pathResolver ?? new UrlPathResolver();
-
-    this.baseUrl = urlUtils.formatPath(manifestUrl.substring(0, manifestUrl.lastIndexOf("/")));
-    this.hasOpened = false;
-
     this.frameLoader = options.frameLoader || new ImageFrameLoader(RGBAIntegerFormat);
-    this.frameFiles = [];
-    this.frames = null;
-    this.backdropFrames = null;
+    this.frames = new DataCache(MAX_CACHED_FRAME_BYTES);
+    this.frameFiles = data.frameFiles;
     this.frameDimensions = null;
 
-    this.frameToGlobalIdLookup = null;
-
     this.backdropLoader = options.frameLoader || new ImageFrameLoader(RGBAFormat);
-    this.backdropData = new Map();
+    this.backdropFrames = new DataCache(MAX_CACHED_BACKDROPS_BYTES);
+    this.backdropData = data.backdrops;
 
-    this.cleanupArrayLoaderOnDispose = !options.arrayLoader;
-    this.arrayLoader = options.arrayLoader || new UrlArrayLoader();
-    this.features = new Map();
+    this.features = data.features;
+    this.times = data.times || null;
+    this.trackIds = data.trackIds || null;
+    this.segIds = data.segIds || null;
+    this.centroids = data.centroids || null;
+    this.bounds = data.bounds || null;
+    this.outliers = data.outliers || null;
+
     this.cachedTracks = new Map();
     this.maxTrackLength = null;
     this.metadata = defaultMetadata;
+
+    this.frameToGlobalIdLookup = buildFrameToGlobalIdLookup(
+      this.times ?? new Uint32Array(),
+      this.segIds ?? new Uint32Array(),
+      this.getTotalFrames()
+    );
 
     this.getSegmentationId = this.getSegmentationId.bind(this);
   }
 
   public get frames2dPaths(): readonly string[] | undefined {
     return this.frameFiles;
-  }
-
-  private resolveManifestPath = (url: string): string | null => {
-    return this.pathResolver.resolve("", url);
-  };
-
-  private resolvePath = (url: string): string | null => {
-    return this.pathResolver.resolve(this.baseUrl, url);
-  };
-
-  private parseFeatureType(
-    inputType: string | undefined,
-    defaultType: FeatureType = FeatureType.CONTINUOUS
-  ): FeatureType {
-    const isFeatureType = (inputType: string): inputType is FeatureType => {
-      return Object.values(FeatureType).includes(inputType as FeatureType);
-    };
-
-    inputType = inputType?.toLowerCase() || "";
-    return isFeatureType(inputType) ? inputType : defaultType;
-  }
-
-  /**
-   * Loads a feature from the dataset, fetching its data from the provided url.
-   * @returns A promise of an array tuple containing the feature key and its FeatureData.
-   */
-  private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData]> {
-    const name = metadata.name;
-    const key = metadata.key || getKeyFromName(name);
-    const url = this.resolvePath(metadata.data);
-    if (!url) {
-      throw new Error(`Failed to resolve URL for feature ${name}: '${metadata.data}'`);
-    }
-    const featureType = this.parseFeatureType(metadata.type);
-
-    const source = await this.arrayLoader.load(
-      url,
-      FeatureDataType.F32,
-      metadata.min ?? undefined,
-      metadata.max ?? undefined
-    );
-
-    const featureCategories = metadata?.categories;
-    // Validation
-    if (featureType === FeatureType.CATEGORICAL && !metadata?.categories) {
-      throw new Error(`Feature ${name} is categorical but no categories were provided.`);
-    }
-    if (featureCategories && featureCategories.length > MAX_FEATURE_CATEGORIES) {
-      throw new Error(
-        `Feature ${name} has too many categories (${featureCategories.length} > max ${MAX_FEATURE_CATEGORIES}).`
-      );
-    }
-
-    return [
-      key,
-      {
-        name,
-        key,
-        tex: source.getTexture(),
-        data: source.getBuffer(),
-        min: source.getMin(),
-        max: source.getMax(),
-        unit: metadata.unit || "",
-        type: featureType,
-        categories: featureCategories || null,
-        description: metadata.description || null,
-      },
-    ];
   }
 
   public hasFeatureKey(key: string): boolean {
@@ -377,29 +286,6 @@ export default class Dataset {
     return this.frames3d !== undefined;
   }
 
-  /**
-   * Fetches and loads a data file as an array and returns its data as a TypedArray using the provided dataType.
-   * @param dataType The expected format of the data.
-   * @param fileUrl String url of the file to be loaded.
-   * @throws An error if the data cannot be loaded from the file.
-   * @returns Promise of a TypedArray loaded from the file. If `fileUrl` is undefined, returns null.
-   */
-  private async loadToBuffer<T extends FeatureDataType>(
-    dataType: T,
-    fileUrl?: string
-  ): Promise<FeatureArrayType[T] | null> {
-    if (!fileUrl) {
-      return null;
-    }
-
-    const url = this.resolvePath(fileUrl);
-    if (!url) {
-      throw new Error(`Failed to resolve path: '${fileUrl}'`);
-    }
-    const source = await this.arrayLoader.load(url, dataType);
-    return source.getBuffer();
-  }
-
   public get numberOfFrames(): number {
     return this.getTotalFrames();
   }
@@ -433,7 +319,7 @@ export default class Dataset {
       return undefined;
     }
 
-    const fullUrl = this.resolvePath(this.frameFiles[index]);
+    const fullUrl = this.frameFiles[index];
     if (!fullUrl) {
       throw new Error(`Failed to resolve path for frame ${index}: '${this.frameFiles[index]}'`);
     }
@@ -441,7 +327,7 @@ export default class Dataset {
     this.frameDimensions = new Vector2(loadedFrame.image.width, loadedFrame.image.height);
     const frameSizeBytes = loadedFrame.image.width * loadedFrame.image.height * 4;
     // Note that, due to image compression, images may take up much less space in memory than their raw size.
-    this.frames?.insert(index, loadedFrame, frameSizeBytes);
+    this.frames.insert(index, loadedFrame, frameSizeBytes);
     return loadedFrame;
   }
 
@@ -468,19 +354,19 @@ export default class Dataset {
       return cachedFrame;
     }
 
-    const frames = this.backdropData.get(key)?.frames;
+    const backdropFrames = this.backdropData.get(key)?.frames;
     // TODO: Wrapping or clamping?
-    if (!frames || index < 0 || index >= frames.length) {
+    if (!backdropFrames || index < 0 || index >= backdropFrames.length) {
       return undefined;
     }
 
-    const fullUrl = this.resolvePath(frames[index]);
+    const fullUrl = backdropFrames[index];
     if (!fullUrl) {
-      throw new Error(`Failed to resolve path for backdrop '${key}' at index ${index}: '${frames[index]}'`);
+      throw new Error(`Failed to resolve path for backdrop '${key}' at index ${index}: '${backdropFrames[index]}'`);
     }
-    const loadedFrame = await this.backdropLoader.load(fullUrl);
-    this.backdropFrames?.insert(cacheKey, loadedFrame);
-    return loadedFrame;
+    const loadedBackdrop = await this.backdropLoader.load(fullUrl);
+    this.backdropFrames?.insert(cacheKey, loadedBackdrop);
+    return loadedBackdrop;
   }
 
   /**
@@ -491,326 +377,13 @@ export default class Dataset {
     return this.frameDimensions || new Vector2(1, 1);
   }
 
-  /** Adds auto-generated features for time and track to this Dataset. */
-  private addTimeAndTrackFeatures(): void {
-    if (this.trackIds && !this.features.has(TRACK_FEATURE_KEY)) {
-      const trackData = new Float32Array(this.trackIds);
-      this.features.set(TRACK_FEATURE_KEY, {
-        name: "Track ID",
-        key: TRACK_FEATURE_KEY,
-        data: this.trackIds,
-        tex: packDataTexture(trackData, FeatureDataType.F32),
-        min: 0,
-        max: this.trackIds.reduce((max, id) => Math.max(max, id), 0),
-        unit: "",
-        type: FeatureType.DISCRETE,
-        categories: null,
-        description: "Track ID of the object. This feature was added by the viewer from provided data.",
-      });
-    }
-
-    if (this.times && !this.features.has(TIME_FEATURE_KEY)) {
-      const timeData = new Float32Array(this.times);
-      this.features.set(TIME_FEATURE_KEY, {
-        name: "Time (frames)",
-        key: TIME_FEATURE_KEY,
-        data: this.times,
-        tex: packDataTexture(timeData, FeatureDataType.F32),
-        min: 0,
-        max: this.times.reduce((max, id) => Math.max(max, id), 0),
-        unit: "",
-        type: FeatureType.CONTINUOUS,
-        categories: null,
-        description: "Frame number where the object appears. This feature was added by the viewer from provided data.",
-      });
-    }
-  }
-
-  private addCentroidFeatures(): void {
-    const centroidFeatureKeys = [CENTROID_X_FEATURE_KEY, CENTROID_Y_FEATURE_KEY, CENTROID_Z_FEATURE_KEY];
-    const axes = ["X", "Y", "Z"];
-    if (!this.centroids) {
-      return;
-    }
-    // TODO: The handling for centroid scaling is not consistent for 2D and 3D
-    // datasets. Currently, 2D datasets must provide centroids in pixels, while
-    // 3D datasets must provide them in physical units. If both 3D and 2D frame
-    // data is present, centroids would be read as being pixel units, which
-    // cause centroids to be scaled incorrectly in 3D. Add a flag to indicate
-    // whether centroids are in physical or pixel units.
-    const metadataDims = this.metadata.frameDims;
-    const hasMetadataDims = metadataDims && metadataDims.width && metadataDims.height;
-    const physicalDims = hasMetadataDims ? [metadataDims.width, metadataDims.height, 1] : [1, 1, 1];
-    const pixelDims = this.frameDimensions ? [this.frameDimensions.x, this.frameDimensions.y, 1] : physicalDims;
-
-    for (let i = 0; i < centroidFeatureKeys.length; i++) {
-      const key = centroidFeatureKeys[i];
-      if (this.features.has(key)) {
-        continue;
-      }
-
-      const rawData = this.centroids.filter((_, index) => index % 3 === i);
-      const data = new Float32Array(rawData);
-      if (this.frameDimensions) {
-        // If provided, normalize centroid coordinates to physical units.
-        const physicalDim = physicalDims[i];
-        const pixelDim = pixelDims[i];
-        for (let j = 0; j < data.length; j++) {
-          data[j] = (data[j] / pixelDim) * physicalDim;
-        }
-      }
-
-      const axis = axes[i];
-      const min = 0;
-      const dataMax = data.reduce((max, value) => Math.max(max, value), -Infinity);
-      const max = hasMetadataDims ? physicalDims[i] : dataMax;
-      const tex = packDataTexture(data, FeatureDataType.F32);
-      const description = `Centroid ${axis} coordinate, in pixels/voxels. This feature was added by the viewer from provided data.`;
-      this.features.set(key, {
-        name: "Centroid " + axis,
-        key,
-        data,
-        tex,
-        min,
-        max,
-        unit: metadataDims?.units || "",
-        type: FeatureType.DISCRETE,
-        categories: null,
-        description,
-      });
-    }
-  }
-
-  private resolveAndValidateFrames3d(data: ManifestFile["frames3d"], options: OpenOptions): Frames3dData | undefined {
-    if (!data) {
-      return undefined;
-    }
-    const frameSource = this.resolvePath(data.source);
-    const backdrops: Backdrop3dData[] = [];
-    if (!frameSource) {
-      // This will only happen if using a file path resolver, if this file does
-      // not exist in a ZIP file.
-
-      // TODO: This will fail for Zarrs, which are directories and not files, so
-      // `resolvePath` will return `null`. Even if `resolvePath` did handle
-      // directories, Zarrs index from the directory root, which is provided as
-      // a Object URL. Adding additional paths to the end of an Object URL (e.g.
-      // TCZYX specifiers for zarrs, like `/0/0/0`) does not result in a working
-      // URL. This means there is no way to make the current path resolver work
-      // without overriding `fetch` in dependency libraries (vole-core).
-      throw new Error(
-        `Failed to resolve path for 3D frame source '${data.source}'. ${LoadTroubleshooting.CHECK_ZIP_ZARR_DATA}`
-      );
-    }
-    // Validate backdrops
-    if (data.backdrops) {
-      const failedBackdrops: Backdrop3dData[] = [];
-      for (const backdrop of data.backdrops) {
-        const backdropSource = this.resolvePath(backdrop.source);
-        if (!backdropSource) {
-          failedBackdrops.push({ channelIndex: 0, ...backdrop });
-          continue;
-        }
-        backdrops.push({
-          ...backdrop,
-          channelIndex: backdrop.channelIndex ?? 0,
-          source: backdropSource,
-        });
-      }
-      if (failedBackdrops.length > 0) {
-        options.reportWarning?.(
-          "One or more 3D backdrop sources could not be resolved to files, and will not be shown.",
-          [
-            "The following backdrop source(s) could not be resolved:",
-            ...failedBackdrops.map((b) => `- ${b.source} (${b.name})`),
-            LoadTroubleshooting.CHECK_ZIP_ZARR_DATA,
-          ]
-        );
-      }
-    }
-    return {
-      source: frameSource,
-      segmentationChannel: data.segmentationChannel ?? 0,
-      totalFrames: data.totalFrames ?? 0,
-      backdrops,
-    };
-  }
-
-  /**
-   * Opens the dataset and loads all necessary files from the manifest.
-   * @param options Configuration options for the dataset loader.
-   * - `manifestLoader` The function used to load the manifest JSON data. If undefined, uses a default fetch method.
-   * - `onLoadStart` Called once for each data file (other than the manifest) that starts an async load process.
-   * - `onLoadComplete` Called once when each data file finishes loading.
-   * - `reportWarning` Called with a string or array of strings to report warnings to the user. These are non-fatal errors.
-   * @returns A Promise that resolves when loading completes.
-   */
-  public async open(options: OpenOptions = {}): Promise<void> {
-    if (this.hasOpened) {
-      return;
-    }
-    if (!options.manifestLoader) {
-      options.manifestLoader = urlUtils.fetchManifestJson;
-    }
-
-    const startTime = new Date();
-
-    const resolvedManifestUrl = this.resolveManifestPath(this.manifestUrl);
-    if (resolvedManifestUrl === null) {
-      // TODO: Currently, only the FilePathResolver (used for ZIP files) can
-      // return `null` when resolving paths, which indicates that a file does
-      // not exist. If support for loading from other sources (local folders,
-      // etc.) is added, Dataset will need to store metadata about the source.
-      throw new Error(`No '${this.manifestUrl}' was found. ${LoadTroubleshooting.CHECK_ZIP_FORMAT_MANIFEST}`);
-    }
-    const manifest = updateManifestVersion(await options.manifestLoader(resolvedManifestUrl));
-
-    this.frameFiles = manifest.frames;
-    this.frames3d = this.resolveAndValidateFrames3d(manifest.frames3d, options);
-    this.outlierFile = manifest.outliers;
-    this.metadata = { ...defaultMetadata, ...manifest.metadata };
-
-    this.tracksFile = manifest.tracks;
-    this.timesFile = manifest.times;
-    this.centroidsFile = manifest.centroids;
-    this.boundsFile = manifest.bounds;
-    this.segIdsFile = manifest.segIds;
-
-    if (manifest.backdrops && manifest.frames) {
-      for (const { name, key, frames } of manifest.backdrops) {
-        this.backdropData.set(key, { name, frames });
-        if (frames.length !== this.frameFiles?.length || 0) {
-          throw new Error(
-            `Number of frames (${this.frameFiles?.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
-              ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
-          );
-        }
-      }
-    }
-
-    this.frames = new DataCache(MAX_CACHED_FRAME_BYTES);
-    this.backdropFrames = new DataCache(MAX_CACHED_BACKDROPS_BYTES);
-
-    // Wrap an async operation and report progress when it starts + completes
-    const reportLoadProgress = async <T>(promise: Promise<T>): Promise<T> => {
-      options.onLoadStart?.();
-      return promise.then((result) => {
-        options.onLoadComplete?.();
-        return result;
-      });
-    };
-
-    // Load feature data
-    if (manifest.features.length === 0) {
-      throw new Error(LoadErrorMessage.MANIFEST_HAS_NO_FEATURES);
-    }
-    const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
-      reportLoadProgress(this.loadFeature(data))
-    );
-
-    const result = await Promise.allSettled([
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U8, this.outlierFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, this.tracksFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, this.timesFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, this.centroidsFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, this.boundsFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, this.segIdsFile)),
-      reportLoadProgress(this.loadFrame(0)),
-      ...featuresPromises,
-    ]);
-    const [outliers, tracks, times, centroids, bounds, frameIdOffsets, _loadedFrame, ...featureResults] = result;
-
-    const unloadableDataFiles: string[] = [];
-    function makeLoadFailedCallback(fileType: string, url?: string): (reason: any) => void {
-      return (reason: any) => {
-        console.warn(`${fileType} data could not be loaded: ${reason}`);
-        unloadableDataFiles.push(`${fileType}: '${url || "N/A"}'`);
-      };
-    }
-
-    this.outliers = urlUtils.getPromiseValue(outliers, makeLoadFailedCallback("Outliers", this.outlierFile));
-    this.trackIds = urlUtils.getPromiseValue(tracks, makeLoadFailedCallback("Tracks", this.tracksFile));
-    this.times = urlUtils.getPromiseValue(times, makeLoadFailedCallback("Times", this.timesFile));
-    this.centroids = urlUtils.getPromiseValue(centroids, makeLoadFailedCallback("Centroids", this.centroidsFile));
-    this.bounds = urlUtils.getPromiseValue(bounds, makeLoadFailedCallback("Bounds", this.boundsFile));
-    this.segIds = urlUtils.getPromiseValue(frameIdOffsets, makeLoadFailedCallback("Segmentation IDs", this.segIdsFile));
-
-    if (unloadableDataFiles.length > 0) {
-      // Report warning of all the files that couldn't be loaded and their associated errors.
-      options.reportWarning?.("Some data files failed to load.", [
-        "The following data file(s) failed to load, which may cause the viewer to behave unexpectedly:",
-        ...unloadableDataFiles.map((fileType) => ` - ${fileType}`),
-        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
-      ]);
-    }
-
-    // Keep original sorting order of features by inserting in promise order.
-    featureResults.forEach((result, index) => {
-      const onFeatureLoadFailed = (reason: any): void => console.warn(`Feature ${index}: `, reason);
-      const featureValue = urlUtils.getPromiseValue(result, onFeatureLoadFailed);
-      if (featureValue) {
-        const [key, data] = featureValue;
-        this.features.set(key, data);
-      }
-    });
-
-    if (this.features.size !== manifest.features.length) {
-      // Report the names of all features that could not be loaded.
-      const loadedFeatureNames = new Set(Array.from(this.features.values()).map((f) => f.name));
-      const missingFeatureNames = manifest.features.filter((f) => !loadedFeatureNames.has(f.name)).map((f) => f.name);
-
-      options.reportWarning?.("Some features failed to load.", [
-        "The following feature(s) could not be loaded and will not be shown: ",
-        ...formatAsBulletList(missingFeatureNames, 5),
-        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
-      ]);
-    }
-
-    // Construct default array of segmentation IDs if not provided in the manifest.
-    if (!this.segIds) {
-      // Construct default segIds array (0, 1, 2, ...)
-      this.segIds = new Uint32Array(this.numObjects);
-      for (let i = 0; i < this.numObjects; i++) {
-        this.segIds[i] = i + 1;
-      }
-    }
-
-    if (this.times) {
-      this.frameToGlobalIdLookup = buildFrameToGlobalIdLookup(this.times, this.segIds, this.getTotalFrames());
-    }
-
-    // Fixup 2D centroids to 3D
-    if (this.centroids) {
-      this.centroids = padCentroidsTo3d(this.centroids, this.numObjects);
-    }
-
-    this.addCentroidFeatures();
-    this.addTimeAndTrackFeatures();
-
-    // Analytics reporting
-    triggerAnalyticsEvent(AnalyticsEvent.DATASET_LOAD, {
-      datasetWriterVersion: this.metadata.writerVersion || "N/A",
-      datasetTotalObjects: this.numObjects,
-      datasetFeatureCount: this.features.size,
-      datasetFrameCount: this.numberOfFrames,
-      datasetLoadTimeMs: new Date().getTime() - startTime.getTime(),
-    });
-
-    this.hasOpened = true;
-    // TODO: Pre-process feature data to handle outlier values by interpolating between known good values (#21)
-  }
-
   /**
    * Frees the GPU resources held by this dataset, and marks internal data
    * structures for garbage collection.
    */
   public dispose(): void {
-    this.frames?.dispose();
-    this.backdropFrames?.dispose();
-    // Cleanup array loader if it was created in the constructor
-    if (this.cleanupArrayLoaderOnDispose) {
-      this.arrayLoader.dispose();
-    }
+    this.frames.dispose();
+    this.backdropFrames.dispose();
     this.features.forEach((feature) => {
       feature.data = new Float32Array(0);
       feature.tex.dispose();
@@ -826,8 +399,6 @@ export default class Dataset {
     this.trackIds = null;
     this.backdropData.clear();
     this.frameFiles = undefined;
-    this.backdropFrames = null;
-    this.frames = null;
     this.frames3d = undefined;
   }
 

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -52,6 +52,7 @@ type BackdropData = {
 };
 
 export type Backdrop3dData = {
+  /** Source for 3D data, resolved to http/https URLs. Expected to be a path to an OME-Zarr array.*/
   source: string;
   name: string;
   description?: string;
@@ -69,6 +70,29 @@ export type Frames3dData = {
   backdrops?: Backdrop3dData[];
 };
 
+export type DatasetInputData = {
+  manifestUrl: string;
+  metadata: ManifestFileMetadata;
+  // Image sources
+  /** List of resolved URLs for each frame in the dataset. */
+  frameFiles: (string | null)[];
+  /**
+   * Map of backdrop names to their data. Note that all backdrop paths must be
+   * resolved to URLs.
+   */
+  backdrops: Map<string, BackdropData>;
+  frames3d: Frames3dData;
+  frameResolution: Vector2;
+  // Data arrays
+  features: Map<string, FeatureData>;
+  segIds: Uint32Array | null;
+  times: Uint32Array | null;
+  trackIds: Uint32Array | null;
+  centroids: Uint16Array | null;
+  bounds: Uint16Array | null;
+  outliers: Uint8Array | null;
+};
+
 const defaultMetadata: ManifestFileMetadata = {
   frameDims: {
     width: 0,
@@ -79,18 +103,44 @@ const defaultMetadata: ManifestFileMetadata = {
   startTimeSeconds: 0,
 };
 
+/**
+ * A data container for the image sources, features, and associated metadata for
+ * a dataset. Provides caching and convenience methods for data access.
+ */
 export default class Dataset {
+  //// Metadata ////
+  public readonly manifestUrl: string | undefined;
+  public readonly metadata: ManifestFileMetadata;
+
+  //// Image sources ////
   private frameLoader: ITextureImageLoader;
   private frameFiles: (string | null)[] | null;
   private frames: DataCache<number, Texture>;
   private frameDimensions: Vector2 | null;
 
-  // TODO: validate frames 3D data
+  private backdropLoader: ITextureImageLoader;
+  private backdropData: Map<string, BackdropData>;
+  private backdropFrames: DataCache<string, Texture>;
+
   public frames3d: Frames3dData | null;
+
+  //// Data arrays ////
+  /** Ordered map from feature keys to feature data. */
+  private features: Map<string, FeatureData>;
+  public trackIds: Uint32Array | null;
+  public times: Uint32Array | null;
 
   /** Lookup from a global index of an object to the raw segmentation ID in the
    * frame/image where it appears. */
   public segIds: Uint32Array | null;
+
+  public outliers: Uint8Array | null;
+  public centroids: Uint16Array | null;
+  public bounds: Uint16Array | null;
+
+  //// Cached Data ////
+  private cachedTracks: Map<number, Track | null>;
+  private maxTrackLength: number | null;
 
   /**
    * Maps from a frame number to a lookup table used to get the global ID of a
@@ -108,46 +158,10 @@ export default class Dataset {
    *
    * See `GlobalIdLookupInfo` for more details.
    */
-  public frameToGlobalIdLookup: Map<number, GlobalIdLookupInfo>;
-
-  private backdropLoader: ITextureImageLoader;
-  private backdropData: Map<string, BackdropData>;
-  private backdropFrames: DataCache<string, Texture>;
-
-  // Use map to enforce ordering
-  /** Ordered map from feature keys to feature data. */
-  private features: Map<string, FeatureData>;
-
-  public trackIds: Uint32Array | null;
-  public times: Uint32Array | null;
-  private cachedTracks: Map<number, Track | null>;
-  private maxTrackLength: number | null;
-
-  public outliers: Uint8Array | null;
-  public centroids: Uint16Array | null;
-  public bounds: Uint16Array | null;
-
-  public readonly manifestUrl: string | undefined;
-  public readonly metadata: ManifestFileMetadata;
+  public readonly frameToGlobalIdLookup: Map<number, GlobalIdLookupInfo>;
 
   constructor(
-    data: {
-      manifestUrl?: string;
-      metadata?: ManifestFileMetadata;
-      // Image sources
-      frameFiles?: (string | null)[];
-      backdrops?: Map<string, BackdropData>;
-      frames3d?: Frames3dData;
-      frameResolution?: Vector2;
-      // Data arrays
-      features: Map<string, FeatureData>;
-      segIds?: Uint32Array | null;
-      times?: Uint32Array | null;
-      trackIds?: Uint32Array | null;
-      centroids?: Uint16Array | null;
-      bounds?: Uint16Array | null;
-      outliers?: Uint8Array | null;
-    },
+    data: Partial<DatasetInputData>,
     options: { frameLoader?: ITextureImageLoader; backdropLoader?: ITextureImageLoader } = {}
   ) {
     this.manifestUrl = data.manifestUrl;
@@ -155,7 +169,6 @@ export default class Dataset {
 
     // Image sources
     this.frameLoader = options.frameLoader || new ImageFrameLoader(RGBAIntegerFormat);
-
     this.frames = new DataCache(MAX_CACHED_FRAME_BYTES);
     this.frameFiles = data.frameFiles || null;
     this.frameDimensions = data.frameResolution ?? null;
@@ -167,7 +180,7 @@ export default class Dataset {
     this.frames3d = data.frames3d || null;
 
     // Data arrays
-    this.features = data.features;
+    this.features = data.features || new Map<string, FeatureData>();
     this.times = data.times || null;
     this.trackIds = data.trackIds || null;
     this.segIds = data.segIds || null;
@@ -347,15 +360,13 @@ export default class Dataset {
   }
 
   public async loadBackdrop(key: string, index: number): Promise<Texture | undefined> {
-    // TODO: Implement caching
     const cacheKey = `${key}-${index}`;
-    const cachedFrame = this.backdropFrames?.get(cacheKey);
+    const cachedFrame = this.backdropFrames.get(cacheKey);
     if (cachedFrame) {
       return cachedFrame;
     }
 
     const backdropFrames = this.backdropData.get(key)?.frames;
-    // TODO: Wrapping or clamping?
     if (!backdropFrames || index < 0 || index >= backdropFrames.length) {
       return undefined;
     }
@@ -365,7 +376,7 @@ export default class Dataset {
       throw new Error(`Failed to resolve path for backdrop '${key}' at index ${index}: '${backdropFrames[index]}'`);
     }
     const loadedBackdrop = await this.backdropLoader.load(fullUrl);
-    this.backdropFrames?.insert(cacheKey, loadedBackdrop);
+    this.backdropFrames.insert(cacheKey, loadedBackdrop);
     return loadedBackdrop;
   }
 
@@ -410,7 +421,7 @@ export default class Dataset {
     return this.times?.[index] || 0;
   }
 
-  public getTotalFrames(): number {
+  private getTotalFrames(): number {
     if (this.has2dFrames()) {
       return this.frameFiles?.length ?? 0;
     } else {

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -141,6 +141,7 @@ export default class Dataset {
   //// Cached Data ////
   private cachedTracks: Map<number, Track | null>;
   private maxTrackLength: number | null;
+  private maxTime: number;
 
   /**
    * Maps from a frame number to a lookup table used to get the global ID of a
@@ -191,6 +192,7 @@ export default class Dataset {
     // Cached data
     this.cachedTracks = new Map();
     this.maxTrackLength = null;
+    this.maxTime = Math.max(...(this.times ?? [0]));
 
     this.frameToGlobalIdLookup = buildFrameToGlobalIdLookup(
       this.times ?? new Uint32Array(),
@@ -334,7 +336,7 @@ export default class Dataset {
 
     const fullUrl = this.frameFiles[index];
     if (!fullUrl) {
-      throw new Error(`Failed to resolve path for frame ${index}: '${this.frameFiles[index]}'`);
+      throw new Error(`Failed to resolve path for frame ${index}: '${fullUrl}'`);
     }
     const loadedFrame = await this.frameLoader.load(fullUrl);
     this.frameDimensions = new Vector2(loadedFrame.image.width, loadedFrame.image.height);
@@ -423,9 +425,11 @@ export default class Dataset {
 
   private getTotalFrames(): number {
     if (this.has2dFrames()) {
-      return this.frameFiles?.length ?? 0;
+      return this.frameFiles!.length;
+    } else if (this.has3dFrames()) {
+      return this.frames3d!.totalFrames;
     } else {
-      return this.frames3d?.totalFrames ?? 0;
+      return this.maxTime + 1;
     }
   }
 

--- a/src/colorizer/constants.ts
+++ b/src/colorizer/constants.ts
@@ -62,3 +62,6 @@ export const CSV_COL_DATASET = "Dataset";
 
 export const BOOLEAN_VALUE_TRUE = "true";
 export const BOOLEAN_VALUE_FALSE = "false";
+
+export const MAX_CACHED_FRAME_BYTES = 500000000; // 500 MB
+export const MAX_CACHED_BACKDROPS_BYTES = 500000000; // 500 MB

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -251,11 +251,11 @@ export default class JsonDatasetLoader {
 
   private reportLoadProgress<T>(promise: Promise<T>): Promise<T> {
     this.numRequests++;
-    return promise.then((result) => {
+    promise.finally(() => {
       this.numCompletedRequests++;
       this.reportProgress?.(this.numCompletedRequests, this.numRequests);
-      return result;
     });
+    return promise;
   }
 
   private async loadDataset(): Promise<Dataset> {

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -45,6 +45,9 @@ const DEFAULT_METADATA: ManifestFileMetadata = {
   startTimeSeconds: 0,
 };
 
+/**
+ * Loads a dataset from a manifest JSON file.
+ */
 export default class JsonDatasetLoader {
   private arrayLoader: IArrayLoader;
   private frameLoader: ITextureImageLoader;
@@ -61,6 +64,8 @@ export default class JsonDatasetLoader {
 
   private numRequests: number;
   private numCompletedRequests: number;
+
+  private datasetPromise: Promise<Dataset> | null = null;
 
   constructor(manifestUrl: string, options?: JsonDatasetLoadOptions) {
     const { reportProgress, reportWarning } = options ?? {};
@@ -79,6 +84,8 @@ export default class JsonDatasetLoader {
 
     this.numCompletedRequests = 0;
     this.numRequests = 0;
+
+    this.reportLoadProgress = this.reportLoadProgress.bind(this);
   }
 
   private resolveManifestPath = (url: string): string | null => {
@@ -242,7 +249,16 @@ export default class JsonDatasetLoader {
     };
   }
 
-  public async open(): Promise<Dataset> {
+  private reportLoadProgress<T>(promise: Promise<T>): Promise<T> {
+    this.numRequests++;
+    return promise.then((result) => {
+      this.numCompletedRequests++;
+      this.reportProgress?.(this.numCompletedRequests, this.numRequests);
+      return result;
+    });
+  }
+
+  private async loadDataset(): Promise<Dataset> {
     const startTime = new Date();
 
     const resolvedManifestUrl = this.resolveManifestPath(this.manifestUrl);
@@ -274,36 +290,26 @@ export default class JsonDatasetLoader {
         backdrops.set(key, { name, frames: resolvedBackdropFrames });
         if (resolvedBackdropFrames.length !== frameFiles?.length || 0) {
           throw new Error(
-            `Number of frames (${frameFiles?.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
+            `Number of frames (${frameFiles?.length}) does not match number of images (${backdropFrames.length}) for backdrop '${key}'. ` +
               ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
           );
         }
       }
     }
 
-    // Wrap an async operation and report progress when it starts + completes
-    const reportLoadProgress = async <T>(promise: Promise<T>): Promise<T> => {
-      this.numRequests++;
-      return promise.then((result) => {
-        this.numCompletedRequests++;
-        this.reportProgress?.(this.numCompletedRequests, this.numRequests);
-        return result;
-      });
-    };
-
     // Load feature data
     const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
-      reportLoadProgress(this.loadFeature(data))
+      this.reportLoadProgress(this.loadFeature(data))
     );
 
     const result = await Promise.allSettled([
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U8, outlierFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, tracksFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, timesFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, centroidsFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, boundsFile)),
-      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, segIdsFile)),
-      reportLoadProgress(this.getFrameDims(frameFiles)),
+      this.reportLoadProgress(this.loadToBuffer(FeatureDataType.U8, outlierFile)),
+      this.reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, tracksFile)),
+      this.reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, timesFile)),
+      this.reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, centroidsFile)),
+      this.reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, boundsFile)),
+      this.reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, segIdsFile)),
+      this.reportLoadProgress(this.getFrameDims(frameFiles)),
       ...featuresPromises,
     ]);
     const [
@@ -398,9 +404,18 @@ export default class JsonDatasetLoader {
     );
   }
 
+  /** Opens the dataset. */
+  public async open(): Promise<Dataset> {
+    if (!this.datasetPromise) {
+      this.datasetPromise = this.loadDataset();
+    }
+    return this.datasetPromise;
+  }
+
   public dispose() {
     if (this.cleanupArrayLoaderOnDispose) {
       this.arrayLoader.dispose();
     }
+    this.datasetPromise = null;
   }
 }

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -1,14 +1,14 @@
 import { RGBAFormat, RGBAIntegerFormat, Vector2 } from "three";
 
 import {
-  FeatureArrayType,
+  type FeatureArrayType,
   FeatureDataType,
-  IArrayLoader,
-  ITextureImageLoader,
+  type IArrayLoader,
+  type ITextureImageLoader,
   LoadTroubleshooting,
   MAX_FEATURE_CATEGORIES,
 } from "src/colorizer";
-import Dataset, { Backdrop3dData, FeatureData, FeatureType, Frames3dData } from "src/colorizer/Dataset";
+import Dataset, { type Backdrop3dData, type FeatureData, FeatureType, type Frames3dData } from "src/colorizer/Dataset";
 import {
   addCentroidFeatures,
   addTimeFeature,
@@ -16,16 +16,16 @@ import {
   getDefaultSegIds,
   reportUnloadedFeatures,
 } from "src/colorizer/dataset_loaders/dataset_loader_utils";
-import { DatasetLoadOptions } from "src/colorizer/dataset_loaders/types";
+import type { DatasetLoadOptions } from "src/colorizer/dataset_loaders/types";
 import ImageFrameLoader from "src/colorizer/loaders/ImageFrameLoader";
 import UrlArrayLoader from "src/colorizer/loaders/UrlArrayLoader";
-import { IPathResolver, UrlPathResolver } from "src/colorizer/path_resolvers";
+import { type IPathResolver, UrlPathResolver } from "src/colorizer/path_resolvers";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "src/colorizer/utils/analytics";
 import { getKeyFromName } from "src/colorizer/utils/data_utils";
 import {
-  AnyManifestFile,
-  ManifestFile,
-  ManifestFileMetadata,
+  type AnyManifestFile,
+  type ManifestFile,
+  type ManifestFileMetadata,
   updateManifestVersion,
 } from "src/colorizer/utils/dataset_utils";
 import { padCentroidsTo3d } from "src/colorizer/utils/math_utils";
@@ -64,7 +64,7 @@ export default class JsonDatasetLoader {
 
   constructor(manifestUrl: string, options?: JsonDatasetLoadOptions) {
     const { reportProgress, reportWarning } = options ?? {};
-    let { frameLoader, arrayLoader, pathResolver, manifestLoader } = options ?? {};
+    const { frameLoader, arrayLoader, pathResolver, manifestLoader } = options ?? {};
     this.frameLoader = frameLoader ?? new ImageFrameLoader(RGBAIntegerFormat);
     this.backdropLoader = frameLoader ?? new ImageFrameLoader(RGBAFormat);
     this.arrayLoader = arrayLoader ?? new UrlArrayLoader();

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -112,12 +112,15 @@ export default class JsonDatasetLoader {
    * Loads a feature from the dataset, fetching its data from the provided url.
    * @returns A promise of an array tuple containing the feature key and its FeatureData.
    */
-  private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData] | undefined> {
+  private async loadFeature(
+    metadata: ManifestFile["features"][number],
+    index: number
+  ): Promise<[string, FeatureData] | undefined> {
     const name = metadata.name;
     const key = metadata.key || getKeyFromName(name);
     const url = this.resolvePath(metadata.data);
     if (!url) {
-      console.error(`Failed to resolve URL for feature ${name}: '${metadata.data}'`);
+      console.warn(`Feature ${index}: Failed to resolve URL for feature ${name}: '${metadata.data}'`);
       return undefined;
     }
     const featureType = this.parseFeatureType(metadata.type);
@@ -132,12 +135,12 @@ export default class JsonDatasetLoader {
     const featureCategories = metadata?.categories;
     // Validation
     if (featureType === FeatureType.CATEGORICAL && !metadata?.categories) {
-      console.error(`Feature ${name} is categorical but no categories were provided.`);
+      console.warn(`Feature ${index}: ${name} is categorical but no categories were provided.`);
       return undefined;
     }
     if (featureCategories && featureCategories.length > MAX_FEATURE_CATEGORIES) {
-      console.error(
-        `Feature ${name} has too many categories (${featureCategories.length} > max ${MAX_FEATURE_CATEGORIES}).`
+      console.warn(
+        `Feature ${index}: ${name} has too many categories (${featureCategories.length} > max ${MAX_FEATURE_CATEGORIES}).`
       );
       return undefined;
     }
@@ -173,7 +176,6 @@ export default class JsonDatasetLoader {
     if (!fileUrl) {
       return null;
     }
-
     const url = this.resolvePath(fileUrl);
     if (!url) {
       throw new Error(`Failed to resolve path: '${fileUrl}'`);
@@ -183,11 +185,8 @@ export default class JsonDatasetLoader {
   }
 
   private getFrameDims = async (frameFiles: (string | null)[] | undefined): Promise<Vector2 | undefined> => {
-    if (!frameFiles || frameFiles.length === 0) {
-      return undefined;
-    }
     let firstValidFramePath = null;
-    for (const framePath of frameFiles) {
+    for (const framePath of frameFiles ?? []) {
       if (framePath) {
         firstValidFramePath = framePath;
         break;
@@ -196,8 +195,15 @@ export default class JsonDatasetLoader {
     if (!firstValidFramePath) {
       return undefined;
     }
-    const result = await this.frameLoader.load(firstValidFramePath);
-    return new Vector2(result.image.width, result.image.height);
+    try {
+      const result = await this.frameLoader.load(firstValidFramePath);
+      return new Vector2(result.image.width, result.image.height);
+    } catch (error) {
+      console.warn(
+        `Failed to determine frame dimensions; encountered the following error while loading frame from path '${firstValidFramePath}': ${error}`
+      );
+      return undefined;
+    }
   };
 
   private resolveAndValidateFrames3d(data: ManifestFile["frames3d"]): Frames3dData | undefined {
@@ -287,11 +293,14 @@ export default class JsonDatasetLoader {
 
     const backdrops = new Map<string, { name: string; frames: (string | null)[] }>();
 
-    if (manifest.backdrops && manifest.frames) {
+    // Validate backdrops
+    if (manifest.backdrops) {
       for (const { name, key, frames: backdropFrames } of manifest.backdrops) {
         const resolvedBackdropFrames = backdropFrames.map((path) => this.resolvePath(path));
         backdrops.set(key, { name, frames: resolvedBackdropFrames });
-        if (resolvedBackdropFrames.length !== (frameFiles?.length ?? 0)) {
+        if (frameFiles && frameFiles.length !== 0 && resolvedBackdropFrames.length !== frameFiles.length) {
+          // If frames are provided, check that backdrop frames match the frame
+          // count.
           throw new Error(
             `Number of frames (${frameFiles?.length}) does not match number of images (${backdropFrames.length}) for backdrop '${key}'. ` +
               ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
@@ -301,8 +310,8 @@ export default class JsonDatasetLoader {
     }
 
     // Load feature data
-    const featuresPromises: Promise<[string, FeatureData] | undefined>[] = Array.from(manifest.features).map((data) =>
-      this.reportLoadProgress(this.loadFeature(data))
+    const featuresPromises: Promise<[string, FeatureData] | undefined>[] = Array.from(manifest.features).map(
+      (data, index) => this.reportLoadProgress(this.loadFeature(data, index))
     );
 
     const result = await Promise.allSettled([
@@ -353,9 +362,10 @@ export default class JsonDatasetLoader {
 
     // Keep original sorting order of features by inserting in promise order.
     const features = new Map<string, FeatureData>();
-    featureResults.forEach((result, index) => {
-      const onFeatureLoadFailed = (reason: any): void => console.warn(`Feature ${index}: `, reason);
-      const featureValue = getPromiseValue(result, onFeatureLoadFailed);
+    featureResults.forEach((result) => {
+      // Load failures are already logged in `loadFeature`, so rejected promises
+      // are ignored.
+      const featureValue = getPromiseValue(result);
       if (featureValue) {
         const [key, data] = featureValue;
         features.set(key, data);
@@ -364,10 +374,10 @@ export default class JsonDatasetLoader {
 
     //// Post-processing and validation steps ////
 
-    const numObjects = features.values().next().value?.data.length || times?.length || trackIds?.length || 0;
-
     reportUnloadedFeatures(manifest.features, features, this.reportWarning);
 
+    const numObjects =
+      features.values().next().value?.data.length || times?.length || trackIds?.length || segIds?.length || 0;
     segIds = segIds ?? getDefaultSegIds(numObjects);
     centroids = centroids && padCentroidsTo3d(centroids, numObjects);
 
@@ -379,12 +389,11 @@ export default class JsonDatasetLoader {
     triggerAnalyticsEvent(AnalyticsEvent.DATASET_LOAD, {
       datasetWriterVersion: metadata.writerVersion || "N/A",
       datasetTotalObjects: numObjects,
-      datasetFeatureCount: features.size,
+      datasetFeatureCount: manifest.features.length,
       datasetFrameCount: frameFiles?.length || frames3d?.totalFrames || 0,
       datasetLoadTimeMs: new Date().getTime() - startTime.getTime(),
     });
 
-    // TODO: Resolve all frame and backdrop paths
     return new Dataset(
       {
         manifestUrl: resolvedManifestUrl,

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -204,7 +204,9 @@ export default class JsonDatasetLoader {
     }
     try {
       const result = await this.frameLoader.load(firstValidFramePath);
-      return new Vector2(result.image.width, result.image.height);
+      const frameDims = new Vector2(result.image.width, result.image.height);
+      result.dispose();
+      return frameDims;
     } catch (error) {
       console.warn(
         `Failed to determine frame dimensions; encountered the following error while loading frame from path '${firstValidFramePath}': ${error}`

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -412,7 +412,7 @@ export default class JsonDatasetLoader {
     return this.datasetPromise;
   }
 
-  public dispose() {
+  public dispose(): void {
     if (this.cleanupArrayLoaderOnDispose) {
       this.arrayLoader.dispose();
     }

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -14,13 +14,15 @@ import {
   addCentroidFeatures,
   addTimeFeature,
   addTrackFeature,
+  getDefaultSegIds,
+  reportUnloadedFeatures,
 } from "src/colorizer/dataset_loaders/dataset_loader_utils";
 import { DatasetLoadOptions } from "src/colorizer/dataset_loaders/types";
 import ImageFrameLoader from "src/colorizer/loaders/ImageFrameLoader";
 import UrlArrayLoader from "src/colorizer/loaders/UrlArrayLoader";
 import { IPathResolver, UrlPathResolver } from "src/colorizer/path_resolvers";
 import { AnalyticsEvent, triggerAnalyticsEvent } from "src/colorizer/utils/analytics";
-import { formatAsBulletList, getKeyFromName } from "src/colorizer/utils/data_utils";
+import { getKeyFromName } from "src/colorizer/utils/data_utils";
 import {
   AnyManifestFile,
   ManifestFile,
@@ -263,12 +265,13 @@ export default class JsonDatasetLoader {
     const boundsFile = manifest.bounds;
     const segIdsFile = manifest.segIds;
 
-    const backdropData = new Map<string, { name: string; frames: string[] }>();
+    const backdrops = new Map<string, { name: string; frames: (string | null)[] }>();
 
     if (manifest.backdrops && manifest.frames) {
-      for (const { name, key, frames } of manifest.backdrops) {
-        backdropData.set(key, { name, frames });
-        if (frames.length !== frameFiles?.length || 0) {
+      for (const { name, key, frames: backdropFrames } of manifest.backdrops) {
+        const resolvedBackdropFrames = backdropFrames.map((path) => this.resolvePath(path));
+        backdrops.set(key, { name, frames: resolvedBackdropFrames });
+        if (resolvedBackdropFrames.length !== frameFiles?.length || 0) {
           throw new Error(
             `Number of frames (${frameFiles?.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
               ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
@@ -354,33 +357,12 @@ export default class JsonDatasetLoader {
 
     //// Post-processing and validation steps ////
 
-    if (features.size !== manifest.features.length) {
-      // Report the names of all features that could not be loaded.
-      const loadedFeatureNames = new Set(Array.from(features.values()).map((f) => f.name));
-      const missingFeatureNames = manifest.features.filter((f) => !loadedFeatureNames.has(f.name)).map((f) => f.name);
-
-      this.reportWarning?.("Some features failed to load.", [
-        "The following feature(s) could not be loaded and will not be shown: ",
-        ...formatAsBulletList(missingFeatureNames, 5),
-        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
-      ]);
-    }
-
     const numObjects = features.values().next().value?.data.length || times?.length || trackIds?.length || 0;
 
-    // Construct default array of segmentation IDs if not provided in the manifest.
-    if (!segIds) {
-      // Construct default segIds array (0, 1, 2, ...)
-      segIds = new Uint32Array(numObjects);
-      for (let i = 0; i < numObjects; i++) {
-        segIds[i] = i + 1;
-      }
-    }
+    reportUnloadedFeatures(manifest.features, features, this.reportWarning);
 
-    // Fixup 2D centroids to 3D
-    if (centroids) {
-      centroids = padCentroidsTo3d(centroids, numObjects);
-    }
+    segIds = segIds ?? getDefaultSegIds(numObjects);
+    centroids = centroids && padCentroidsTo3d(centroids, numObjects);
 
     addCentroidFeatures(features, centroids, metadata, frames3d ? undefined : frameDimensions);
     addTimeFeature(features, times);
@@ -398,10 +380,15 @@ export default class JsonDatasetLoader {
     // TODO: Resolve all frame and backdrop paths
     return new Dataset(
       {
-        features,
-        frameFiles,
-        backdrops,
+        manifestUrl: resolvedManifestUrl,
         metadata,
+        // Image sources
+        frameFiles,
+        frames3d,
+        backdrops,
+        frameResolution: frameDimensions ?? undefined,
+        // Data arrays
+        features,
         segIds,
         times,
         trackIds,

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -291,9 +291,6 @@ export default class JsonDatasetLoader {
     };
 
     // Load feature data
-    if (manifest.features.length === 0) {
-      throw new Error(LoadErrorMessage.MANIFEST_HAS_NO_FEATURES);
-    }
     const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
       reportLoadProgress(this.loadFeature(data))
     );

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -112,12 +112,13 @@ export default class JsonDatasetLoader {
    * Loads a feature from the dataset, fetching its data from the provided url.
    * @returns A promise of an array tuple containing the feature key and its FeatureData.
    */
-  private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData]> {
+  private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData] | undefined> {
     const name = metadata.name;
     const key = metadata.key || getKeyFromName(name);
     const url = this.resolvePath(metadata.data);
     if (!url) {
-      throw new Error(`Failed to resolve URL for feature ${name}: '${metadata.data}'`);
+      console.error(`Failed to resolve URL for feature ${name}: '${metadata.data}'`);
+      return undefined;
     }
     const featureType = this.parseFeatureType(metadata.type);
 
@@ -131,12 +132,14 @@ export default class JsonDatasetLoader {
     const featureCategories = metadata?.categories;
     // Validation
     if (featureType === FeatureType.CATEGORICAL && !metadata?.categories) {
-      throw new Error(`Feature ${name} is categorical but no categories were provided.`);
+      console.error(`Feature ${name} is categorical but no categories were provided.`);
+      return undefined;
     }
     if (featureCategories && featureCategories.length > MAX_FEATURE_CATEGORIES) {
-      throw new Error(
+      console.error(
         `Feature ${name} has too many categories (${featureCategories.length} > max ${MAX_FEATURE_CATEGORIES}).`
       );
+      return undefined;
     }
 
     return [
@@ -298,7 +301,7 @@ export default class JsonDatasetLoader {
     }
 
     // Load feature data
-    const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
+    const featuresPromises: Promise<[string, FeatureData] | undefined>[] = Array.from(manifest.features).map((data) =>
       this.reportLoadProgress(this.loadFeature(data))
     );
 

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -69,9 +69,9 @@ export default class JsonDatasetLoader {
 
   constructor(manifestUrl: string, options?: JsonDatasetLoadOptions) {
     const { reportProgress, reportWarning } = options ?? {};
-    const { frameLoader, arrayLoader, pathResolver, manifestLoader } = options ?? {};
+    const { frameLoader, backdropLoader, arrayLoader, pathResolver, manifestLoader } = options ?? {};
     this.frameLoader = frameLoader ?? new ImageFrameLoader(RGBAIntegerFormat);
-    this.backdropLoader = frameLoader ?? new ImageFrameLoader(RGBAFormat);
+    this.backdropLoader = backdropLoader ?? new ImageFrameLoader(RGBAFormat);
     this.arrayLoader = arrayLoader ?? new UrlArrayLoader();
     this.pathResolver = pathResolver ?? new UrlPathResolver();
     this.manifestLoader = manifestLoader ?? fetchManifestJson;
@@ -288,7 +288,7 @@ export default class JsonDatasetLoader {
       for (const { name, key, frames: backdropFrames } of manifest.backdrops) {
         const resolvedBackdropFrames = backdropFrames.map((path) => this.resolvePath(path));
         backdrops.set(key, { name, frames: resolvedBackdropFrames });
-        if (resolvedBackdropFrames.length !== frameFiles?.length || 0) {
+        if (resolvedBackdropFrames.length !== (frameFiles?.length ?? 0)) {
           throw new Error(
             `Number of frames (${frameFiles?.length}) does not match number of images (${backdropFrames.length}) for backdrop '${key}'. ` +
               ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -1,6 +1,7 @@
 import { RGBAFormat, RGBAIntegerFormat, Vector2 } from "three";
 
 import {
+  type ArraySource,
   type FeatureArrayType,
   FeatureDataType,
   type IArrayLoader,
@@ -125,12 +126,18 @@ export default class JsonDatasetLoader {
     }
     const featureType = this.parseFeatureType(metadata.type);
 
-    const source = await this.arrayLoader.load(
-      url,
-      FeatureDataType.F32,
-      metadata.min ?? undefined,
-      metadata.max ?? undefined
-    );
+    let source: ArraySource<FeatureDataType.F32> | undefined;
+    try {
+      source = await this.arrayLoader.load(
+        url,
+        FeatureDataType.F32,
+        metadata.min ?? undefined,
+        metadata.max ?? undefined
+      );
+    } catch (error) {
+      console.warn(`Feature ${index}: Failed to load data for feature ${name} from URL '${url}': ${error}`);
+      return undefined;
+    }
 
     const featureCategories = metadata?.categories;
     // Validation

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -1,0 +1,421 @@
+import { Vector2 } from "three";
+
+import {
+  FeatureArrayType,
+  FeatureDataType,
+  IArrayLoader,
+  ITextureImageLoader,
+  LoadErrorMessage,
+  LoadTroubleshooting,
+  MAX_FEATURE_CATEGORIES,
+} from "src/colorizer";
+import Dataset, { Backdrop3dData, FeatureData, FeatureType, Frames3dData } from "src/colorizer/Dataset";
+import {
+  addCentroidFeatures,
+  addTimeFeature,
+  addTrackFeature,
+} from "src/colorizer/dataset_loaders/dataset_loader_utils";
+import { DatasetLoadOptions } from "src/colorizer/dataset_loaders/types";
+import ImageFrameLoader from "src/colorizer/loaders/ImageFrameLoader";
+import UrlArrayLoader from "src/colorizer/loaders/UrlArrayLoader";
+import { IPathResolver, UrlPathResolver } from "src/colorizer/path_resolvers";
+import { AnalyticsEvent, triggerAnalyticsEvent } from "src/colorizer/utils/analytics";
+import { formatAsBulletList, getKeyFromName } from "src/colorizer/utils/data_utils";
+import {
+  AnyManifestFile,
+  ManifestFile,
+  ManifestFileMetadata,
+  updateManifestVersion,
+} from "src/colorizer/utils/dataset_utils";
+import { padCentroidsTo3d } from "src/colorizer/utils/math_utils";
+import { fetchManifestJson, formatPath, getPromiseValue } from "src/colorizer/utils/url_utils";
+
+export type JsonDatasetLoadOptions = DatasetLoadOptions & {
+  manifestLoader?: typeof fetchManifestJson;
+};
+
+const DEFAULT_METADATA: ManifestFileMetadata = {
+  frameDims: {
+    width: 0,
+    height: 0,
+    units: "",
+  },
+  frameDurationSeconds: 0,
+  startTimeSeconds: 0,
+};
+
+export default class JsonDatasetLoader {
+  private arrayLoader: IArrayLoader;
+  private frameLoader: ITextureImageLoader;
+  private pathResolver: IPathResolver;
+  private manifestLoader: (url: string) => Promise<AnyManifestFile>;
+  private cleanupArrayLoaderOnDispose: boolean;
+
+  private reportProgress: DatasetLoadOptions["reportProgress"];
+  private reportWarning: DatasetLoadOptions["reportWarning"];
+
+  private manifestUrl: string;
+  private baseUrl: string;
+
+  private numRequests: number;
+  private numCompletedRequests: number;
+
+  constructor(manifestUrl: string, options?: JsonDatasetLoadOptions) {
+    const { reportProgress, reportWarning } = options ?? {};
+    let { frameLoader, arrayLoader, pathResolver, manifestLoader } = options ?? {};
+    this.frameLoader = frameLoader ?? new ImageFrameLoader();
+    this.arrayLoader = arrayLoader ?? new UrlArrayLoader();
+    this.pathResolver = pathResolver ?? new UrlPathResolver();
+    this.manifestLoader = manifestLoader ?? fetchManifestJson;
+    this.reportProgress = reportProgress ?? (() => {});
+    this.reportWarning = reportWarning ?? (() => {});
+    this.cleanupArrayLoaderOnDispose = !arrayLoader;
+
+    this.manifestUrl = manifestUrl;
+    this.baseUrl = formatPath(manifestUrl.substring(0, manifestUrl.lastIndexOf("/")));
+
+    this.numCompletedRequests = 0;
+    this.numRequests = 0;
+  }
+
+  private resolveManifestPath = (url: string): string | null => {
+    return this.pathResolver.resolve("", url);
+  };
+
+  private resolvePath = (url: string): string | null => {
+    return this.pathResolver.resolve(this.baseUrl, url);
+  };
+
+  private parseFeatureType(
+    inputType: string | undefined,
+    defaultType: FeatureType = FeatureType.CONTINUOUS
+  ): FeatureType {
+    const isFeatureType = (inputType: string): inputType is FeatureType => {
+      return Object.values(FeatureType).includes(inputType as FeatureType);
+    };
+
+    inputType = inputType?.toLowerCase() || "";
+    return isFeatureType(inputType) ? inputType : defaultType;
+  }
+
+  /**
+   * Loads a feature from the dataset, fetching its data from the provided url.
+   * @returns A promise of an array tuple containing the feature key and its FeatureData.
+   */
+  private async loadFeature(metadata: ManifestFile["features"][number]): Promise<[string, FeatureData]> {
+    const name = metadata.name;
+    const key = metadata.key || getKeyFromName(name);
+    const url = this.resolvePath(metadata.data);
+    if (!url) {
+      throw new Error(`Failed to resolve URL for feature ${name}: '${metadata.data}'`);
+    }
+    const featureType = this.parseFeatureType(metadata.type);
+
+    const source = await this.arrayLoader.load(
+      url,
+      FeatureDataType.F32,
+      metadata.min ?? undefined,
+      metadata.max ?? undefined
+    );
+
+    const featureCategories = metadata?.categories;
+    // Validation
+    if (featureType === FeatureType.CATEGORICAL && !metadata?.categories) {
+      throw new Error(`Feature ${name} is categorical but no categories were provided.`);
+    }
+    if (featureCategories && featureCategories.length > MAX_FEATURE_CATEGORIES) {
+      throw new Error(
+        `Feature ${name} has too many categories (${featureCategories.length} > max ${MAX_FEATURE_CATEGORIES}).`
+      );
+    }
+
+    return [
+      key,
+      {
+        name,
+        key,
+        tex: source.getTexture(),
+        data: source.getBuffer(),
+        min: source.getMin(),
+        max: source.getMax(),
+        unit: metadata.unit || "",
+        type: featureType,
+        categories: featureCategories || null,
+        description: metadata.description || null,
+      },
+    ];
+  }
+
+  /**
+   * Fetches and loads a data file as an array and returns its data as a TypedArray using the provided dataType.
+   * @param dataType The expected format of the data.
+   * @param fileUrl String url of the file to be loaded.
+   * @throws An error if the data cannot be loaded from the file.
+   * @returns Promise of a TypedArray loaded from the file. If `fileUrl` is undefined, returns null.
+   */
+  private async loadToBuffer<T extends FeatureDataType>(
+    dataType: T,
+    fileUrl?: string
+  ): Promise<FeatureArrayType[T] | null> {
+    if (!fileUrl) {
+      return null;
+    }
+
+    const url = this.resolvePath(fileUrl);
+    if (!url) {
+      throw new Error(`Failed to resolve path: '${fileUrl}'`);
+    }
+    const source = await this.arrayLoader.load(url, dataType);
+    return source.getBuffer();
+  }
+
+  private getFrameDims = async (frameFiles: (string | null)[] | undefined): Promise<Vector2 | undefined> => {
+    if (!frameFiles || frameFiles.length === 0) {
+      return undefined;
+    }
+    let firstValidFramePath = null;
+    for (const framePath of frameFiles) {
+      if (framePath) {
+        firstValidFramePath = framePath;
+        break;
+      }
+    }
+    if (!firstValidFramePath) {
+      return undefined;
+    }
+    const result = await this.frameLoader.load(firstValidFramePath);
+    return new Vector2(result.image.width, result.image.height);
+  };
+
+  private resolveAndValidateFrames3d(data: ManifestFile["frames3d"]): Frames3dData | undefined {
+    if (!data) {
+      return undefined;
+    }
+    const frameSource = this.resolvePath(data.source);
+    const backdrops: Backdrop3dData[] = [];
+    if (!frameSource) {
+      // This will only happen if using a file path resolver, if this file does
+      // not exist in a ZIP file.
+
+      // TODO: This will fail for Zarrs, which are directories and not files, so
+      // `resolvePath` will return `null`. Even if `resolvePath` did handle
+      // directories, Zarrs index from the directory root, which is provided as
+      // a Object URL. Adding additional paths to the end of an Object URL (e.g.
+      // TCZYX specifiers for zarrs, like `/0/0/0`) does not result in a working
+      // URL. This means there is no way to make the current path resolver work
+      // without overriding `fetch` in dependency libraries (vole-core).
+      throw new Error(
+        `Failed to resolve path for 3D frame source '${data.source}'. ${LoadTroubleshooting.CHECK_ZIP_ZARR_DATA}`
+      );
+    }
+    // Validate backdrops
+    if (data.backdrops) {
+      const failedBackdrops: Backdrop3dData[] = [];
+      for (const backdrop of data.backdrops) {
+        const backdropSource = this.resolvePath(backdrop.source);
+        if (!backdropSource) {
+          failedBackdrops.push({ channelIndex: 0, ...backdrop });
+          continue;
+        }
+        backdrops.push({
+          ...backdrop,
+          channelIndex: backdrop.channelIndex ?? 0,
+          source: backdropSource,
+        });
+      }
+      if (failedBackdrops.length > 0) {
+        this.reportWarning?.("One or more 3D backdrop sources could not be resolved to files, and will not be shown.", [
+          "The following backdrop source(s) could not be resolved:",
+          ...failedBackdrops.map((b) => `- ${b.source} (${b.name})`),
+          LoadTroubleshooting.CHECK_ZIP_ZARR_DATA,
+        ]);
+      }
+    }
+    return {
+      source: frameSource,
+      segmentationChannel: data.segmentationChannel ?? 0,
+      totalFrames: data.totalFrames ?? 0,
+      backdrops,
+    };
+  }
+
+  public async open(): Promise<Dataset> {
+    const startTime = new Date();
+
+    const resolvedManifestUrl = this.resolveManifestPath(this.manifestUrl);
+    if (resolvedManifestUrl === null) {
+      // TODO: Currently, only the FilePathResolver (used for ZIP files) can
+      // return `null` when resolving paths, which indicates that a file does
+      // not exist. If support for loading from other sources (local folders,
+      // etc.) is added, Dataset will need to store metadata about the source.
+      throw new Error(`No '${this.manifestUrl}' was found. ${LoadTroubleshooting.CHECK_ZIP_FORMAT_MANIFEST}`);
+    }
+    const manifest = updateManifestVersion(await this.manifestLoader(resolvedManifestUrl));
+
+    const frameFiles = manifest.frames?.map((frame) => this.resolvePath(frame));
+    const frames3d = this.resolveAndValidateFrames3d(manifest.frames3d);
+    const outlierFile = manifest.outliers;
+    const metadata = { ...DEFAULT_METADATA, ...manifest.metadata };
+
+    const tracksFile = manifest.tracks;
+    const timesFile = manifest.times;
+    const centroidsFile = manifest.centroids;
+    const boundsFile = manifest.bounds;
+    const segIdsFile = manifest.segIds;
+
+    const backdropData = new Map<string, { name: string; frames: string[] }>();
+
+    if (manifest.backdrops && manifest.frames) {
+      for (const { name, key, frames } of manifest.backdrops) {
+        backdropData.set(key, { name, frames });
+        if (frames.length !== frameFiles?.length || 0) {
+          throw new Error(
+            `Number of frames (${frameFiles?.length}) does not match number of images (${frames.length}) for backdrop '${key}'. ` +
+              ` If you are a dataset author, please ensure that the number of frames in the manifest matches the number of images for each backdrop.`
+          );
+        }
+      }
+    }
+
+    // Wrap an async operation and report progress when it starts + completes
+    const reportLoadProgress = async <T>(promise: Promise<T>): Promise<T> => {
+      this.numRequests++;
+      return promise.then((result) => {
+        this.numCompletedRequests++;
+        this.reportProgress?.(this.numCompletedRequests, this.numRequests);
+        return result;
+      });
+    };
+
+    // Load feature data
+    if (manifest.features.length === 0) {
+      throw new Error(LoadErrorMessage.MANIFEST_HAS_NO_FEATURES);
+    }
+    const featuresPromises: Promise<[string, FeatureData]>[] = Array.from(manifest.features).map((data) =>
+      reportLoadProgress(this.loadFeature(data))
+    );
+
+    const result = await Promise.allSettled([
+      reportLoadProgress(this.loadToBuffer(FeatureDataType.U8, outlierFile)),
+      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, tracksFile)),
+      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, timesFile)),
+      reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, centroidsFile)),
+      reportLoadProgress(this.loadToBuffer(FeatureDataType.U16, boundsFile)),
+      reportLoadProgress(this.loadToBuffer(FeatureDataType.U32, segIdsFile)),
+      reportLoadProgress(this.getFrameDims(frameFiles)),
+      ...featuresPromises,
+    ]);
+    const [
+      outliersResult,
+      tracksResult,
+      timesResult,
+      centroidsResult,
+      boundsResult,
+      frameIdOffsetsResult,
+      frameDimensionsResult,
+      ...featureResults
+    ] = result;
+
+    const unloadableDataFiles: string[] = [];
+    function makeLoadFailedCallback(fileType: string, url?: string): (reason: any) => void {
+      return (reason: any) => {
+        console.warn(`${fileType} data could not be loaded: ${reason}`);
+        unloadableDataFiles.push(`${fileType}: '${url || "N/A"}'`);
+      };
+    }
+
+    const outliers = getPromiseValue(outliersResult, makeLoadFailedCallback("Outliers", outlierFile));
+    const trackIds = getPromiseValue(tracksResult, makeLoadFailedCallback("Tracks", tracksFile));
+    const times = getPromiseValue(timesResult, makeLoadFailedCallback("Times", timesFile));
+    let centroids = getPromiseValue(centroidsResult, makeLoadFailedCallback("Centroids", centroidsFile));
+    const bounds = getPromiseValue(boundsResult, makeLoadFailedCallback("Bounds", boundsFile));
+    let segIds = getPromiseValue(frameIdOffsetsResult, makeLoadFailedCallback("Segmentation IDs", segIdsFile));
+    const frameDimensions = getPromiseValue(frameDimensionsResult, makeLoadFailedCallback("Frame Dimensions"));
+
+    if (unloadableDataFiles.length > 0) {
+      // Report warning of all the files that couldn't be loaded and their associated errors.
+      this.reportWarning?.("Some data files failed to load.", [
+        "The following data file(s) failed to load, which may cause the viewer to behave unexpectedly:",
+        ...unloadableDataFiles.map((fileType) => ` - ${fileType}`),
+        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
+      ]);
+    }
+
+    // Keep original sorting order of features by inserting in promise order.
+    const features = new Map<string, FeatureData>();
+    featureResults.forEach((result, index) => {
+      const onFeatureLoadFailed = (reason: any): void => console.warn(`Feature ${index}: `, reason);
+      const featureValue = getPromiseValue(result, onFeatureLoadFailed);
+      if (featureValue) {
+        const [key, data] = featureValue;
+        features.set(key, data);
+      }
+    });
+
+    //// Post-processing and validation steps ////
+
+    if (features.size !== manifest.features.length) {
+      // Report the names of all features that could not be loaded.
+      const loadedFeatureNames = new Set(Array.from(features.values()).map((f) => f.name));
+      const missingFeatureNames = manifest.features.filter((f) => !loadedFeatureNames.has(f.name)).map((f) => f.name);
+
+      this.reportWarning?.("Some features failed to load.", [
+        "The following feature(s) could not be loaded and will not be shown: ",
+        ...formatAsBulletList(missingFeatureNames, 5),
+        LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
+      ]);
+    }
+
+    const numObjects = features.values().next().value?.data.length || times?.length || trackIds?.length || 0;
+
+    // Construct default array of segmentation IDs if not provided in the manifest.
+    if (!segIds) {
+      // Construct default segIds array (0, 1, 2, ...)
+      segIds = new Uint32Array(numObjects);
+      for (let i = 0; i < numObjects; i++) {
+        segIds[i] = i + 1;
+      }
+    }
+
+    // Fixup 2D centroids to 3D
+    if (centroids) {
+      centroids = padCentroidsTo3d(centroids, numObjects);
+    }
+
+    addCentroidFeatures(features, centroids, metadata, frames3d ? undefined : frameDimensions);
+    addTimeFeature(features, times);
+    addTrackFeature(features, trackIds);
+
+    // Analytics reporting
+    triggerAnalyticsEvent(AnalyticsEvent.DATASET_LOAD, {
+      datasetWriterVersion: metadata.writerVersion || "N/A",
+      datasetTotalObjects: numObjects,
+      datasetFeatureCount: features.size,
+      datasetFrameCount: frameFiles?.length || frames3d?.totalFrames || 0,
+      datasetLoadTimeMs: new Date().getTime() - startTime.getTime(),
+    });
+
+    // TODO: Resolve all frame and backdrop paths
+    return new Dataset(
+      {
+        features,
+        frameFiles,
+        backdrops,
+        metadata,
+        segIds,
+        times,
+        trackIds,
+        centroids,
+        bounds,
+        outliers,
+      },
+      { frameLoader: this.frameLoader }
+    );
+  }
+
+  public dispose() {
+    if (this.cleanupArrayLoaderOnDispose) {
+      this.arrayLoader.dispose();
+    }
+  }
+}

--- a/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
+++ b/src/colorizer/dataset_loaders/JsonDatasetLoader.ts
@@ -1,11 +1,10 @@
-import { Vector2 } from "three";
+import { RGBAFormat, RGBAIntegerFormat, Vector2 } from "three";
 
 import {
   FeatureArrayType,
   FeatureDataType,
   IArrayLoader,
   ITextureImageLoader,
-  LoadErrorMessage,
   LoadTroubleshooting,
   MAX_FEATURE_CATEGORIES,
 } from "src/colorizer";
@@ -49,6 +48,7 @@ const DEFAULT_METADATA: ManifestFileMetadata = {
 export default class JsonDatasetLoader {
   private arrayLoader: IArrayLoader;
   private frameLoader: ITextureImageLoader;
+  private backdropLoader: ITextureImageLoader;
   private pathResolver: IPathResolver;
   private manifestLoader: (url: string) => Promise<AnyManifestFile>;
   private cleanupArrayLoaderOnDispose: boolean;
@@ -65,7 +65,8 @@ export default class JsonDatasetLoader {
   constructor(manifestUrl: string, options?: JsonDatasetLoadOptions) {
     const { reportProgress, reportWarning } = options ?? {};
     let { frameLoader, arrayLoader, pathResolver, manifestLoader } = options ?? {};
-    this.frameLoader = frameLoader ?? new ImageFrameLoader();
+    this.frameLoader = frameLoader ?? new ImageFrameLoader(RGBAIntegerFormat);
+    this.backdropLoader = frameLoader ?? new ImageFrameLoader(RGBAFormat);
     this.arrayLoader = arrayLoader ?? new UrlArrayLoader();
     this.pathResolver = pathResolver ?? new UrlPathResolver();
     this.manifestLoader = manifestLoader ?? fetchManifestJson;
@@ -393,7 +394,7 @@ export default class JsonDatasetLoader {
         bounds,
         outliers,
       },
-      { frameLoader: this.frameLoader }
+      { frameLoader: this.frameLoader, backdropLoader: this.backdropLoader }
     );
   }
 

--- a/src/colorizer/dataset_loaders/dataset_loader_utils.ts
+++ b/src/colorizer/dataset_loaders/dataset_loader_utils.ts
@@ -1,0 +1,110 @@
+import { Vector2, Vector3 } from "three";
+
+import {
+  CENTROID_X_FEATURE_KEY,
+  CENTROID_Y_FEATURE_KEY,
+  CENTROID_Z_FEATURE_KEY,
+  FeatureData,
+  FeatureType,
+  TIME_FEATURE_KEY,
+  TRACK_FEATURE_KEY,
+} from "src/colorizer/Dataset";
+import { FeatureDataType } from "src/colorizer/types";
+import { ManifestFileMetadata } from "src/colorizer/utils/dataset_utils";
+import { packDataTexture } from "src/colorizer/utils/texture_utils";
+
+export function addTrackFeature(features: Map<string, FeatureData>, trackIds: Uint32Array | null): void {
+  if (trackIds && !features.has(TRACK_FEATURE_KEY)) {
+    const trackData = new Float32Array(trackIds);
+    features.set(TRACK_FEATURE_KEY, {
+      name: "Track ID",
+      key: TRACK_FEATURE_KEY,
+      data: trackIds,
+      tex: packDataTexture(trackData, FeatureDataType.F32),
+      min: 0,
+      max: trackIds.reduce((max, id) => Math.max(max, id), 0),
+      unit: "",
+      type: FeatureType.DISCRETE,
+      categories: null,
+      description: "Track ID of the object. This feature was added by the viewer from provided data.",
+    });
+  }
+}
+
+export function addTimeFeature(features: Map<string, FeatureData>, times: Uint32Array | null): void {
+  if (times && !features.has(TIME_FEATURE_KEY)) {
+    const timeData = new Float32Array(times);
+    features.set(TIME_FEATURE_KEY, {
+      name: "Time (frames)",
+      key: TIME_FEATURE_KEY,
+      data: times,
+      tex: packDataTexture(timeData, FeatureDataType.F32),
+      min: 0,
+      max: times.reduce((max, id) => Math.max(max, id), 0),
+      unit: "",
+      type: FeatureType.CONTINUOUS,
+      categories: null,
+      description: "Frame number where the object appears. This feature was added by the viewer from provided data.",
+    });
+  }
+}
+
+export function addCentroidFeatures(
+  features: Map<string, FeatureData>,
+  centroids: Uint16Array | null,
+  metadata?: ManifestFileMetadata,
+  frameDimensions?: Vector2 | null
+): void {
+  const centroidFeatureKeys = [CENTROID_X_FEATURE_KEY, CENTROID_Y_FEATURE_KEY, CENTROID_Z_FEATURE_KEY];
+  const axes = ["X", "Y", "Z"];
+  if (!centroids) {
+    return;
+  }
+  // TODO: The handling for centroid scaling is not consistent for 2D and 3D
+  // datasets. Currently, 2D datasets must provide centroids in pixels, while
+  // 3D datasets must provide them in physical units. If both 3D and 2D frame
+  // data is present, centroids would be read as being pixel units, which
+  // cause centroids to be scaled incorrectly in 3D. Add a flag to indicate
+  // whether centroids are in physical or pixel units.
+  const metadataDims = metadata?.frameDims;
+  const hasMetadataDims = metadataDims && metadataDims.width && metadataDims.height;
+  const physicalDims = hasMetadataDims ? [metadataDims.width, metadataDims.height, 1] : [1, 1, 1];
+  const pixelDims = frameDimensions ? [frameDimensions.x, frameDimensions.y, 1] : physicalDims;
+
+  for (let i = 0; i < centroidFeatureKeys.length; i++) {
+    const key = centroidFeatureKeys[i];
+    if (features.has(key)) {
+      continue;
+    }
+
+    const rawData = centroids.filter((_, index) => index % 3 === i);
+    const data = new Float32Array(rawData);
+    if (frameDimensions) {
+      // If provided, normalize centroid coordinates to physical units.
+      const physicalDim = physicalDims[i];
+      const pixelDim = pixelDims[i];
+      for (let j = 0; j < data.length; j++) {
+        data[j] = (data[j] / pixelDim) * physicalDim;
+      }
+    }
+
+    const axis = axes[i];
+    const min = 0;
+    const dataMax = data.reduce((max, value) => Math.max(max, value), -Infinity);
+    const max = hasMetadataDims ? physicalDims[i] : dataMax;
+    const tex = packDataTexture(data, FeatureDataType.F32);
+    const description = `Centroid ${axis} coordinate, in pixels/voxels. This feature was added by the viewer from provided data.`;
+    features.set(key, {
+      name: "Centroid " + axis,
+      key,
+      data,
+      tex,
+      min,
+      max,
+      unit: metadataDims?.units || "",
+      type: FeatureType.DISCRETE,
+      categories: null,
+      description,
+    });
+  }
+}

--- a/src/colorizer/dataset_loaders/dataset_loader_utils.ts
+++ b/src/colorizer/dataset_loaders/dataset_loader_utils.ts
@@ -1,4 +1,4 @@
-import { Vector2, Vector3 } from "three";
+import { Vector2 } from "three";
 
 import {
   CENTROID_X_FEATURE_KEY,
@@ -9,9 +9,18 @@ import {
   TIME_FEATURE_KEY,
   TRACK_FEATURE_KEY,
 } from "src/colorizer/Dataset";
-import { FeatureDataType } from "src/colorizer/types";
-import { ManifestFileMetadata } from "src/colorizer/utils/dataset_utils";
+import { FeatureDataType, LoadTroubleshooting, ReportWarningCallback } from "src/colorizer/types";
+import { formatAsBulletList } from "src/colorizer/utils/data_utils";
+import { ManifestFile, ManifestFileMetadata } from "src/colorizer/utils/dataset_utils";
 import { packDataTexture } from "src/colorizer/utils/texture_utils";
+
+export function getDefaultSegIds(numObjects: number): Uint32Array {
+  const segIds = new Uint32Array(numObjects);
+  for (let i = 0; i < numObjects; i++) {
+    segIds[i] = i + 1;
+  }
+  return segIds;
+}
 
 export function addTrackFeature(features: Map<string, FeatureData>, trackIds: Uint32Array | null): void {
   if (trackIds && !features.has(TRACK_FEATURE_KEY)) {
@@ -106,5 +115,35 @@ export function addCentroidFeatures(
       categories: null,
       description,
     });
+  }
+}
+
+export function reportUnloadedFeatures(
+  featureSpec: ManifestFile["features"],
+  loadedFeatures: Map<string, FeatureData>,
+  reportWarning: ReportWarningCallback | undefined
+): void {
+  if (loadedFeatures.size !== featureSpec.length) {
+    // Report the names of all features that could not be loaded.
+    const loadedFeatureNames = new Set(Array.from(loadedFeatures.values()).map((f) => f.name));
+    const missingFeatureNames = featureSpec.filter((f) => !loadedFeatureNames.has(f.name)).map((f) => f.name);
+
+    reportWarning?.("Some features failed to load.", [
+      "The following feature(s) could not be loaded and will not be shown: ",
+      ...formatAsBulletList(missingFeatureNames, 5),
+      LoadTroubleshooting.CHECK_FILE_OR_NETWORK,
+    ]);
+  }
+}
+
+export function reportUnresolvedPaths(
+  pathType: string,
+  paths: string[],
+  resolvedPaths: (string | null)[],
+  reportWarning: ReportWarningCallback | undefined
+): void {
+  const unresolvedPaths = paths.filter((_, index) => !resolvedPaths[index]);
+  if (unresolvedPaths.length === 0) {
+    return;
   }
 }

--- a/src/colorizer/dataset_loaders/dataset_loader_utils.ts
+++ b/src/colorizer/dataset_loaders/dataset_loader_utils.ts
@@ -1,17 +1,17 @@
-import { Vector2 } from "three";
+import type { Vector2 } from "three";
 
 import {
   CENTROID_X_FEATURE_KEY,
   CENTROID_Y_FEATURE_KEY,
   CENTROID_Z_FEATURE_KEY,
-  FeatureData,
+  type FeatureData,
   FeatureType,
   TIME_FEATURE_KEY,
   TRACK_FEATURE_KEY,
 } from "src/colorizer/Dataset";
-import { FeatureDataType, LoadTroubleshooting, ReportWarningCallback } from "src/colorizer/types";
+import { FeatureDataType, LoadTroubleshooting, type ReportWarningCallback } from "src/colorizer/types";
 import { formatAsBulletList } from "src/colorizer/utils/data_utils";
-import { ManifestFile, ManifestFileMetadata } from "src/colorizer/utils/dataset_utils";
+import type { ManifestFile, ManifestFileMetadata } from "src/colorizer/utils/dataset_utils";
 import { packDataTexture } from "src/colorizer/utils/texture_utils";
 
 export function getDefaultSegIds(numObjects: number): Uint32Array {

--- a/src/colorizer/dataset_loaders/dataset_loader_utils.ts
+++ b/src/colorizer/dataset_loaders/dataset_loader_utils.ts
@@ -135,15 +135,3 @@ export function reportUnloadedFeatures(
     ]);
   }
 }
-
-export function reportUnresolvedPaths(
-  pathType: string,
-  paths: string[],
-  resolvedPaths: (string | null)[],
-  reportWarning: ReportWarningCallback | undefined
-): void {
-  const unresolvedPaths = paths.filter((_, index) => !resolvedPaths[index]);
-  if (unresolvedPaths.length === 0) {
-    return;
-  }
-}

--- a/src/colorizer/dataset_loaders/types.ts
+++ b/src/colorizer/dataset_loaders/types.ts
@@ -7,6 +7,7 @@ export type DatasetLoadOptions = {
   reportWarning?: ReportWarningCallback;
 
   frameLoader?: ITextureImageLoader;
+  backdropLoader?: ITextureImageLoader;
   arrayLoader?: IArrayLoader;
   pathResolver?: IPathResolver;
 };

--- a/src/colorizer/dataset_loaders/types.ts
+++ b/src/colorizer/dataset_loaders/types.ts
@@ -3,9 +3,10 @@ import type { IPathResolver } from "src/colorizer/path_resolvers";
 import type { ReportLoadProgressCallback, ReportWarningCallback } from "src/colorizer/types";
 
 export type DatasetLoadOptions = {
+  // Callbacks
   reportProgress?: ReportLoadProgressCallback;
   reportWarning?: ReportWarningCallback;
-
+  // Loaders
   frameLoader?: ITextureImageLoader;
   backdropLoader?: ITextureImageLoader;
   arrayLoader?: IArrayLoader;

--- a/src/colorizer/dataset_loaders/types.ts
+++ b/src/colorizer/dataset_loaders/types.ts
@@ -1,0 +1,12 @@
+import type { IArrayLoader, ITextureImageLoader } from "src/colorizer/loaders/ILoader";
+import type { IPathResolver } from "src/colorizer/path_resolvers";
+import type { ReportLoadProgressCallback, ReportWarningCallback } from "src/colorizer/types";
+
+export type DatasetLoadOptions = {
+  reportProgress?: ReportLoadProgressCallback;
+  reportWarning?: ReportWarningCallback;
+
+  frameLoader?: ITextureImageLoader;
+  arrayLoader?: IArrayLoader;
+  pathResolver?: IPathResolver;
+};

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -12,8 +12,6 @@ import {
   UnsignedIntType,
 } from "three";
 
-// This file provides a bit of type trickery to allow data loading code to be generic over multiple numeric types.
-
 export type HexColorString = `#${string}`;
 
 /** Available types for data loading (features, tracks, outliers, etc.), as a CPU buffer or a GPU texture */

--- a/src/state/slices/dataset_slice.ts
+++ b/src/state/slices/dataset_slice.ts
@@ -78,7 +78,7 @@ export const createDatasetSlice: StateCreator<CollectionSlice & DatasetSlice, []
     let featureKey = get().featureKey;
     if (featureKey === null || !dataset.hasFeatureKey(featureKey)) {
       // Set to default feature key of the new dataset
-      featureKey = dataset.featureKeys[0];
+      featureKey = dataset.featureKeys[0] ?? null;
     }
 
     // Switch to new dataset's default backdrop if the current one is not in the new dataset.

--- a/tests/Collection.test.ts
+++ b/tests/Collection.test.ts
@@ -7,7 +7,7 @@ import Collection, {
   type DatasetLoadOptions,
 } from "src/colorizer/Collection";
 import { DEFAULT_COLLECTION_FILENAME, DEFAULT_DATASET_FILENAME } from "src/colorizer/constants";
-import { MOCK_DATASET_FEATURE_1, MOCK_DATASET_MANIFEST, MOCK_DATASET_TIMES } from "tests/constants";
+import { MOCK_DATASET_FILEMAP } from "tests/constants";
 import { ANY_ERROR, makeMockFetchMethod, MockFetchArrayLoader } from "tests/utils";
 
 const collectionData = new Map([
@@ -189,7 +189,7 @@ describe("Collection", () => {
     const urlToFile: Record<string, File> = {};
 
     window.URL.createObjectURL = (file: File): string => {
-      const url = "http://mocked-created-url/" + generateUUID();
+      const url = "http://mocked-created-url.com/" + generateUUID();
       urlToFile[url] = file;
       return url;
     };
@@ -224,15 +224,6 @@ describe("Collection", () => {
     const MOCK_COLLECTION_FILEMAP = {
       // eslint-disable-next-line
       "collection.json": new File([MOCK_COLLECTION_JSON], "collection.json"),
-    };
-    const MOCK_DATASET_FILEMAP = {
-      // eslint-disable-next-line
-      "manifest.json": new File([JSON.stringify(MOCK_DATASET_MANIFEST)], "manifest.json"),
-      // add minimal files to ensure the Dataset can actually load
-      // eslint-disable-next-line
-      "times.json": new File([JSON.stringify(MOCK_DATASET_TIMES)], "times.json"),
-      // eslint-disable-next-line
-      "feature1.json": new File([JSON.stringify(MOCK_DATASET_FEATURE_1)], "frames.json"),
     };
 
     const DATASET_LOAD_OPTIONS: DatasetLoadOptions = {

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -13,7 +13,6 @@ import {
   MOCK_DATASET_MANIFEST,
 } from "tests/constants";
 import {
-  ANY_ERROR,
   DEFAULT_DATASET_DIR,
   DEFAULT_DATASET_PATH,
   makeMockAsyncLoader,
@@ -165,11 +164,12 @@ describe("Dataset", () => {
         expect(dataset.getFeatureCategories("feature5")).to.deep.equal(["small", "medium", "large"]);
       });
 
-      it("throws an error if categorical data is missing categories", async () => {
+      it("skips categorical features that are missing categories", async () => {
         const badManifest = {
           frames: ["frame0.json"],
           features: {
             feature1: "feature1.json",
+            feature2: "feature2.json",
           },
           featureMetadata: {
             feature1: { type: "categorical" },
@@ -181,15 +181,17 @@ describe("Dataset", () => {
           arrayLoader: new MockArrayLoader(),
           manifestLoader: mockFetch,
         });
-        await expect(datasetLoader.open()).rejects.toThrowError(ANY_ERROR);
+        const dataset = await datasetLoader.open();
+        expect(dataset.featureKeys).to.deep.equal(["feature2"]);
       });
 
-      it("throws an error if the number of categories exceeds the max", async () => {
+      it("skips categorical features that exceed the max number of categories", async () => {
         const categories = [...Array(MAX_FEATURE_CATEGORIES + 1).keys()].map((i) => i.toString());
         const badManifest = {
           frames: ["frame0.json"],
           features: {
             feature1: "feature1.json",
+            feature2: "feature2.json",
           },
           featureMetadata: {
             feature1: {
@@ -204,7 +206,8 @@ describe("Dataset", () => {
           arrayLoader: new MockArrayLoader(),
           manifestLoader: mockFetch,
         });
-        await expect(datasetLoader.open()).rejects.toThrowError(ANY_ERROR);
+        const dataset = await datasetLoader.open();
+        expect(dataset.featureKeys).to.deep.equal(["feature2"]);
       });
 
       it("Loads the first frame and retrieves frame dimensions on open", async () => {

--- a/tests/Dataset.test.ts
+++ b/tests/Dataset.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it } from "vitest";
 
 import { FeatureDataType } from "src/colorizer";
 import { MAX_FEATURE_CATEGORIES } from "src/colorizer/constants";
-import Dataset, { FeatureType } from "src/colorizer/Dataset";
+import { FeatureType } from "src/colorizer/Dataset";
+import JsonDatasetLoader from "src/colorizer/dataset_loaders/JsonDatasetLoader";
 import type { AnyManifestFile, ManifestFile } from "src/colorizer/utils/dataset_utils";
 import {
   MOCK_DATASET_ARRAY_LOADER,
@@ -174,12 +175,13 @@ describe("Dataset", () => {
             feature1: { type: "categorical" },
           },
         };
-        const dataset = new Dataset(DEFAULT_DATASET_PATH, {
+        const mockFetch = makeMockAsyncLoader(DEFAULT_DATASET_PATH, badManifest);
+        const datasetLoader = new JsonDatasetLoader(DEFAULT_DATASET_PATH, {
           frameLoader: new MockFrameLoader(),
           arrayLoader: new MockArrayLoader(),
+          manifestLoader: mockFetch,
         });
-        const mockFetch = makeMockAsyncLoader(DEFAULT_DATASET_PATH, badManifest);
-        await expect(dataset.open({ manifestLoader: mockFetch })).rejects.toThrowError(ANY_ERROR);
+        await expect(datasetLoader.open()).rejects.toThrowError(ANY_ERROR);
       });
 
       it("throws an error if the number of categories exceeds the max", async () => {
@@ -196,12 +198,13 @@ describe("Dataset", () => {
             },
           },
         };
-        const dataset = new Dataset(DEFAULT_DATASET_PATH, {
+        const mockFetch = makeMockAsyncLoader(DEFAULT_DATASET_PATH, badManifest);
+        const datasetLoader = new JsonDatasetLoader(DEFAULT_DATASET_PATH, {
           frameLoader: new MockFrameLoader(),
           arrayLoader: new MockArrayLoader(),
+          manifestLoader: mockFetch,
         });
-        const mockFetch = makeMockAsyncLoader(DEFAULT_DATASET_PATH, badManifest);
-        await expect(dataset.open({ manifestLoader: mockFetch })).rejects.toThrowError(ANY_ERROR);
+        await expect(datasetLoader.open()).rejects.toThrowError(ANY_ERROR);
       });
 
       it("Loads the first frame and retrieves frame dimensions on open", async () => {
@@ -217,12 +220,12 @@ describe("Dataset", () => {
         ];
 
         for (const [width, height] of dimensionTests) {
-          const dataset = new Dataset(DEFAULT_DATASET_PATH, {
+          const datasetLoader = new JsonDatasetLoader(DEFAULT_DATASET_PATH, {
             frameLoader: new MockFrameLoader(width, height),
             arrayLoader: new MockArrayLoader(),
+            manifestLoader: mockFetch,
           });
-          expect(dataset.frameResolution).to.deep.equal(new Vector2(1, 1));
-          await dataset.open({ manifestLoader: mockFetch });
+          const dataset = await datasetLoader.open();
           expect(dataset.frameResolution).to.deep.equal(new Vector2(width, height));
         }
       });
@@ -350,7 +353,6 @@ describe("Dataset", () => {
   describe("toCsvDataColumns", () => {
     it("converts default dataset to CSV data columns", async () => {
       const dataset = await makeMockDataset(MOCK_DATASET_MANIFEST, MOCK_DATASET_ARRAY_LOADER);
-      await dataset.open();
       const csvColumns = dataset.toCsvDataColumns();
       expect(csvColumns[0]).to.deep.equal({
         name: "ID",

--- a/tests/constants/index.ts
+++ b/tests/constants/index.ts
@@ -157,6 +157,21 @@ export const MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE = makeMockDatasetArrayLoad
 
 export const MOCK_DATASET_ARRAY_LOADER = new MockArrayLoader(MOCK_DATASET_ARRAY_LOADER_DEFAULT_SOURCE);
 
+export const fileToData: [string, number[] | Object][] = [
+  ["manifest.json", MOCK_DATASET_MANIFEST],
+  ["times.json", MOCK_DATASET_TIMES],
+  ["seg_ids.json", MOCK_DATASET_SEG_IDS],
+  ["tracks.json", MOCK_DATASET_TRACKS],
+  ["feature1.json", MOCK_DATASET_FEATURE_1],
+  ["feature2.json", MOCK_DATASET_FEATURE_2],
+  ["feature3.json", MOCK_DATASET_FEATURE_3],
+  ["feature4.json", MOCK_DATASET_FEATURE_4],
+  ["centroids.json", MOCK_DATASET_CENTROIDS],
+];
+export const MOCK_DATASET_FILEMAP = Object.fromEntries(
+  fileToData.map(([filename, data]) => [filename, new File([JSON.stringify(data)], filename)])
+);
+
 export const MOCK_DATASET = await makeMockDataset(MOCK_DATASET_MANIFEST, MOCK_DATASET_ARRAY_LOADER);
 
 export const MOCK_DATASET_WITH_TWO_FRAMES = await makeMockDataset(

--- a/tests/state/ViewerState/channel_slice.test.ts
+++ b/tests/state/ViewerState/channel_slice.test.ts
@@ -346,7 +346,11 @@ describe("ChannelSlice", () => {
 
     function getRandomSerializableNumber(): number {
       // Must have no more than 3 digits of precision
-      return Math.round(Math.random() * 200_000 - 100_000) / 1000;
+      const value = Math.round(Math.random() * 200_000 - 100_000) / 1000;
+      if (value === -0) {
+        return 0;
+      }
+      return value;
     }
 
     function makeRandomChannelSettings(): ChannelSetting {

--- a/tests/state/ViewerState/channel_slice.test.ts
+++ b/tests/state/ViewerState/channel_slice.test.ts
@@ -347,7 +347,7 @@ describe("ChannelSlice", () => {
     function getRandomSerializableNumber(): number {
       // Must have no more than 3 digits of precision
       const value = Math.round(Math.random() * 200_000 - 100_000) / 1000;
-      if (value === -0) {
+      if (Object.is(value, -0)) {
         return 0;
       }
       return value;

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -2,7 +2,7 @@ import { DataTexture, RGBAFormat, type Texture, UnsignedByteType } from "three";
 
 import {
   type ArraySource,
-  Dataset,
+  type Dataset,
   type FeatureArrayType,
   type FeatureDataType,
   featureTypeSpecs,

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -9,6 +9,7 @@ import {
   type IArrayLoader,
   type ITextureImageLoader,
 } from "src/colorizer";
+import JsonDatasetLoader from "src/colorizer/dataset_loaders/JsonDatasetLoader";
 import type { AnyManifestFile } from "src/colorizer/utils/dataset_utils";
 import type { fetchWithTimeout } from "src/colorizer/utils/url_utils";
 
@@ -161,8 +162,12 @@ export const makeMockDataset = async (
   manifest: AnyManifestFile,
   loader: MockArrayLoader = new MockArrayLoader()
 ): Promise<Dataset> => {
-  const dataset = new Dataset(DEFAULT_DATASET_PATH, { frameLoader: new MockFrameLoader(), arrayLoader: loader });
   const mockLoader = makeMockAsyncLoader(DEFAULT_DATASET_PATH, manifest);
-  await dataset.open({ manifestLoader: mockLoader });
+  const datasetLoader = new JsonDatasetLoader(DEFAULT_DATASET_PATH, {
+    frameLoader: new MockFrameLoader(),
+    arrayLoader: loader,
+    manifestLoader: mockLoader,
+  });
+  const dataset = await datasetLoader.open();
   return dataset;
 };


### PR DESCRIPTION
Problem
=======
Part 1 of 2 for #632, "single file datasets."

Previously, the `Dataset` class in TFE acted as a representation of the currently loaded Dataset, but also served double-duty as its own data loader. This change moves loading logic out of `Dataset` and into a new `JsonDatasetLoader` class with several helper methods.

Doing this will allow us to make many different kinds of loaders in the future that support different source formats!

*Estimated review size: large, 40-50 minutes (mostly copied/moved code, faster if comparing)*

Solution
========
- Moved loading logic out of `Dataset` and into the new `JsonDatasetLoader`.
  - `JsonDatasetLoader.open()` returns a `Dataset` promise.
- Moved several functions into the new `dataset_loader_utils.ts` helper file.
- Removed unused fields from `Dataset`, changed default value for missing data arrays to `null` instead of `undefined`.
- Updated unit tests.

Misc:
- Fixed a bug in `channel_slice.test.ts` where, at low probabilities, an unserializable `-0` value would be returned.
- Added fallbacks for determining the number of frames in a dataset using `times` data.


## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-930/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Medium
2. The dataset should load and be interactive. Feel free to click around the UI.

Keyfiles (delete if not relevant):
-----------------------
1. `JsonDatasetLoader.ts` (compare with `Dataset.ts`)
2. `dataset_loader_utils.ts` (compare with `Dataset.ts`)
