### PR TITLE
feat: Change cursor and show tooltip when click interaction is disabled

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -655,7 +655,6 @@ function Viewer(): ReactElement {
                 canv={canv}
                 isRecording={isRecording}
                 onClickId={onClickId}
-                hoveredId={currentHoveredId}
                 onMouseHover={(info: PixelIdInfo | null): void => {
                   const isObject = info !== null;
                   setShowObjectHoverInfo(isObject);

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -655,6 +655,7 @@ function Viewer(): ReactElement {
                 canv={canv}
                 isRecording={isRecording}
                 onClickId={onClickId}
+                hoveredId={currentHoveredId}
                 onMouseHover={(info: PixelIdInfo | null): void => {
                   const isObject = info !== null;
                   setShowObjectHoverInfo(isObject);

--- a/src/components/CanvasWrapper/CanvasWrapper.tsx
+++ b/src/components/CanvasWrapper/CanvasWrapper.tsx
@@ -125,6 +125,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
   const showScaleBar = useViewerStateStore((state) => state.showScaleBar);
   const showTimestamp = useViewerStateStore((state) => state.showTimestamp);
   const frameLoadResult = useViewerStateStore((state) => state.frameLoadResult);
+  const showSegmentations = useViewerStateStore((state) => state.showSegmentations);
+  const showCentroids = useViewerStateStore((state) => state.showCentroids);
 
   const isAnnotationModeEnabled = props.annotationState.isAnnotationModeEnabled;
 
@@ -308,6 +310,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     (offsetX: number, offsetY: number): void => {
       if (isMouseDragging.current) {
         canv.domElement.style.cursor = "move";
+      } else if (!showSegmentations && !showCentroids) {
+        canv.domElement.style.cursor = "not-allowed";
       } else if (props.annotationState.isAnnotationModeEnabled) {
         // Check if mouse is over an object, and if it's labeled with an editable label.
         // If so, show the edit cursor.
@@ -339,6 +343,8 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     [
       isMouseDragging,
       datasetKey,
+      showCentroids,
+      showSegmentations,
       props.annotationState.isAnnotationModeEnabled,
       props.annotationState.data,
       props.annotationState.selectionMode,
@@ -384,6 +390,10 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
     async (event: MouseEvent): Promise<void> => {
       setLastClickPosition([event.offsetX, event.offsetY]);
       updateCanvasCursor(event.offsetX, event.offsetY);
+      if (!showSegmentations && !showCentroids) {
+        return;
+      }
+
       const info = canv.getIdAtPixel(event.offsetX, event.offsetY);
       props.onClickId(info);
 
@@ -397,7 +407,17 @@ export default function CanvasWrapper(inputProps: CanvasWrapperProps): ReactElem
         handleBackgroundClicked();
       }
     },
-    [canv, dataset, props.onClickId, clearTracks, handleObjectClicked, handleBackgroundClicked]
+    [
+      canv,
+      dataset,
+      props.onClickId,
+      showSegmentations,
+      showCentroids,
+      clearTracks,
+      updateCanvasCursor,
+      handleObjectClicked,
+      handleBackgroundClicked,
+    ]
   );
 
   // Mouse event handlers

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -1,5 +1,5 @@
 import { Tag } from "antd";
-import React, { type PropsWithChildren, type ReactElement, ReactNode, useCallback, useContext } from "react";
+import React, { type PropsWithChildren, type ReactElement, type ReactNode, useCallback, useContext } from "react";
 import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
 

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -236,11 +236,16 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
 
   // If segmentations and centroids are both hidden, show a warning that click
   // interactions will not work.
+
+  // TODO: Ideally, click interactions should work no matter what. Consider
+  // refactoring the 2D and 3D canvas to secretly enable segmentations even when
+  // they are hidden, so interactions still work as expected. Note that this
+  // will be a performance tradeoff.
   let noInteractionWarning: ReactNode;
   if (!showSegmentations && !showCentroids) {
     noInteractionWarning = (
-      <Tag style={{ width: "fit-content", margin: "0 2px" }} color={theme.color.text.hint}>
-        Segmentations are hidden
+      <Tag style={{ maxWidth: "150px", margin: "0 2px", textWrap: "wrap" }} color={theme.color.text.hint}>
+        Enable segmentations or centroids to interact
       </Tag>
     );
   }

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -1,5 +1,5 @@
 import { Tag } from "antd";
-import React, { type PropsWithChildren, type ReactElement, useCallback } from "react";
+import React, { type PropsWithChildren, type ReactElement, ReactNode, useCallback, useContext } from "react";
 import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
 
@@ -9,6 +9,7 @@ import { formatNumber } from "src/colorizer/utils/math_utils";
 import type { AnnotationState } from "src/hooks";
 import { selectVectorConfigFromState } from "src/state/slices";
 import { useViewerStateStore } from "src/state/ViewerState";
+import { AppThemeContext } from "src/styles/AppStyle";
 import { FlexColumn, FlexRow } from "src/styles/utils";
 
 import HoverTooltip from "./HoverTooltip";
@@ -47,10 +48,14 @@ const DebugText = styled.p`
 export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverTooltipProps>): ReactElement {
   const { lastValidHoveredId: lastHoveredId } = props;
 
+  const theme = useContext(AppThemeContext);
+
   const dataset = useViewerStateStore((state) => state.dataset);
   const datasetKey = useViewerStateStore((state) => state.datasetKey);
   const featureKey = useViewerStateStore((state) => state.featureKey);
   const motionDeltas = useViewerStateStore((state) => state.vectorMotionDeltas);
+  const showCentroids = useViewerStateStore((state) => state.showCentroids);
+  const showSegmentations = useViewerStateStore((state) => state.showSegmentations);
   const vectorConfig = useViewerStateStore(useShallow(selectVectorConfigFromState));
 
   const featureName = featureKey ? dataset?.getFeatureName(featureKey) : undefined;
@@ -167,7 +172,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
   }
 
   // If editing annotations, also show the current label being applied
-  let annotationLabel: React.ReactNode;
+  let annotationLabel: ReactNode;
   const currentLabelIdx = props.annotationState.currentLabelIdx;
   if (props.annotationState.isAnnotationModeEnabled && currentLabelIdx !== null) {
     const currentLabelData = labelData[currentLabelIdx];
@@ -229,9 +234,21 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
     }
   }
 
+  // If segmentations and centroids are both hidden, show a warning that click
+  // interactions will not work.
+  let noInteractionWarning: ReactNode;
+  if (!showSegmentations && !showCentroids) {
+    noInteractionWarning = (
+      <Tag style={{ width: "fit-content", margin: "0 2px" }} color={theme.color.text.hint}>
+        Segmentations are hidden
+      </Tag>
+    );
+  }
+
   const tooltipContent = (
     <FlexColumn $gap={6}>
       {annotationLabel}
+      {noInteractionWarning}
       <ObjectInfoCard style={{ opacity: props.showObjectHoverInfo ? 1 : 0 }}>{objectInfoContent}</ObjectInfoCard>
     </FlexColumn>
   );


### PR DESCRIPTION
Problem
=======

This change addresses a possible error state by giving more user feedback. 

It's possible for users to have both centroids and segmentations disabled, which means that no click interaction can take place. This change switches the cursor when hovering over the viewport (🚫) and adds an informational tooltip that follows the mouse.

From talking with UX, an improved version of this would be to always be loading segmentations in the background even when hidden. I'll likely open this up as a future PR.

*Estimated review size: tiny, 5 minutes*

Solution
========
- When centroid and segmentations are both disabled:
  - `CanvasWrapper` now ignores mouse clicks when both centroids and segmentations are off, and shows a `not-allowed` cursor style.
  - `CanvasHoverTooltip` shows a message explaining that users should enable segmentations or centroids to interact with the viewport.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-934/viewer?collection=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Ftimelapse_feature_explorer_datasets%2Fexploratory_dataset%2Fcollection.json&dataset=Small&bg=1&seg=0&centroids=0
2. Hover over the viewport. The new cursor and the hover tooltip will appear.
3. Enable either centroids or segmentations. The cursor and hover tooltip will disappear.

Screenshots (optional):
-----------------------

<img width="890" height="661" alt="image" src="https://github.com/user-attachments/assets/b4800395-4bb7-476d-a272-ff0c17d9701a" />
