### PR TITLE
fix: Fixed bug where paths would sometimes not appear in 3D

### DIFF
--- a/src/colorizer/viewport/utils.ts
+++ b/src/colorizer/viewport/utils.ts
@@ -109,7 +109,6 @@ export function reassignTrackPaths<T extends TrackPath2D | TrackPath3D>(
     const trackPath = prevTrackPathMap.get(track.trackId);
     if (trackPath) {
       unusedTrackPaths.push(trackPath);
-      removeAndDisposeTrackPath(trackPath);
     }
     newTrackPathMap.delete(track.trackId);
   }
@@ -120,6 +119,10 @@ export function reassignTrackPaths<T extends TrackPath2D | TrackPath3D>(
     addedTrackPaths.push(trackPath);
     newTrackPathMap.set(track.trackId, trackPath);
     addTrackPathToScene(trackPath);
+  }
+
+  for (const trackPath of unusedTrackPaths) {
+    removeAndDisposeTrackPath(trackPath);
   }
 
   return newTrackPathMap;

--- a/src/colorizer/viewport/utils.ts
+++ b/src/colorizer/viewport/utils.ts
@@ -103,7 +103,7 @@ export function reassignTrackPaths<T extends TrackPath2D | TrackPath3D>(
     }
   }
 
-  // Remove unused TrackPath2D objects
+  // Remove unused TrackPath objects
   const unusedTrackPaths: T[] = [];
   for (const track of removedTracks) {
     const trackPath = prevTrackPathMap.get(track.trackId);
@@ -112,7 +112,7 @@ export function reassignTrackPaths<T extends TrackPath2D | TrackPath3D>(
     }
     newTrackPathMap.delete(track.trackId);
   }
-  // Add new TrackPath2D objects, reusing unused ones where possible
+  // Add new TrackPath objects, reusing unused ones where possible
   const addedTrackPaths: T[] = [];
   for (const track of addedTracks) {
     const trackPath = unusedTrackPaths.pop() ?? makeNewTrackPath();
@@ -121,6 +121,7 @@ export function reassignTrackPaths<T extends TrackPath2D | TrackPath3D>(
     addTrackPathToScene(trackPath);
   }
 
+  // Dispose of TrackPath objects that were not reused
   for (const trackPath of unusedTrackPaths) {
     removeAndDisposeTrackPath(trackPath);
   }


### PR DESCRIPTION

Problem
=======
Closes #936, "Paths do not show for first selected object in 3D."

*Estimated review size: tiny, <5 minutes*

Solution
========
- Fixed a bug where TrackPath2D and 3D objects were disposed of too early before being reused, causing them not to render onscreen.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open bugged main build: https://timelapse.allencell.org/viewer?dataset=https%3A%2F%2Fvast-files.int.allencell.org%2Fusers%2Falex.khang%2F2026-06-08%2Ftimelapse_colorizer_export%2Fh2b_488_lattice_lightsheet_data_2%2Fmanifest.json&track=272%3A0&t=33
2. Click on another cell. The cell will not have a track path.
1. Open PR preview:  https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-937/viewer?dataset=https%3A%2F%2Fvast-files.int.allencell.org%2Fusers%2Falex.khang%2F2026-06-08%2Ftimelapse_colorizer_export%2Fh2b_488_lattice_lightsheet_data_2%2Fmanifest.json&track=272%3A0&t=33
2. Click on another cell. The path will appear.
