### PR TITLE
refactor: Moved opacity slider into segmentation toggle (opacity pt. 1)

### DIFF
--- a/src/components/Buttons/ToggleButtonWithConfig.tsx
+++ b/src/components/Buttons/ToggleButtonWithConfig.tsx
@@ -64,7 +64,7 @@ export function ToggleButtonWithConfig(inputProps: ToggleButtonWithConfigProps):
   const tooltipTitle = buttonActionVerb + " " + props.name;
 
   const tooltipContents = Array.isArray(props.tooltipContents) ? [...props.tooltipContents] : [props.tooltipContents];
-  if (props.visible && !configMenuOpen) {
+  if (props.visible && !configMenuOpen && hasConfigMenu) {
     tooltipContents.push("Double-click to hide " + props.name.toLowerCase());
   }
 

--- a/src/components/Buttons/ToggleButtonWithConfig.tsx
+++ b/src/components/Buttons/ToggleButtonWithConfig.tsx
@@ -47,11 +47,13 @@ export function ToggleButtonWithConfig(inputProps: ToggleButtonWithConfigProps):
   const popupContainerRef = useRef<HTMLDivElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
+  const hasConfigMenu = !!props.configMenuContents;
+
   let buttonActionVerb: string;
   if (props.visible) {
     // While visible, clicking the first time opens the config menu, and
     // clicking again hides the image layer.
-    if (!configMenuOpen) {
+    if (hasConfigMenu && !configMenuOpen) {
       buttonActionVerb = "Configure";
     } else {
       buttonActionVerb = "Hide";
@@ -68,7 +70,7 @@ export function ToggleButtonWithConfig(inputProps: ToggleButtonWithConfigProps):
 
   const onClick = (): void => {
     if (props.visible) {
-      if (!configMenuOpen) {
+      if (hasConfigMenu && !configMenuOpen) {
         setConfigMenuOpen(true);
       } else {
         setConfigMenuOpen(false);
@@ -121,7 +123,7 @@ export function ToggleButtonWithConfig(inputProps: ToggleButtonWithConfigProps):
         trigger={["click"]}
         getPopupContainer={() => props.popupContainer || popupContainerRef.current || document.body}
         onOpenChange={(open) => setConfigMenuOpen(open)}
-        open={configMenuOpen}
+        open={configMenuOpen && hasConfigMenu}
       >
         <TooltipWithSubtitle
           title={tooltipTitle}

--- a/src/components/CanvasWrapper/BackdropToggleButton.tsx
+++ b/src/components/CanvasWrapper/BackdropToggleButton.tsx
@@ -4,14 +4,12 @@ import { ToggleButtonWithConfig } from "src/components/Buttons/ToggleButtonWithC
 import ShortcutTooltipHint from "src/components/Display/ShortcutTooltipHint";
 import SelectionDropdown from "src/components/Dropdowns/SelectionDropdown";
 import type { SelectItem } from "src/components/Dropdowns/types";
-import LabeledSlider from "src/components/Inputs/LabeledSlider";
 import { SettingsContainer, SettingsItem } from "src/components/SettingsContainer";
 import { SHORTCUT_KEYS } from "src/constants";
 import { useViewerStateStore } from "src/state";
 import { FlexColumn, FlexRow } from "src/styles/utils";
 
 const enum BackdropToggleButtonHtmlIds {
-  OPACITY_SLIDER = "backdrop-toggle-opacity-slider",
   BACKDROP_SELECT = "backdrop-toggle-backdrop-select",
 }
 
@@ -19,10 +17,8 @@ export default function BackdropToggleButton(): ReactElement {
   const dataset = useViewerStateStore((state) => state.dataset);
   const backdropKey = useViewerStateStore((state) => state.backdropKey);
   const backdropVisible = useViewerStateStore((state) => state.backdropVisible);
-  const objectOpacity = useViewerStateStore((state) => state.objectOpacity);
   const setBackdropKey = useViewerStateStore((state) => state.setBackdropKey);
   const setBackdropVisible = useViewerStateStore((state) => state.setBackdropVisible);
-  const setObjectOpacity = useViewerStateStore((state) => state.setObjectOpacity);
 
   const backdropData = dataset?.getBackdropData();
   const hasBackdrops = backdropData !== undefined && backdropData.size > 0 && backdropKey !== null;
@@ -42,7 +38,7 @@ export default function BackdropToggleButton(): ReactElement {
 
   // Config menu
   const createBackdropConfigMenuContents = [
-    <SettingsContainer labelWidth="85px" key="backdrop-settings-container">
+    <SettingsContainer labelWidth="85px" key="backdrop-settings-container" style={{ marginBottom: "8px" }}>
       <SettingsItem
         label={
           <FlexRow $gap={6}>
@@ -69,25 +65,9 @@ export default function BackdropToggleButton(): ReactElement {
               setBackdropVisible(true);
               setBackdropKey(value);
             }}
-            controlWidth="220px"
+            controlWidth="180px"
           />
         </FlexColumn>
-      </SettingsItem>
-      <SettingsItem label="Opacity" htmlFor={BackdropToggleButtonHtmlIds.OPACITY_SLIDER} style={{ marginBottom: 14 }}>
-        <div style={{ display: "flex", flexGrow: 1 }}>
-          <LabeledSlider
-            id={BackdropToggleButtonHtmlIds.OPACITY_SLIDER}
-            disabled={!backdropVisible}
-            type="value"
-            value={objectOpacity}
-            onChange={setObjectOpacity}
-            step={1}
-            minSliderBound={0}
-            maxSliderBound={100}
-            showInput={false}
-            numberFormatter={(value) => value + "%"}
-          />
-        </div>
       </SettingsItem>
     </SettingsContainer>,
   ];

--- a/src/components/CanvasWrapper/CanvasToolbar.tsx
+++ b/src/components/CanvasWrapper/CanvasToolbar.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from "antd";
 import React, { type ReactElement, type ReactNode } from "react";
 import styled from "styled-components";
 
-import { ImageIconSVG, ImageSlashIconSVG, TagIconSVG, TagSlashIconSVG } from "src/assets";
+import { TagIconSVG, TagSlashIconSVG } from "src/assets";
 import { TabType, ViewMode } from "src/colorizer/types";
 import type CanvasOverlay from "src/colorizer/viewport/CanvasOverlay";
 import IconButton from "src/components/Buttons/IconButton";
@@ -11,6 +11,7 @@ import TooltipButtonStyleLink from "src/components/Buttons/TooltipButtonStyleLin
 import BackdropToggleButton from "src/components/CanvasWrapper/BackdropToggleButton";
 import CentroidsToggleButton from "src/components/CanvasWrapper/CentroidsToggleButton";
 import ChannelToggleButton from "src/components/CanvasWrapper/ChannelToggleButton";
+import SegmentationsToggleButton from "src/components/CanvasWrapper/SegmentationsToggleButton";
 import { TooltipWithSubtitle } from "src/components/Tooltips/TooltipWithSubtitle";
 import type { AnnotationState } from "src/hooks";
 import { useViewerStateStore } from "src/state";
@@ -37,8 +38,6 @@ export default function CanvasToolbar(props: CanvasToolbarProps): ReactElement {
   const { canv } = props;
 
   const setOpenTab = useViewerStateStore((state) => state.setOpenTab);
-  const setShowSegmentations = useViewerStateStore((state) => state.setShowSegmentations);
-  const showSegmentations = useViewerStateStore((state) => state.showSegmentations);
   const viewMode = useViewerStateStore((state) => state.viewMode);
 
   const isDataset3d = viewMode === ViewMode.VIEW_3D;
@@ -101,19 +100,7 @@ export default function CanvasToolbar(props: CanvasToolbarProps): ReactElement {
       <StyledHorizontalRule style={{ margin: 0 }} />
 
       {/* Segmentations toggle */}
-      <TooltipWithSubtitle
-        title={showSegmentations ? "Hide segmentations" : "Show segmentations"}
-        placement="right"
-        trigger={["hover", "focus"]}
-      >
-        <IconButton
-          type={showSegmentations ? "primary" : "link"}
-          onClick={() => setShowSegmentations(!showSegmentations)}
-        >
-          {showSegmentations ? <ImageIconSVG /> : <ImageSlashIconSVG />}
-          <VisuallyHidden>{showSegmentations ? "Hide segmentations" : "Show segmentations"}</VisuallyHidden>
-        </IconButton>
-      </TooltipWithSubtitle>
+      <SegmentationsToggleButton />
 
       {/* 2D backdrop or 3D channels toggle */}
       {isDataset3d ? <ChannelToggleButton /> : <BackdropToggleButton />}

--- a/src/components/CanvasWrapper/SegmentationsToggleButton.tsx
+++ b/src/components/CanvasWrapper/SegmentationsToggleButton.tsx
@@ -1,0 +1,66 @@
+import { Tooltip } from "antd";
+import React, { type ReactElement } from "react";
+
+import { ImageIconSVG, ImageSlashIconSVG } from "src/assets";
+import { ToggleButtonWithConfig } from "src/components/Buttons/ToggleButtonWithConfig";
+import LabeledSlider from "src/components/Inputs/LabeledSlider";
+import { SettingsContainer, SettingsItem } from "src/components/SettingsContainer";
+import { useViewerStateStore } from "src/state";
+
+const enum SegmentationsToggleButtonHtmlIds {
+  OPACITY_SLIDER = "segmentations-toggle-opacity-slider",
+}
+
+export default function SegmentationsToggleButton(): ReactElement {
+  const backdropVisible = useViewerStateStore((state) => state.backdropVisible);
+  const objectOpacity = useViewerStateStore((state) => state.objectOpacity);
+  const setShowSegmentations = useViewerStateStore((state) => state.setShowSegmentations);
+  const showSegmentations = useViewerStateStore((state) => state.showSegmentations);
+  const setObjectOpacity = useViewerStateStore((state) => state.setObjectOpacity);
+
+  const configMenuContents = (
+    <div style={{ marginBottom: "14px" }}>
+      <SettingsContainer labelWidth="65px" style={{ width: "240px" }}>
+        <SettingsItem
+          label="Opacity"
+          htmlFor={SegmentationsToggleButtonHtmlIds.OPACITY_SLIDER}
+          style={{ marginBottom: 14 }}
+        >
+          <Tooltip
+            title="Segmentation opacity is only applied when backdrops are enabled"
+            open={backdropVisible ? false : undefined}
+            placement="top"
+          >
+            <div style={{ display: "flex", flexGrow: 1 }}>
+              <LabeledSlider
+                id={SegmentationsToggleButtonHtmlIds.OPACITY_SLIDER}
+                disabled={!backdropVisible}
+                type="value"
+                value={objectOpacity}
+                onChange={setObjectOpacity}
+                step={1}
+                minSliderBound={0}
+                maxSliderBound={100}
+                marks={[50]}
+                showInput={false}
+                numberFormatter={(value) => value + "%"}
+              />
+            </div>
+          </Tooltip>
+        </SettingsItem>
+      </SettingsContainer>
+    </div>
+  );
+
+  return (
+    <ToggleButtonWithConfig
+      name="segmentations"
+      visible={showSegmentations}
+      setVisible={setShowSegmentations}
+      configMenuContents={configMenuContents}
+      settingsLinkText="Viewer settings > Objects"
+      visibleIcon={<ImageIconSVG />}
+      hiddenIcon={<ImageSlashIconSVG />}
+    />
+  );
+}

--- a/src/components/CanvasWrapper/SegmentationsToggleButton.tsx
+++ b/src/components/CanvasWrapper/SegmentationsToggleButton.tsx
@@ -2,6 +2,7 @@ import { Tooltip } from "antd";
 import React, { type ReactElement } from "react";
 
 import { ImageIconSVG, ImageSlashIconSVG } from "src/assets";
+import { ViewMode } from "src/colorizer";
 import { ToggleButtonWithConfig } from "src/components/Buttons/ToggleButtonWithConfig";
 import LabeledSlider from "src/components/Inputs/LabeledSlider";
 import { SettingsContainer, SettingsItem } from "src/components/SettingsContainer";
@@ -14,43 +15,45 @@ const enum SegmentationsToggleButtonHtmlIds {
 export default function SegmentationsToggleButton(): ReactElement {
   const backdropVisible = useViewerStateStore((state) => state.backdropVisible);
   const objectOpacity = useViewerStateStore((state) => state.objectOpacity);
+  const setObjectOpacity = useViewerStateStore((state) => state.setObjectOpacity);
   const setShowSegmentations = useViewerStateStore((state) => state.setShowSegmentations);
   const showSegmentations = useViewerStateStore((state) => state.showSegmentations);
-  const setObjectOpacity = useViewerStateStore((state) => state.setObjectOpacity);
+  const viewMode = useViewerStateStore((state) => state.viewMode);
 
-  const configMenuContents = (
-    <div style={{ marginBottom: "14px" }}>
-      <SettingsContainer labelWidth="65px" style={{ width: "240px" }}>
-        <SettingsItem
-          label="Opacity"
-          htmlFor={SegmentationsToggleButtonHtmlIds.OPACITY_SLIDER}
-          style={{ marginBottom: 14 }}
-        >
-          <Tooltip
-            title="Segmentation opacity is only applied when backdrops are enabled"
-            open={backdropVisible ? false : undefined}
-            placement="top"
+  const configMenuContents =
+    viewMode !== ViewMode.VIEW_3D ? (
+      <div style={{ marginBottom: "14px" }}>
+        <SettingsContainer labelWidth="65px" style={{ width: "240px" }}>
+          <SettingsItem
+            label="Opacity"
+            htmlFor={SegmentationsToggleButtonHtmlIds.OPACITY_SLIDER}
+            style={{ marginBottom: 14 }}
           >
-            <div style={{ display: "flex", flexGrow: 1 }}>
-              <LabeledSlider
-                id={SegmentationsToggleButtonHtmlIds.OPACITY_SLIDER}
-                disabled={!backdropVisible}
-                type="value"
-                value={objectOpacity}
-                onChange={setObjectOpacity}
-                step={1}
-                minSliderBound={0}
-                maxSliderBound={100}
-                marks={[50]}
-                showInput={false}
-                numberFormatter={(value) => value + "%"}
-              />
-            </div>
-          </Tooltip>
-        </SettingsItem>
-      </SettingsContainer>
-    </div>
-  );
+            <Tooltip
+              title="Segmentation opacity is only applied when backdrops are enabled"
+              open={backdropVisible ? false : undefined}
+              placement="top"
+            >
+              <div style={{ display: "flex", flexGrow: 1 }}>
+                <LabeledSlider
+                  id={SegmentationsToggleButtonHtmlIds.OPACITY_SLIDER}
+                  disabled={!backdropVisible}
+                  type="value"
+                  value={objectOpacity}
+                  onChange={setObjectOpacity}
+                  step={1}
+                  minSliderBound={0}
+                  maxSliderBound={100}
+                  marks={[50]}
+                  showInput={false}
+                  numberFormatter={(value) => value + "%"}
+                />
+              </div>
+            </Tooltip>
+          </SettingsItem>
+        </SettingsContainer>
+      </div>
+    ) : null;
 
   return (
     <ToggleButtonWithConfig


### PR DESCRIPTION
Problem
=======
Closes #923, "move segmentation opacity control into segmentation toggle button."

Note: In the process of making this change, I also am going to go in and make a separate control for centroid opacity. That will be in a follow up PR!

*Estimated review size: tiny, 10 minutes*

Solution
========
- Moves opacity control out of backdrop toggle menu and into a new `SegmentationsToggleButton.tsx` component.
  - Opacity slider is disabled when backdrops are not enabled.
  - Segmentations config menu is hidden when in 3D mode, since there are no 3D-related segmentation settings yet.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview-internal/pr-933/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&bg=1
2. Click on the segmentation toggle button. The opacity slider will appear.
3. Disable backdrops and return to the segmentations menu. The opacity slider will be disabled and show an explanatory tooltip.

Screenshots (optional):
-----------------------
<img width="473" height="253" alt="image" src="https://github.com/user-attachments/assets/b688382e-bd1f-49da-a2f4-bd76d215ef10" />


<img width="350" height="266" alt="image" src="https://github.com/user-attachments/assets/9744eea4-e837-49a3-8bec-8aad3c39a891" />


