### PR TITLE
fix: Added back behavior where flow field plot threshold scaled with bin

### DIFF
--- a/src/components/Display/LabelWithHint.tsx
+++ b/src/components/Display/LabelWithHint.tsx
@@ -1,6 +1,6 @@
-import React, { PropsWithChildren, ReactElement } from "react";
+import React, { type PropsWithChildren, type ReactElement } from "react";
 
-import InlineHint, { InlineHintProps } from "src/components/Display/InlineHint";
+import InlineHint, { type InlineHintProps } from "src/components/Display/InlineHint";
 import { FlexRowAlignCenter } from "src/styles/utils";
 
 type LabelWithHintProps = {

--- a/src/components/Tabs/Plot3d/Plot3dTab.tsx
+++ b/src/components/Tabs/Plot3d/Plot3dTab.tsx
@@ -10,8 +10,8 @@ import { useInteractionListener } from "src/hooks";
 import { useViewerStateStore } from "src/state";
 import { FlexColumn } from "src/styles/utils";
 
-import Plot3d from "./Plot3d";
 import { make3dConeTrace } from "./plot_3d_utils";
+import Plot3d from "./Plot3d";
 
 const RESUME_PLAYBACK_TIMEOUT_MS = 500;
 

--- a/src/components/Tabs/Plot3d/Plot3dTab.tsx
+++ b/src/components/Tabs/Plot3d/Plot3dTab.tsx
@@ -10,9 +10,10 @@ import { useInteractionListener } from "src/hooks";
 import { useViewerStateStore } from "src/state";
 import { FlexColumn } from "src/styles/utils";
 
-import { make3dConeTrace } from "./plot_3d_utils";
 import Plot3d from "./Plot3d";
+import { make3dConeTrace } from "./plot_3d_utils";
 
+const MINIMUM_BIN_COUNT = 10;
 const RESUME_PLAYBACK_TIMEOUT_MS = 500;
 
 export default function Plot3dTab(): ReactElement {
@@ -182,7 +183,11 @@ export default function Plot3dTab(): ReactElement {
         make3dConeTrace(vectorFieldData, {
           coneSize,
           colorRamp: coneColorRamp,
-          threshold: threshold * (10 / bins),
+          // Scale threshold based on bin count. At the minimum bin count, the
+          // `threshold` value maps directly to the number of deltas that fell
+          // into a bin. As the bin count increases, dividing by the number of
+          // bins keeps the thresholding visually consistent.
+          threshold: threshold * (MINIMUM_BIN_COUNT / bins),
         })
       );
     }

--- a/src/components/Tabs/Plot3d/Plot3dTab.tsx
+++ b/src/components/Tabs/Plot3d/Plot3dTab.tsx
@@ -182,11 +182,11 @@ export default function Plot3dTab(): ReactElement {
         make3dConeTrace(vectorFieldData, {
           coneSize,
           colorRamp: coneColorRamp,
-          threshold,
+          threshold: threshold * (10 / bins),
         })
       );
     }
-  }, [dataset, vectorFieldData, threshold, coneSize, coneColorRamp]);
+  }, [dataset, vectorFieldData, threshold, bins, coneSize, coneColorRamp]);
 
   // Sync plot with state changes
   useEffect(() => {


### PR DESCRIPTION
Problem
=======
Fixes a behavior that was lost during merging for the 3D flow field plot.

*Estimated review size: tiny, <5 minutes*

Solution
========
- Added scaling of threshold with bin count.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
