### PR TITLE
feat: Show track lineage tab (lineage pt. 2b)

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -549,7 +549,7 @@ function Viewer(): ReactElement {
       label: "Lineage",
       key: TabType.LINEAGE,
       // Only show the lineage tab if the dataset has lineage data, or if the
-      // user has already has the tab selected (likely via a URL parameter).
+      // user has already the tab selected (likely via a URL parameter).
       // TODO: Show the lineage tab in a hidden section under a dropdown?
       visible: dataset?.hasLineageData(dataset.getDefaultTrackKey() ?? "") ?? false,
       children: (

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -549,7 +549,7 @@ function Viewer(): ReactElement {
       label: "Lineage",
       key: TabType.LINEAGE,
       // Only show the lineage tab if the dataset has lineage data, or if the
-      // user has already the tab selected (likely via a URL parameter).
+      // user already has the tab selected (likely via a URL parameter).
       // TODO: Show the lineage tab in a hidden section under a dropdown?
       visible: dataset?.hasLineageData(dataset.getDefaultTrackKey() ?? "") ?? false,
       children: (

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -43,6 +43,7 @@ import {
   AnnotationTab,
   CorrelationPlotTab,
   FeatureThresholdsTab,
+  LineageTab,
   Plot3dTab,
   PlotTab,
   ScatterPlotTab,
@@ -63,8 +64,6 @@ import { AppThemeContext } from "src/styles/AppStyle";
 import { FlexColumn, FlexRowAlignCenter } from "src/styles/utils";
 import type { LocationState } from "src/types";
 import { loadInitialCollectionAndDataset } from "src/utils/dataset_load_utils";
-
-import LineageTab from "./components/Tabs/Lineage/LineageTab";
 
 // TODO: Refactor with styled-components
 import styles from "./Viewer.module.css";
@@ -550,7 +549,8 @@ function Viewer(): ReactElement {
       label: "Lineage",
       key: TabType.LINEAGE,
       // Only show the lineage tab if the dataset has lineage data, or if the
-      // user has manually opened the tab.
+      // user has already has the tab selected (likely via a URL parameter).
+      // TODO: Show the lineage tab in a hidden section under a dropdown?
       visible: dataset?.hasLineageData(dataset.getDefaultTrackKey() ?? "") ?? false,
       children: (
         <div className={styles.tabContent}>

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -7,7 +7,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
   useTransition,
@@ -50,7 +49,6 @@ import {
   SettingsTab,
 } from "src/components/Tabs";
 import CanvasHoverTooltip from "src/components/Tooltips/CanvasHoverTooltip";
-import { INTERNAL_BUILD } from "src/constants";
 import { useAnnotations, useBackdropShortcuts, useConstructor, useRecentCollections } from "src/hooks";
 import { renderCanvasStateParamsSelector } from "src/state";
 import { getDifferingProperties } from "src/state/utils/data_validation";
@@ -66,12 +64,14 @@ import { FlexColumn, FlexRowAlignCenter } from "src/styles/utils";
 import type { LocationState } from "src/types";
 import { loadInitialCollectionAndDataset } from "src/utils/dataset_load_utils";
 
+import LineageTab from "./components/Tabs/Lineage/LineageTab";
+
 // TODO: Refactor with styled-components
 import styles from "./Viewer.module.css";
 
-type TabItem = {
+type TabItem<T extends string> = {
   label: string;
-  key: string;
+  key: T;
   visible?: boolean;
   children: ReactNode;
 };
@@ -386,7 +386,6 @@ function Viewer(): ReactElement {
       if (isLoadingInitialDataset.current || isInitialDatasetLoaded) {
         return;
       }
-
       setIsDatasetLoading(true);
       setDatasetLoadProgress(null);
       isLoadingInitialDataset.current = true;
@@ -506,7 +505,7 @@ function Viewer(): ReactElement {
 
   const disableUi: boolean = isRecording || !datasetOpen;
 
-  const allTabItems: TabItem[] = [
+  const allTabItems: TabItem<TabType>[] = [
     {
       label: "Track plot",
       key: TabType.TRACK_PLOT,
@@ -548,6 +547,18 @@ function Viewer(): ReactElement {
       ),
     },
     {
+      label: "Lineage",
+      key: TabType.LINEAGE,
+      // Only show the lineage tab if the dataset has lineage data, or if the
+      // user has manually opened the tab.
+      visible: dataset?.hasLineageData(dataset.getDefaultTrackKey() ?? "") ?? false,
+      children: (
+        <div className={styles.tabContent}>
+          <LineageTab></LineageTab>
+        </div>
+      ),
+    },
+    {
       label: `Filters ${featureThresholds.length > 0 ? `(${featureThresholds.length})` : ""}`,
       key: TabType.FILTERS,
       children: (
@@ -576,8 +587,9 @@ function Viewer(): ReactElement {
       ),
     },
   ];
-  const tabItems = allTabItems.filter((item) => item.visible !== false);
-  const visibleTabKeys = useMemo(() => new Set(tabItems.map((item) => item.key)), [INTERNAL_BUILD]);
+  // If non-visible tab is selected, show it
+  const tabItems = allTabItems.filter((item) => item.visible !== false || item.key === openTab);
+  const visibleTabKeys = new Set(tabItems.map((item) => item.key));
   const currentTab = visibleTabKeys.has(openTab) ? openTab : TabType.TRACK_PLOT;
 
   let datasetHeader: ReactNode = null;

--- a/src/colorizer/Dataset.ts
+++ b/src/colorizer/Dataset.ts
@@ -229,6 +229,10 @@ export default class Dataset {
     return this.trackData ? Array.from(this.trackData.keys()) : [];
   }
 
+  public getDefaultTrackKey(): string | null {
+    return this.trackData?.keys().next().value ?? null;
+  }
+
   public getTrackData(key: string): TrackData | undefined {
     return this.trackData?.get(key);
   }

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -205,6 +205,7 @@ export enum TabType {
   TRACK_PLOT = "track_plot",
   SCATTER_PLOT = "scatter_plot",
   CORRELATION_PLOT = "correlation_plot",
+  LINEAGE = "lineage",
   FILTERS = "filters",
   ANNOTATION = "annotation",
   PLOT_3D = "3d_plot",
@@ -318,6 +319,8 @@ export enum LoadTroubleshooting {
   CHECK_ZIP_FORMAT_MANIFEST = "A 'manifest.json' should exist in the base directory.",
   CHECK_ZIP_ZARR_DATA = "Please check if the file exists. If this was a Zarr array, note that Zarr data cannot currently be loaded from ZIP archives. " +
     "Consider opening the dataset locally with the CLI tools provided in colorizer-data; for more details, see Help > Visit GitHub repository.",
+  CHECK_PARQUET_3D_METADATA = "This may be because the provided Parquet file is missing required metadata, especially source data for the 3D volume. " +
+    "Please see the developer console for more details.",
 }
 
 export const enum LoadErrorMessage {

--- a/src/colorizer/types.ts
+++ b/src/colorizer/types.ts
@@ -319,8 +319,6 @@ export enum LoadTroubleshooting {
   CHECK_ZIP_FORMAT_MANIFEST = "A 'manifest.json' should exist in the base directory.",
   CHECK_ZIP_ZARR_DATA = "Please check if the file exists. If this was a Zarr array, note that Zarr data cannot currently be loaded from ZIP archives. " +
     "Consider opening the dataset locally with the CLI tools provided in colorizer-data; for more details, see Help > Visit GitHub repository.",
-  CHECK_PARQUET_3D_METADATA = "This may be because the provided Parquet file is missing required metadata, especially source data for the 3D volume. " +
-    "Please see the developer console for more details.",
 }
 
 export const enum LoadErrorMessage {

--- a/src/colorizer/utils/dataset_utils.ts
+++ b/src/colorizer/utils/dataset_utils.ts
@@ -211,6 +211,7 @@ function isV1_1_0FrameData(manifest: AnyManifestFile): manifest is ManifestFileV
   return frames !== undefined || backdrops !== undefined || frames3d?.source !== undefined;
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function isV1_1_0TrackData(manifest: AnyManifestFile): manifest is ManifestFileV1_1_0 {
   return typeof (manifest as ManifestFileV1_1_0).tracks === "string";
 }

--- a/src/components/Tabs/Lineage/LineageTab.tsx
+++ b/src/components/Tabs/Lineage/LineageTab.tsx
@@ -6,7 +6,7 @@ import HoverTooltip from "src/components/Tooltips/HoverTooltip";
 import { TooltipCard } from "src/components/Tooltips/TooltipCard";
 import { SHORTCUT_KEYS } from "src/constants/shortcuts";
 import { useViewerStateStore } from "src/state";
-import { FlexColumn, FlexRow } from "src/styles/utils";
+import { FlexColumn } from "src/styles/utils";
 import { areAnyHotkeysPressed } from "src/utils/user_input";
 
 import { getLineageData, getLineageRelationships } from "./lineage_utils";
@@ -19,15 +19,15 @@ function getColorAndRadiusScale(data: LineageData): {
 } {
   const trackInfo = Array.from(data.trackIdToTrackInfo.values());
   const startMin = d3.min(trackInfo, (d) => d.startTime) ?? 0;
-  const startMax = d3.max(trackInfo, (d) => d.startTime) ?? startMin;
+  let startMax = d3.max(trackInfo, (d) => d.startTime) ?? startMin;
   const lengthMin = d3.min(trackInfo, (d) => d.length) ?? 1;
-  const lengthMax = d3.max(trackInfo, (d) => d.length) ?? lengthMin;
+  let lengthMax = d3.max(trackInfo, (d) => d.length) ?? lengthMin;
 
-  const safeStartMax = startMin === startMax ? startMin + 1 : startMax;
-  const safeLengthMax = lengthMin === lengthMax ? lengthMin + 1 : lengthMax;
+  startMax = startMin === startMax ? startMin + 1 : startMax;
+  lengthMax = lengthMin === lengthMax ? lengthMin + 1 : lengthMax;
 
-  const colorScale = d3.scaleSequential(d3.interpolateTurbo).domain([startMin, safeStartMax]);
-  const radiusScale = d3.scaleSqrt().domain([lengthMin, safeLengthMax]).range([10, 25]);
+  const colorScale = d3.scaleSequential(d3.interpolateTurbo).domain([startMin, startMax]);
+  const radiusScale = d3.scaleSqrt().domain([lengthMin, lengthMax]).range([10, 25]);
   return { colorScale, radiusScale };
 }
 
@@ -127,8 +127,6 @@ export default function LineageTab(): ReactElement {
 
   return (
     <FlexColumn style={{ width: "100%", height: "100%" }}>
-      <FlexRow></FlexRow>
-
       <HoverTooltip
         tooltipContent={tooltipContent}
         style={{ width: "100%", height: "100%" }}

--- a/src/components/Tabs/Lineage/LineageTab.tsx
+++ b/src/components/Tabs/Lineage/LineageTab.tsx
@@ -96,9 +96,10 @@ export default function LineageTab(): ReactElement {
 
   //// Rendering ////
 
+  const tooltipVisible = hoveredTrack !== null;
   const tooltipContent = useMemo(() => {
     return (
-      <TooltipCard style={{ opacity: hoveredTrack ? 1 : 0 }}>
+      <TooltipCard>
         {lastHoveredTrack.current && (
           <FlexColumn>
             <div>Track ID: {lastHoveredTrack.current.trackId}</div>
@@ -128,7 +129,11 @@ export default function LineageTab(): ReactElement {
     <FlexColumn style={{ width: "100%", height: "100%" }}>
       <FlexRow></FlexRow>
 
-      <HoverTooltip tooltipContent={tooltipContent} style={{ width: "100%", height: "100%" }}>
+      <HoverTooltip
+        tooltipContent={tooltipContent}
+        style={{ width: "100%", height: "100%" }}
+        disabled={!tooltipVisible}
+      >
         <div ref={containerRef} style={{ width: "100%", height: "100%" }}>
           <TreeLineageView {...lineageViewProps}></TreeLineageView>
 

--- a/src/components/Tabs/Lineage/LineageTab.tsx
+++ b/src/components/Tabs/Lineage/LineageTab.tsx
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
-import React, { ReactElement, useCallback, useMemo, useRef, useState } from "react";
+import React, { type ReactElement, useCallback, useMemo, useRef, useState } from "react";
 
-import Track from "src/colorizer/Track";
+import type Track from "src/colorizer/Track";
 import HoverTooltip from "src/components/Tooltips/HoverTooltip";
 import { TooltipCard } from "src/components/Tooltips/TooltipCard";
 import { SHORTCUT_KEYS } from "src/constants/shortcuts";
@@ -11,7 +11,7 @@ import { areAnyHotkeysPressed } from "src/utils/user_input";
 
 import { getLineageData } from "./lineage_utils";
 import TreeLineageView from "./LineageViews/TreeLineageView";
-import { LineageData } from "./types";
+import type { LineageData } from "./types";
 
 function getColorAndRadiusScale(data: LineageData): {
   colorScale: d3.ScaleSequential<string>;

--- a/src/components/Tabs/Lineage/LineageTab.tsx
+++ b/src/components/Tabs/Lineage/LineageTab.tsx
@@ -1,0 +1,124 @@
+import * as d3 from "d3";
+import React, { ReactElement, useCallback, useMemo, useRef, useState } from "react";
+
+import Track from "src/colorizer/Track";
+import HoverTooltip from "src/components/Tooltips/HoverTooltip";
+import { TooltipCard } from "src/components/Tooltips/TooltipCard";
+import { SHORTCUT_KEYS } from "src/constants/shortcuts";
+import { useViewerStateStore } from "src/state";
+import { FlexColumn, FlexRow } from "src/styles/utils";
+import { areAnyHotkeysPressed } from "src/utils/user_input";
+
+import { getLineageData } from "./lineage_utils";
+import TreeLineageView from "./LineageViews/TreeLineageView";
+import { LineageData } from "./types";
+
+function getColorAndRadiusScale(data: LineageData): {
+  colorScale: d3.ScaleSequential<string>;
+  radiusScale: d3.ScalePower<number, number>;
+} {
+  const startMin = d3.min(data.trackInfo, (d) => d.startTime) ?? 0;
+  const startMax = d3.max(data.trackInfo, (d) => d.startTime) ?? startMin;
+  const lengthMin = d3.min(data.trackInfo, (d) => d.length) ?? 1;
+  const lengthMax = d3.max(data.trackInfo, (d) => d.length) ?? lengthMin;
+
+  const safeStartMax = startMin === startMax ? startMin + 1 : startMax;
+  const safeLengthMax = lengthMin === lengthMax ? lengthMin + 1 : lengthMax;
+
+  const colorScale = d3.scaleSequential(d3.interpolateTurbo).domain([startMin, safeStartMax]);
+  const radiusScale = d3.scaleSqrt().domain([lengthMin, safeLengthMax]).range([10, 30]);
+  return { colorScale, radiusScale };
+}
+
+export default function LineageTab(): ReactElement {
+  const dataset = useViewerStateStore((state) => state.dataset);
+  const currentFrame = useViewerStateStore((state) => state.currentFrame);
+  const tracks = useViewerStateStore((state) => state.tracks);
+  const trackColors = useViewerStateStore((state) => state.trackColors);
+  const setTracks = useViewerStateStore((state) => state.setTracks);
+  const toggleTrack = useViewerStateStore((state) => state.toggleTrack);
+  const setFrame = useViewerStateStore((state) => state.setFrame);
+
+  const [hoveredTrack, setHoveredTrack] = useState<Track | null>(null);
+  const lastHoveredTrack = useRef<Track | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const lineageData = useMemo(() => {
+    return dataset ? getLineageData(dataset) : { trackInfo: [], edges: [] };
+  }, [dataset]);
+  const { colorScale, radiusScale } = useMemo(() => getColorAndRadiusScale(lineageData), [lineageData]);
+
+  const onClickTrack = useCallback(
+    (trackId: number) => {
+      const isMultiTrackSelectHotkeyPressed = areAnyHotkeysPressed(SHORTCUT_KEYS.viewport.multiTrackSelect.keycode);
+      const track = dataset?.getTrack(trackId);
+      if (track) {
+        if (isMultiTrackSelectHotkeyPressed) {
+          toggleTrack(track);
+        } else {
+          setTracks([track]);
+        }
+        if (currentFrame < track.times[0] || currentFrame > track.times[track.times.length - 1]) {
+          setFrame(track.times[0]);
+        }
+      }
+    },
+    [dataset, setTracks, toggleTrack, currentFrame, setFrame]
+  );
+
+  const onHoverTrack = useCallback(
+    (trackId: number | null) => {
+      if (trackId === null) {
+        setHoveredTrack(null);
+      } else {
+        const track = dataset?.getTrack(trackId);
+        if (track) {
+          setHoveredTrack(track);
+          lastHoveredTrack.current = track;
+        }
+      }
+    },
+    [dataset]
+  );
+
+  const tooltipContent = useMemo(() => {
+    return (
+      <TooltipCard style={{ opacity: hoveredTrack ? 1 : 0 }}>
+        {lastHoveredTrack.current && (
+          <FlexColumn>
+            <div>Track ID: {lastHoveredTrack.current.trackId}</div>
+            <div>Start: {lastHoveredTrack.current.startTime()}</div>
+            <div>Length: {lastHoveredTrack.current.duration()}</div>
+          </FlexColumn>
+        )}
+      </TooltipCard>
+    );
+  }, [hoveredTrack]);
+
+  const selectedTracks = useMemo(() => new Set(tracks.keys()), [tracks]);
+
+  return (
+    <FlexColumn style={{ width: "100%", height: "100%" }}>
+      <FlexRow></FlexRow>
+
+      <HoverTooltip tooltipContent={tooltipContent} style={{ width: "100%", height: "100%" }}>
+        <div ref={containerRef} style={{ width: "100%", height: "100%" }}>
+          <TreeLineageView
+            container={containerRef}
+            data={lineageData}
+            colorScale={colorScale}
+            radiusScale={radiusScale}
+            onClick={onClickTrack}
+            onHover={onHoverTrack}
+            selectedTracks={selectedTracks}
+            trackColors={trackColors}
+          ></TreeLineageView>
+          {lineageData?.edges.length === 0 && (
+            <div style={{ textAlign: "center", marginTop: "20px" }}>No lineage data available.</div>
+          )}
+        </div>
+      </HoverTooltip>
+    </FlexColumn>
+  );
+}

--- a/src/components/Tabs/Lineage/LineageTab.tsx
+++ b/src/components/Tabs/Lineage/LineageTab.tsx
@@ -9,18 +9,19 @@ import { useViewerStateStore } from "src/state";
 import { FlexColumn, FlexRow } from "src/styles/utils";
 import { areAnyHotkeysPressed } from "src/utils/user_input";
 
-import { getLineageData } from "./lineage_utils";
+import { getLineageData, getLineageRelationships } from "./lineage_utils";
 import TreeLineageView from "./LineageViews/TreeLineageView";
-import type { LineageData } from "./types";
+import type { LineageData, SharedLineageViewProps } from "./types";
 
 function getColorAndRadiusScale(data: LineageData): {
   colorScale: d3.ScaleSequential<string>;
   radiusScale: d3.ScalePower<number, number>;
 } {
-  const startMin = d3.min(data.trackInfo, (d) => d.startTime) ?? 0;
-  const startMax = d3.max(data.trackInfo, (d) => d.startTime) ?? startMin;
-  const lengthMin = d3.min(data.trackInfo, (d) => d.length) ?? 1;
-  const lengthMax = d3.max(data.trackInfo, (d) => d.length) ?? lengthMin;
+  const trackInfo = Array.from(data.trackIdToTrackInfo.values());
+  const startMin = d3.min(trackInfo, (d) => d.startTime) ?? 0;
+  const startMax = d3.max(trackInfo, (d) => d.startTime) ?? startMin;
+  const lengthMin = d3.min(trackInfo, (d) => d.length) ?? 1;
+  const lengthMax = d3.max(trackInfo, (d) => d.length) ?? lengthMin;
 
   const safeStartMax = startMin === startMax ? startMin + 1 : startMax;
   const safeLengthMax = lengthMin === lengthMax ? lengthMin + 1 : lengthMax;
@@ -30,6 +31,12 @@ function getColorAndRadiusScale(data: LineageData): {
   return { colorScale, radiusScale };
 }
 
+const EMPTY_LINEAGE_DATA = { trackIdToTrackInfo: new Map(), edges: [] } satisfies LineageData;
+
+/**
+ * Renders lineage data in a tab. Includes a tree view of the tracks and their
+ * relationships, and a tooltip on hover.
+ */
 export default function LineageTab(): ReactElement {
   const dataset = useViewerStateStore((state) => state.dataset);
   const currentFrame = useViewerStateStore((state) => state.currentFrame);
@@ -45,9 +52,14 @@ export default function LineageTab(): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const lineageData = useMemo(() => {
-    return dataset ? getLineageData(dataset) : { trackInfo: [], edges: [] };
+    return dataset ? getLineageData(dataset) : EMPTY_LINEAGE_DATA;
   }, [dataset]);
+  const lineageRelationships = useMemo(() => {
+    return getLineageRelationships(lineageData);
+  }, [lineageData]);
   const { colorScale, radiusScale } = useMemo(() => getColorAndRadiusScale(lineageData), [lineageData]);
+
+  //// Callbacks ////
 
   const onClickTrack = useCallback(
     (trackId: number) => {
@@ -82,6 +94,8 @@ export default function LineageTab(): ReactElement {
     [dataset]
   );
 
+  //// Rendering ////
+
   const tooltipContent = useMemo(() => {
     return (
       <TooltipCard style={{ opacity: hoveredTrack ? 1 : 0 }}>
@@ -98,22 +112,26 @@ export default function LineageTab(): ReactElement {
 
   const selectedTracks = useMemo(() => new Set(tracks.keys()), [tracks]);
 
+  const lineageViewProps: SharedLineageViewProps = {
+    container: containerRef,
+    data: lineageData,
+    relationships: lineageRelationships,
+    colorScale: colorScale,
+    radiusScale: radiusScale,
+    onClick: onClickTrack,
+    onHover: onHoverTrack,
+    selectedTracks: selectedTracks,
+    trackColors: trackColors,
+  };
+
   return (
     <FlexColumn style={{ width: "100%", height: "100%" }}>
       <FlexRow></FlexRow>
 
       <HoverTooltip tooltipContent={tooltipContent} style={{ width: "100%", height: "100%" }}>
         <div ref={containerRef} style={{ width: "100%", height: "100%" }}>
-          <TreeLineageView
-            container={containerRef}
-            data={lineageData}
-            colorScale={colorScale}
-            radiusScale={radiusScale}
-            onClick={onClickTrack}
-            onHover={onHoverTrack}
-            selectedTracks={selectedTracks}
-            trackColors={trackColors}
-          ></TreeLineageView>
+          <TreeLineageView {...lineageViewProps}></TreeLineageView>
+
           {lineageData?.edges.length === 0 && (
             <div style={{ textAlign: "center", marginTop: "20px" }}>No lineage data available.</div>
           )}

--- a/src/components/Tabs/Lineage/LineageTab.tsx
+++ b/src/components/Tabs/Lineage/LineageTab.tsx
@@ -27,7 +27,7 @@ function getColorAndRadiusScale(data: LineageData): {
   const safeLengthMax = lengthMin === lengthMax ? lengthMin + 1 : lengthMax;
 
   const colorScale = d3.scaleSequential(d3.interpolateTurbo).domain([startMin, safeStartMax]);
-  const radiusScale = d3.scaleSqrt().domain([lengthMin, safeLengthMax]).range([10, 30]);
+  const radiusScale = d3.scaleSqrt().domain([lengthMin, safeLengthMax]).range([10, 25]);
   return { colorScale, radiusScale };
 }
 

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -1,0 +1,278 @@
+import * as d3 from "d3";
+import React, { ReactElement, useEffect, useRef } from "react";
+import { Color } from "three";
+
+import { useConstructor } from "src/hooks";
+
+import { LineageData, SharedLineageViewProps, TrackInfo } from "../types";
+
+const TREE_LEAF_HEIGHT_PX = 30;
+const TREE_LAYER_DEPTH_PX = 110;
+
+type TreeLineageViewProps = SharedLineageViewProps & {};
+
+type NodeSelection = d3.Selection<SVGGElement | d3.BaseType, d3.HierarchyPointNode<TrackInfo>, SVGGElement, TrackInfo>;
+
+function getRelationships(data: LineageData): {
+  idToChildren: Map<number, number[]>;
+  idToParents: Map<number, number[]>;
+  crossLinks: [number, number][];
+} {
+  const idToChildren = new Map<number, number[]>(data.trackInfo.map((n) => [n.id, []]));
+  const idToParents = new Map<number, number[]>(data.trackInfo.map((n) => [n.id, []]));
+
+  // Links to a node where the node already has a parent (i.e. the second parent
+  // of a merge node).
+  const crossLinks: [number, number][] = [];
+  const idsWithParents = new Set<number>();
+
+  for (const [source, target] of data.edges) {
+    if (!idsWithParents.has(target)) {
+      idToChildren.get(source)?.push(target);
+    } else {
+      // If the target node already has a parent, intentionally prevent adding
+      // it to the children of this source node or else it will be duplicated in
+      // the tree. Instead, add it to a list of cross links that will be
+      // rendered separately.
+      crossLinks.push([source, target]);
+    }
+    idToParents.get(target)?.push(source);
+    idsWithParents.add(target);
+  }
+  return { idToChildren, idToParents, crossLinks };
+}
+
+function renderTree(
+  g: d3.Selection<SVGGElement, TrackInfo, null, undefined>,
+  data: LineageData,
+  onClickTrack?: (trackId: number) => void,
+  onHoverTrack?: (trackId: number | null) => void
+): NodeSelection | undefined {
+  const { trackInfo } = data;
+  const edges = [...data.edges];
+
+  const trackIdToTrackInfo = new Map<number, TrackInfo>(trackInfo.map((track) => [track.id, track]));
+  const { idToChildren, idToParents, crossLinks } = getRelationships(data);
+
+  const mergeNodes = new Set([...idToParents.entries()].filter(([, parents]) => parents.length > 1).map(([id]) => id));
+  // All nodes with no parents
+  const rootNodeIds = [...idToParents.entries()].filter(([, parents]) => parents.length === 0).map(([id]) => id);
+
+  let rootNode: TrackInfo;
+  if (rootNodeIds.length === 0) {
+    return;
+  } else if (rootNodeIds.length === 1) {
+    rootNode = trackIdToTrackInfo.get(rootNodeIds[0])!;
+  } else {
+    // TODO: Hide the dummy root node
+    // Multiple root nodes, make a dummy root node that is the parent of all root nodes
+    rootNode = { id: -1, length: 0, startTime: 0 };
+    // Add dummy track info for the dummy root node
+    trackIdToTrackInfo.set(rootNode.id, rootNode);
+    for (const root of rootNodeIds) {
+      edges.push([rootNode.id, root]);
+    }
+    idToChildren.set(rootNode.id, rootNodeIds);
+  }
+
+  const root = d3.hierarchy<TrackInfo>(
+    rootNode,
+    // Returns an array of the trackInfo for each child of a track
+    (trackInfo) => {
+      const childIds = idToChildren.get(trackInfo.id) ?? [];
+      const childTrackInfo = childIds
+        .map((id) => {
+          return trackIdToTrackInfo.get(id);
+        })
+        .filter((trackInfo) => !!trackInfo);
+      return childTrackInfo;
+    }
+  );
+
+  const leafCount = root.leaves().length;
+  const depth = root.height;
+
+  const treeRoot = d3.tree<TrackInfo>().size([leafCount * TREE_LEAF_HEIGHT_PX, depth * TREE_LAYER_DEPTH_PX])(root);
+
+  // Render tree edges, coloring merge edges as an orange dotted line
+  g.append("g")
+    .selectAll("line")
+    .data(treeRoot.links())
+    .join("line")
+    // TODO: Make colors into constants here? Or parameterize via options
+    .attr("stroke", (d) => (mergeNodes.has(d.target.data.id) ? "#f6ad55" : "#4a5568"))
+    .attr("stroke-opacity", (d) => (mergeNodes.has(d.target.data.id) ? 0.7 : 0.6))
+    .attr("stroke-width", 1.5)
+    .attr("stroke-dasharray", (d) => (mergeNodes.has(d.target.data.id) ? "4 3" : null))
+    .attr("x1", (d) => d.source.y)
+    .attr("y1", (d) => d.source.x)
+    .attr("x2", (d) => d.target.y)
+    .attr("y2", (d) => d.target.x);
+
+  if (crossLinks.length) {
+    const posOf = new Map(treeRoot.descendants().map((d) => [d.data.id, { x: d.x, y: d.y }]));
+    g.append("g")
+      .selectAll("line")
+      .data(crossLinks)
+      .join("line")
+      .attr("stroke", "#f6ad55")
+      .attr("stroke-opacity", 0.7)
+      .attr("stroke-width", 1.5)
+      .attr("stroke-dasharray", "4 3")
+      .attr("x1", (d) => posOf.get(d[0])?.y ?? 0)
+      .attr("y1", (d) => posOf.get(d[0])?.x ?? 0)
+      .attr("x2", (d) => posOf.get(d[1])?.y ?? 0)
+      .attr("y2", (d) => posOf.get(d[1])?.x ?? 0);
+  }
+
+  // TODO: return nodes out of this method, so they can be updated/recalculated
+  // without updating the entire tree?
+
+  // Render nodes
+  const node = g
+    .append("g")
+    .selectAll("g")
+    .data(treeRoot.descendants())
+    .join("g")
+    .attr("transform", (d) => `translate(${d.y},${d.x})`);
+
+  // Draw circles for each node
+  node.append("circle");
+
+  // Text labels
+  node
+    .append("text")
+    .text((d) => d.data.id)
+    .attr("text-anchor", "middle")
+    .attr("dominant-baseline", "middle")
+    .attr("fill", "#ffffff")
+    .attr("font-size", 9)
+    .attr("pointer-events", "none");
+
+  // Setup pointer events
+  const handleClickTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>) => {
+    onClickTrack?.(d.data.id);
+  };
+  const handleHoverTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>) => {
+    // d3.select(event.currentTarget).select("circle").attr("stroke", "#fff").attr("stroke-width", 2.5);
+    onHoverTrack?.(d.data.id);
+  };
+  const handleUnhoverTrack = (_event: any, _d: d3.HierarchyPointNode<TrackInfo>) => {
+    // d3.select(event.currentTarget).select("circle").attr("stroke", "#1a1f2e").attr("stroke-width", 1.5);
+    onHoverTrack?.(null);
+  };
+
+  node.on("click", handleClickTrack).on("mouseover", handleHoverTrack).on("mouseout", handleUnhoverTrack);
+
+  return node;
+}
+
+function updateNodeStyles(
+  node: NodeSelection,
+  radiusScale: d3.ScalePower<number, number>,
+  colorScale: d3.ScaleSequential<string>,
+  trackColors: Map<number, Color>
+) {
+  // Draw circles for each node
+  node
+    .select<SVGCircleElement>("circle")
+    .attr("r", (d) => radiusScale(d.data.length))
+    .attr("fill", (d) => colorScale(d.data.startTime))
+    .attr("stroke", (d) => trackColors.get(d.data.id)?.getStyle() ?? "#1a1f2e")
+    .attr("stroke-width", 1.5)
+    .style("cursor", "default");
+
+  // Text labels
+  node
+    .select<SVGTextElement>("text")
+    .text((d) => d.data.id)
+    .attr("text-anchor", "middle")
+    .attr("dominant-baseline", "middle")
+    .attr("fill", "#ffffff")
+    .attr("font-size", 9)
+    .attr("pointer-events", "none");
+}
+
+export default function TreeLineageView(props: TreeLineageViewProps): ReactElement {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const groupRef = useRef<SVGGElement>(null);
+  const nodeRef = useRef<NodeSelection | undefined>(undefined);
+
+  const onClickRef = useRef(props.onClick);
+  onClickRef.current = props.onClick;
+  const onHoverRef = useRef(props.onHover);
+  onHoverRef.current = props.onHover;
+
+  //// SVG Elements ////
+
+  const zoom = useConstructor(() =>
+    d3
+      .zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.1, 10])
+      .on("zoom", (event) => {
+        d3.select(groupRef.current).attr("transform", event.transform);
+      })
+  );
+
+  const resetZoom = () => {
+    if (!svgRef.current || !groupRef.current) {
+      return;
+    }
+    const svg = d3.select(svgRef.current);
+    const svgNode = svg.node();
+    const gNode = d3.select(groupRef.current).node();
+    if (!gNode || !svgNode || !svg) {
+      return;
+    }
+    const bbox = gNode.getBBox();
+    const cw = svgNode.clientWidth;
+    const ch = svgNode.clientHeight;
+    const scale = Math.min(cw / (bbox.width + 80), ch / (bbox.height + 40)) * 0.92;
+    const tx = (cw - bbox.width * scale) / 2 - bbox.x * scale;
+    const ty = (ch - bbox.height * scale) / 2 - bbox.y * scale;
+    const initT = d3.zoomIdentity.translate(tx, ty).scale(scale);
+    zoom.current.transform(svg, initT);
+  };
+
+  useEffect(() => {
+    if (svgRef.current) {
+      const svg = d3.select(svgRef.current);
+      svg.call(zoom.current);
+    }
+  }, [zoom]);
+
+  //// Viewport ////
+
+  useEffect(() => {
+    if (groupRef.current) {
+      const g = d3.select(groupRef.current) as d3.Selection<SVGGElement, TrackInfo, null, undefined>;
+      const onClickTrack = (trackId: number) => onClickRef.current?.(trackId);
+      const onHoverTrack = (trackId: number | null) => onHoverRef.current?.(trackId);
+      nodeRef.current = renderTree(g, props.data, onClickTrack, onHoverTrack);
+    }
+    // Clear on unmount
+    return () => {
+      if (groupRef.current) {
+        d3.select(groupRef.current).selectAll("*").remove();
+      }
+    };
+  }, [props.data]);
+
+  useEffect(() => {
+    // Update node styling
+    if (nodeRef.current) {
+      updateNodeStyles(nodeRef.current, props.radiusScale, props.colorScale, props.trackColors);
+    }
+  }, [props.data, props.radiusScale, props.colorScale, props.trackColors]);
+
+  // Fit on first render
+  useEffect(() => {
+    resetZoom();
+  }, [props.data]);
+
+  return (
+    <svg ref={svgRef} style={{ width: "100%", height: "100%", display: "block" }} id="tree-lineage-view-svg">
+      <g ref={groupRef}></g>
+    </svg>
+  );
+}

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -1,10 +1,10 @@
 import * as d3 from "d3";
-import React, { ReactElement, useEffect, useRef } from "react";
-import { Color } from "three";
+import React, { type ReactElement, useEffect, useRef } from "react";
+import type { Color } from "three";
 
 import { useConstructor } from "src/hooks";
 
-import { LineageData, SharedLineageViewProps, TrackInfo } from "../types";
+import type { LineageData, SharedLineageViewProps, TrackInfo } from "../types";
 
 const TREE_LEAF_HEIGHT_PX = 30;
 const TREE_LAYER_DEPTH_PX = 110;

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -2,9 +2,8 @@ import * as d3 from "d3";
 import React, { type ReactElement, useEffect, useRef } from "react";
 import type { Color } from "three";
 
+import type { LineageData, SharedLineageViewProps, TrackInfo } from "src/components/Tabs/Lineage/types";
 import { useConstructor } from "src/hooks";
-
-import type { LineageData, SharedLineageViewProps, TrackInfo } from "../types";
 
 const TREE_LEAF_HEIGHT_PX = 30;
 const TREE_LAYER_DEPTH_PX = 110;
@@ -150,14 +149,14 @@ function renderTree(
     .attr("pointer-events", "none");
 
   // Setup pointer events
-  const handleClickTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>) => {
+  const handleClickTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>): void => {
     onClickTrack?.(d.data.id);
   };
-  const handleHoverTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>) => {
+  const handleHoverTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>): void => {
     // d3.select(event.currentTarget).select("circle").attr("stroke", "#fff").attr("stroke-width", 2.5);
     onHoverTrack?.(d.data.id);
   };
-  const handleUnhoverTrack = (_event: any, _d: d3.HierarchyPointNode<TrackInfo>) => {
+  const handleUnhoverTrack = (_event: any, _d: d3.HierarchyPointNode<TrackInfo>): void => {
     // d3.select(event.currentTarget).select("circle").attr("stroke", "#1a1f2e").attr("stroke-width", 1.5);
     onHoverTrack?.(null);
   };
@@ -172,7 +171,7 @@ function updateNodeStyles(
   radiusScale: d3.ScalePower<number, number>,
   colorScale: d3.ScaleSequential<string>,
   trackColors: Map<number, Color>
-) {
+): void {
   // Draw circles for each node
   node
     .select<SVGCircleElement>("circle")
@@ -214,7 +213,7 @@ export default function TreeLineageView(props: TreeLineageViewProps): ReactEleme
       })
   );
 
-  const resetZoom = () => {
+  const resetZoom = (): void => {
     if (!svgRef.current || !groupRef.current) {
       return;
     }
@@ -246,8 +245,8 @@ export default function TreeLineageView(props: TreeLineageViewProps): ReactEleme
   useEffect(() => {
     if (groupRef.current) {
       const g = d3.select(groupRef.current) as d3.Selection<SVGGElement, TrackInfo, null, undefined>;
-      const onClickTrack = (trackId: number) => onClickRef.current?.(trackId);
-      const onHoverTrack = (trackId: number | null) => onHoverRef.current?.(trackId);
+      const onClickTrack = (trackId: number): void => onClickRef.current?.(trackId);
+      const onHoverTrack = (trackId: number | null): void => onHoverRef.current?.(trackId);
       nodeRef.current = renderTree(g, props.data, onClickTrack, onHoverTrack);
     }
     // Clear on unmount

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -10,13 +10,19 @@ import type {
 } from "src/components/Tabs/Lineage/types";
 import { useConstructor } from "src/hooks";
 
+import { getDefaultZoomTransform } from "../lineage_utils";
+
+const DUMMY_ROOT_NODE_ID = -1;
 const TREE_LEAF_HEIGHT_PX = 30;
 const TREE_LAYER_DEPTH_PX = 110;
 const MERGE_EDGE_COLOR = "#ff9410";
 const DEFAULT_EDGE_COLOR = "#4a5568";
+const DEFAULT_TEXT_COLOR = "#ffffff";
 const DEFAULT_NODE_EDGE_COLOR = "#1a1f2e";
 
-type TreeLineageViewProps = SharedLineageViewProps & {};
+const INNER_HIGHLIGHT_CLASS = "inner-highlight";
+
+type TreeLineageViewProps = SharedLineageViewProps;
 
 type NodeSelection = d3.Selection<SVGGElement | d3.BaseType, d3.HierarchyPointNode<TrackInfo>, SVGGElement, TrackInfo>;
 
@@ -27,7 +33,7 @@ function renderTree(
   onClickTrack?: (trackId: number) => void,
   onHoverTrack?: (trackId: number | null) => void
 ): NodeSelection | undefined {
-  const { idToChildrenRenderable, idToParents, multiparentEdges: multiparentEdges } = relationships;
+  const { idToChildrenRenderable, idToParents, multiparentEdges } = relationships;
 
   const trackIdToTrackInfo = new Map(data.trackIdToTrackInfo);
   const idToChildren = new Map(idToChildrenRenderable);
@@ -38,12 +44,13 @@ function renderTree(
 
   let rootNode: TrackInfo;
   if (rootNodeIds.length === 0) {
+    console.warn("No root nodes found in lineage data, skipping tree rendering.");
     return;
   } else if (rootNodeIds.length === 1) {
     rootNode = trackIdToTrackInfo.get(rootNodeIds[0])!;
   } else {
     // Multiple root nodes, make a dummy root node that is the parent of all root nodes
-    rootNode = { id: -1, length: 0, startTime: 0 };
+    rootNode = { id: DUMMY_ROOT_NODE_ID, length: 0, startTime: 0 };
     // Add dummy track info for the dummy root node
     trackIdToTrackInfo.set(rootNode.id, rootNode);
     idToChildren.set(rootNode.id, rootNodeIds);
@@ -76,7 +83,7 @@ function renderTree(
     .attr("stroke", (d) => (mergeNodes.has(d.target.data.id) ? MERGE_EDGE_COLOR : DEFAULT_EDGE_COLOR))
     .attr("stroke-width", 1.5)
     .attr("stroke-dasharray", (d) => (mergeNodes.has(d.target.data.id) ? "4 3" : null))
-    .attr("opacity", (d) => (d.source.data.id === -1 ? 0 : 1)) // Hide links to the dummy root node
+    .attr("opacity", (d) => (d.source.data.id === DUMMY_ROOT_NODE_ID ? 0 : 1)) // Hide links to the dummy root node
     .attr("x1", (d) => d.source.y)
     .attr("y1", (d) => d.source.x)
     .attr("x2", (d) => d.target.y)
@@ -108,31 +115,42 @@ function renderTree(
   // Draw circles for each node
   node.append("circle");
 
+  // Add a second circle for an inner white highlight when a track is selected.
+  node.append("circle").classed(INNER_HIGHLIGHT_CLASS, true);
+
   // Text labels
+  // TODO: Update text color in `updateNodeStyles` based on the fill color
   node
     .append("text")
     .text((d) => d.data.id)
     .attr("text-anchor", "middle")
     .attr("dominant-baseline", "middle")
-    .attr("fill", "#ffffff")
+    .attr("fill", DEFAULT_TEXT_COLOR)
     .attr("font-size", 9)
     .attr("pointer-events", "none");
 
   // Setup pointer events
-  const handleClickTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>): void => {
+  const handleClickTrack = (
+    _event: React.MouseEvent<SVGCircleElement, MouseEvent>,
+    d: d3.HierarchyPointNode<TrackInfo>
+  ): void => {
     onClickTrack?.(d.data.id);
   };
-  const handleHoverTrack = (_event: any, d: d3.HierarchyPointNode<TrackInfo>): void => {
-    // d3.select(event.currentTarget).select("circle").attr("stroke", "#fff").attr("stroke-width", 2.5);
+  const handleHoverTrack = (
+    _event: React.MouseEvent<SVGCircleElement, MouseEvent>,
+    d: d3.HierarchyPointNode<TrackInfo>
+  ): void => {
     onHoverTrack?.(d.data.id);
   };
-  const handleUnhoverTrack = (_event: any, _d: d3.HierarchyPointNode<TrackInfo>): void => {
-    // d3.select(event.currentTarget).select("circle").attr("stroke", "#1a1f2e").attr("stroke-width", 1.5);
+  const handleUnhoverTrack = (
+    _event: React.MouseEvent<SVGCircleElement, MouseEvent>,
+    _d: d3.HierarchyPointNode<TrackInfo>
+  ): void => {
     onHoverTrack?.(null);
   };
 
   node
-    .filter((d) => d.data.id !== -1)
+    .filter((d) => d.data.id !== DUMMY_ROOT_NODE_ID)
     .on("click", handleClickTrack)
     .on("mouseover", handleHoverTrack)
     .on("mouseout", handleUnhoverTrack);
@@ -147,25 +165,24 @@ function updateNodeStyles(
   trackColors: Map<number, Color>
 ): void {
   // Draw circles for each node
+  const strokeWidth = 1.5;
   node
     .select<SVGCircleElement>("circle")
     .attr("r", (d) => radiusScale(d.data.length))
     .attr("fill", (d) => colorScale(d.data.startTime))
-    .attr("opacity", (d) => (d.data.id === -1 ? 0 : 1)) // Hide the dummy root node
+    .attr("opacity", (d) => (d.data.id === DUMMY_ROOT_NODE_ID ? 0 : 1)) // Hide the dummy root node
     .attr("stroke", (d) => trackColors.get(d.data.id)?.getStyle() ?? DEFAULT_NODE_EDGE_COLOR)
     .attr("stroke-width", 1.5)
     .style("cursor", "default");
 
-  // Text labels
+  // Show inner highlight circle for selected tracks.
   node
-    .select<SVGTextElement>("text")
-    .text((d) => d.data.id)
-    .attr("text-anchor", "middle")
-    .attr("dominant-baseline", "middle")
-    .attr("fill", "#ffffff")
-    .attr("opacity", (d) => (d.data.id === -1 ? 0 : 1)) // Hide the dummy root node
-    .attr("font-size", 9)
-    .attr("pointer-events", "none");
+    .select<SVGCircleElement>(`circle.${INNER_HIGHLIGHT_CLASS}`)
+    .attr("r", (d) => radiusScale(d.data.length) - strokeWidth)
+    .attr("stroke", "#ffffff")
+    .attr("stroke-width", strokeWidth)
+    .attr("fill", "none")
+    .attr("opacity", (d) => (trackColors.get(d.data.id) !== undefined ? 1 : 0));
 }
 
 /** Renders a tree view of the lineage data. */
@@ -196,18 +213,12 @@ export default function TreeLineageView(props: TreeLineageViewProps): ReactEleme
     }
     const svg = d3.select(svgRef.current);
     const svgNode = svg.node();
-    const gNode = d3.select(groupRef.current).node();
-    if (!gNode || !svgNode || !svg) {
+    const groupNode = d3.select(groupRef.current).node();
+    if (!groupNode || !svgNode || !svg) {
       return;
     }
-    const bbox = gNode.getBBox();
-    const cw = svgNode.clientWidth;
-    const ch = svgNode.clientHeight;
-    const scale = Math.min(cw / (bbox.width + 80), ch / (bbox.height + 40)) * 0.92;
-    const tx = (cw - bbox.width * scale) / 2 - bbox.x * scale;
-    const ty = (ch - bbox.height * scale) / 2 - bbox.y * scale;
-    const initT = d3.zoomIdentity.translate(tx, ty).scale(scale);
-    zoom.current.transform(svg, initT);
+    const initialTransform = getDefaultZoomTransform(svgNode, groupNode);
+    zoom.current.transform(svg, initialTransform);
   };
 
   useEffect(() => {
@@ -232,7 +243,7 @@ export default function TreeLineageView(props: TreeLineageViewProps): ReactEleme
         d3.select(groupRef.current).selectAll("*").remove();
       }
     };
-  }, [props.data]);
+  }, [props.data, props.relationships]);
 
   useEffect(() => {
     // Update node styling

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -2,7 +2,12 @@ import * as d3 from "d3";
 import React, { type ReactElement, useEffect, useRef } from "react";
 import type { Color } from "three";
 
-import type { LineageData, SharedLineageViewProps, TrackInfo } from "src/components/Tabs/Lineage/types";
+import type {
+  LineageData,
+  LineageDataRelationships,
+  SharedLineageViewProps,
+  TrackInfo,
+} from "src/components/Tabs/Lineage/types";
 import { useConstructor } from "src/hooks";
 
 const TREE_LEAF_HEIGHT_PX = 30;
@@ -12,46 +17,16 @@ type TreeLineageViewProps = SharedLineageViewProps & {};
 
 type NodeSelection = d3.Selection<SVGGElement | d3.BaseType, d3.HierarchyPointNode<TrackInfo>, SVGGElement, TrackInfo>;
 
-function getRelationships(data: LineageData): {
-  idToChildren: Map<number, number[]>;
-  idToParents: Map<number, number[]>;
-  crossLinks: [number, number][];
-} {
-  const idToChildren = new Map<number, number[]>(data.trackInfo.map((n) => [n.id, []]));
-  const idToParents = new Map<number, number[]>(data.trackInfo.map((n) => [n.id, []]));
-
-  // Links to a node where the node already has a parent (i.e. the second parent
-  // of a merge node).
-  const crossLinks: [number, number][] = [];
-  const idsWithParents = new Set<number>();
-
-  for (const [source, target] of data.edges) {
-    if (!idsWithParents.has(target)) {
-      idToChildren.get(source)?.push(target);
-    } else {
-      // If the target node already has a parent, intentionally prevent adding
-      // it to the children of this source node or else it will be duplicated in
-      // the tree. Instead, add it to a list of cross links that will be
-      // rendered separately.
-      crossLinks.push([source, target]);
-    }
-    idToParents.get(target)?.push(source);
-    idsWithParents.add(target);
-  }
-  return { idToChildren, idToParents, crossLinks };
-}
-
 function renderTree(
   g: d3.Selection<SVGGElement, TrackInfo, null, undefined>,
   data: LineageData,
+  relationships: LineageDataRelationships,
   onClickTrack?: (trackId: number) => void,
   onHoverTrack?: (trackId: number | null) => void
 ): NodeSelection | undefined {
-  const { trackInfo } = data;
+  const { trackIdToTrackInfo } = data;
   const edges = [...data.edges];
-
-  const trackIdToTrackInfo = new Map<number, TrackInfo>(trackInfo.map((track) => [track.id, track]));
-  const { idToChildren, idToParents, crossLinks } = getRelationships(data);
+  const { idToChildrenRenderable: idToChildren, idToParents, multiparentEdges: multiparentEdges } = relationships;
 
   const mergeNodes = new Set([...idToParents.entries()].filter(([, parents]) => parents.length > 1).map(([id]) => id));
   // All nodes with no parents
@@ -103,16 +78,17 @@ function renderTree(
     .attr("stroke-opacity", (d) => (mergeNodes.has(d.target.data.id) ? 0.7 : 0.6))
     .attr("stroke-width", 1.5)
     .attr("stroke-dasharray", (d) => (mergeNodes.has(d.target.data.id) ? "4 3" : null))
+    .attr("opacity", (d) => (d.source.data.id === -1 ? 0 : 1)) // Hide links to the dummy root node
     .attr("x1", (d) => d.source.y)
     .attr("y1", (d) => d.source.x)
     .attr("x2", (d) => d.target.y)
     .attr("y2", (d) => d.target.x);
 
-  if (crossLinks.length) {
+  if (multiparentEdges.length > 0) {
     const posOf = new Map(treeRoot.descendants().map((d) => [d.data.id, { x: d.x, y: d.y }]));
     g.append("g")
       .selectAll("line")
-      .data(crossLinks)
+      .data(multiparentEdges)
       .join("line")
       .attr("stroke", "#f6ad55")
       .attr("stroke-opacity", 0.7)
@@ -123,9 +99,6 @@ function renderTree(
       .attr("x2", (d) => posOf.get(d[1])?.y ?? 0)
       .attr("y2", (d) => posOf.get(d[1])?.x ?? 0);
   }
-
-  // TODO: return nodes out of this method, so they can be updated/recalculated
-  // without updating the entire tree?
 
   // Render nodes
   const node = g
@@ -177,6 +150,7 @@ function updateNodeStyles(
     .select<SVGCircleElement>("circle")
     .attr("r", (d) => radiusScale(d.data.length))
     .attr("fill", (d) => colorScale(d.data.startTime))
+    .attr("opacity", (d) => (d.data.id === -1 ? 0 : 1)) // Hide the dummy root node
     .attr("stroke", (d) => trackColors.get(d.data.id)?.getStyle() ?? "#1a1f2e")
     .attr("stroke-width", 1.5)
     .style("cursor", "default");
@@ -188,10 +162,12 @@ function updateNodeStyles(
     .attr("text-anchor", "middle")
     .attr("dominant-baseline", "middle")
     .attr("fill", "#ffffff")
+    .attr("opacity", (d) => (d.data.id === -1 ? 0 : 1)) // Hide the dummy root node
     .attr("font-size", 9)
     .attr("pointer-events", "none");
 }
 
+/** Renders a tree view of the lineage data. */
 export default function TreeLineageView(props: TreeLineageViewProps): ReactElement {
   const svgRef = useRef<SVGSVGElement>(null);
   const groupRef = useRef<SVGGElement>(null);
@@ -247,7 +223,7 @@ export default function TreeLineageView(props: TreeLineageViewProps): ReactEleme
       const g = d3.select(groupRef.current) as d3.Selection<SVGGElement, TrackInfo, null, undefined>;
       const onClickTrack = (trackId: number): void => onClickRef.current?.(trackId);
       const onHoverTrack = (trackId: number | null): void => onHoverRef.current?.(trackId);
-      nodeRef.current = renderTree(g, props.data, onClickTrack, onHoverTrack);
+      nodeRef.current = renderTree(g, props.data, props.relationships, onClickTrack, onHoverTrack);
     }
     // Clear on unmount
     return () => {

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -27,9 +27,10 @@ function renderTree(
   onClickTrack?: (trackId: number) => void,
   onHoverTrack?: (trackId: number | null) => void
 ): NodeSelection | undefined {
-  const { trackIdToTrackInfo } = data;
-  const edges = [...data.edges];
-  const { idToChildrenRenderable: idToChildren, idToParents, multiparentEdges: multiparentEdges } = relationships;
+  const { idToChildrenRenderable, idToParents, multiparentEdges: multiparentEdges } = relationships;
+
+  const trackIdToTrackInfo = new Map(data.trackIdToTrackInfo);
+  const idToChildren = new Map(idToChildrenRenderable);
 
   const mergeNodes = new Set([...idToParents.entries()].filter(([, parents]) => parents.length > 1).map(([id]) => id));
   // All nodes with no parents
@@ -45,9 +46,6 @@ function renderTree(
     rootNode = { id: -1, length: 0, startTime: 0 };
     // Add dummy track info for the dummy root node
     trackIdToTrackInfo.set(rootNode.id, rootNode);
-    for (const root of rootNodeIds) {
-      edges.push([rootNode.id, root]);
-    }
     idToChildren.set(rootNode.id, rootNodeIds);
   }
 
@@ -133,7 +131,11 @@ function renderTree(
     onHoverTrack?.(null);
   };
 
-  node.on("click", handleClickTrack).on("mouseover", handleHoverTrack).on("mouseout", handleUnhoverTrack);
+  node
+    .filter((d) => d.data.id !== -1)
+    .on("click", handleClickTrack)
+    .on("mouseover", handleHoverTrack)
+    .on("mouseout", handleUnhoverTrack);
 
   return node;
 }

--- a/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
+++ b/src/components/Tabs/Lineage/LineageViews/TreeLineageView.tsx
@@ -12,6 +12,9 @@ import { useConstructor } from "src/hooks";
 
 const TREE_LEAF_HEIGHT_PX = 30;
 const TREE_LAYER_DEPTH_PX = 110;
+const MERGE_EDGE_COLOR = "#ff9410";
+const DEFAULT_EDGE_COLOR = "#4a5568";
+const DEFAULT_NODE_EDGE_COLOR = "#1a1f2e";
 
 type TreeLineageViewProps = SharedLineageViewProps & {};
 
@@ -38,7 +41,6 @@ function renderTree(
   } else if (rootNodeIds.length === 1) {
     rootNode = trackIdToTrackInfo.get(rootNodeIds[0])!;
   } else {
-    // TODO: Hide the dummy root node
     // Multiple root nodes, make a dummy root node that is the parent of all root nodes
     rootNode = { id: -1, length: 0, startTime: 0 };
     // Add dummy track info for the dummy root node
@@ -73,9 +75,7 @@ function renderTree(
     .selectAll("line")
     .data(treeRoot.links())
     .join("line")
-    // TODO: Make colors into constants here? Or parameterize via options
-    .attr("stroke", (d) => (mergeNodes.has(d.target.data.id) ? "#f6ad55" : "#4a5568"))
-    .attr("stroke-opacity", (d) => (mergeNodes.has(d.target.data.id) ? 0.7 : 0.6))
+    .attr("stroke", (d) => (mergeNodes.has(d.target.data.id) ? MERGE_EDGE_COLOR : DEFAULT_EDGE_COLOR))
     .attr("stroke-width", 1.5)
     .attr("stroke-dasharray", (d) => (mergeNodes.has(d.target.data.id) ? "4 3" : null))
     .attr("opacity", (d) => (d.source.data.id === -1 ? 0 : 1)) // Hide links to the dummy root node
@@ -90,8 +90,7 @@ function renderTree(
       .selectAll("line")
       .data(multiparentEdges)
       .join("line")
-      .attr("stroke", "#f6ad55")
-      .attr("stroke-opacity", 0.7)
+      .attr("stroke", MERGE_EDGE_COLOR)
       .attr("stroke-width", 1.5)
       .attr("stroke-dasharray", "4 3")
       .attr("x1", (d) => posOf.get(d[0])?.y ?? 0)
@@ -151,7 +150,7 @@ function updateNodeStyles(
     .attr("r", (d) => radiusScale(d.data.length))
     .attr("fill", (d) => colorScale(d.data.startTime))
     .attr("opacity", (d) => (d.data.id === -1 ? 0 : 1)) // Hide the dummy root node
-    .attr("stroke", (d) => trackColors.get(d.data.id)?.getStyle() ?? "#1a1f2e")
+    .attr("stroke", (d) => trackColors.get(d.data.id)?.getStyle() ?? DEFAULT_NODE_EDGE_COLOR)
     .attr("stroke-width", 1.5)
     .style("cursor", "default");
 

--- a/src/components/Tabs/Lineage/lineage_utils.ts
+++ b/src/components/Tabs/Lineage/lineage_utils.ts
@@ -1,0 +1,51 @@
+import { Dataset } from "src/colorizer";
+
+import { LineageData } from "./types";
+
+export function getLineageData(dataset: Dataset): LineageData {
+  const tracks = dataset.trackIds;
+  const times = dataset.times;
+  // Get first track edge (TODO: handle multiple track edges in the future?)
+  const defaultTrackKey = dataset.getDefaultTrackKey();
+  const trackData = defaultTrackKey ? dataset.getTrackData(defaultTrackKey) : undefined;
+  const trackEdges = trackData?.trackEdges;
+  if (!tracks || !times || !trackEdges) {
+    return { trackInfo: [], edges: [] };
+  }
+
+  const allTracks = new Set<number>();
+  const trackToInfo = new Map<number, { id: number; length: number; startTime: number }>();
+  for (let i = 0; i < tracks.length; i++) {
+    const trackId = tracks[i];
+    const time = times[i];
+
+    if (!trackToInfo.has(trackId)) {
+      trackToInfo.set(trackId, { id: trackId, length: 1, startTime: time });
+    } else {
+      const info = trackToInfo.get(trackId)!;
+      info.length += 1;
+      info.startTime = Math.min(info.startTime, time);
+    }
+    allTracks.add(trackId);
+  }
+
+  const trackInfo = Array.from(trackToInfo.values());
+
+  const skippedEdges: [number, number][] = [];
+  const edges: [number, number][] = [];
+  for (let i = 0; i < trackEdges.length; i += 2) {
+    const source = trackEdges[i];
+    const target = trackEdges[i + 1];
+    // Skip edges that do not exist in the dataset
+    if (!allTracks.has(source) || !allTracks.has(target)) {
+      skippedEdges.push([source, target]);
+      continue;
+    }
+    edges.push([source, target]);
+  }
+
+  if (skippedEdges.length > 0) {
+    console.warn(`Skipped ${skippedEdges.length} edges that reference non-existent tracks:`, skippedEdges);
+  }
+  return { trackInfo, edges };
+}

--- a/src/components/Tabs/Lineage/lineage_utils.ts
+++ b/src/components/Tabs/Lineage/lineage_utils.ts
@@ -31,7 +31,10 @@ export function getLineageData(dataset: Dataset): LineageData {
 
   const skippedEdges: [number, number][] = [];
   const edges: [number, number][] = [];
-  for (let i = 0; i < trackEdges.length; i += 2) {
+  if (trackEdges.length % 2 !== 0) {
+    console.warn(`Track edges array has an odd length (${trackEdges.length}), skipping the last edge.`);
+  }
+  for (let i = 0; i < trackEdges.length + 1; i += 2) {
     const source = trackEdges[i];
     const target = trackEdges[i + 1];
     // Skip edges that do not exist in the dataset

--- a/src/components/Tabs/Lineage/lineage_utils.ts
+++ b/src/components/Tabs/Lineage/lineage_utils.ts
@@ -1,6 +1,6 @@
 import type { Dataset } from "src/colorizer";
 
-import type { LineageData } from "./types";
+import type { LineageData, LineageDataRelationships, TrackInfo } from "./types";
 
 export function getLineageData(dataset: Dataset): LineageData {
   const tracks = dataset.trackIds;
@@ -10,26 +10,24 @@ export function getLineageData(dataset: Dataset): LineageData {
   const trackData = defaultTrackKey ? dataset.getTrackData(defaultTrackKey) : undefined;
   const trackEdges = trackData?.trackEdges;
   if (!tracks || !times || !trackEdges) {
-    return { trackInfo: [], edges: [] };
+    return { trackIdToTrackInfo: new Map<number, TrackInfo>(), edges: [] };
   }
 
   const allTracks = new Set<number>();
-  const trackToInfo = new Map<number, { id: number; length: number; startTime: number }>();
+  const trackIdToTrackInfo = new Map<number, TrackInfo>();
   for (let i = 0; i < tracks.length; i++) {
     const trackId = tracks[i];
     const time = times[i];
 
-    if (!trackToInfo.has(trackId)) {
-      trackToInfo.set(trackId, { id: trackId, length: 1, startTime: time });
+    if (!trackIdToTrackInfo.has(trackId)) {
+      trackIdToTrackInfo.set(trackId, { id: trackId, length: 1, startTime: time });
     } else {
-      const info = trackToInfo.get(trackId)!;
+      const info = trackIdToTrackInfo.get(trackId)!;
       info.length += 1;
       info.startTime = Math.min(info.startTime, time);
     }
     allTracks.add(trackId);
   }
-
-  const trackInfo = Array.from(trackToInfo.values());
 
   const skippedEdges: [number, number][] = [];
   const edges: [number, number][] = [];
@@ -47,5 +45,33 @@ export function getLineageData(dataset: Dataset): LineageData {
   if (skippedEdges.length > 0) {
     console.warn(`Skipped ${skippedEdges.length} edges that reference non-existent tracks:`, skippedEdges);
   }
-  return { trackInfo, edges };
+  return { trackIdToTrackInfo, edges };
+}
+
+export function getLineageRelationships(data: LineageData): LineageDataRelationships {
+  const trackIds = Array.from(data.trackIdToTrackInfo.keys());
+  const idToChildren = new Map<number, number[]>(trackIds.map((id) => [id, []]));
+  const idToChildrenRenderable = new Map<number, number[]>(trackIds.map((id) => [id, []]));
+  const idToParents = new Map<number, number[]>(trackIds.map((id) => [id, []]));
+
+  // Links to a node where the node already has a parent (i.e. the second parent
+  // of a merge node).
+  const multiparentEdges: [number, number][] = [];
+  const idsWithParents = new Set<number>();
+
+  for (const [source, target] of data.edges) {
+    if (!idsWithParents.has(target)) {
+      idToChildrenRenderable.get(source)?.push(target);
+    } else {
+      // If the target node already has a parent, intentionally prevent adding
+      // it to the children of this source node or else it will be duplicated in
+      // the tree. Instead, add it to a list of cross links that will be
+      // rendered separately.
+      multiparentEdges.push([source, target]);
+    }
+    idToChildren.get(source)?.push(target);
+    idToParents.get(target)?.push(source);
+    idsWithParents.add(target);
+  }
+  return { idToChildren, idToChildrenRenderable, idToParents, multiparentEdges };
 }

--- a/src/components/Tabs/Lineage/lineage_utils.ts
+++ b/src/components/Tabs/Lineage/lineage_utils.ts
@@ -1,6 +1,6 @@
-import { Dataset } from "src/colorizer";
+import type { Dataset } from "src/colorizer";
 
-import { LineageData } from "./types";
+import type { LineageData } from "./types";
 
 export function getLineageData(dataset: Dataset): LineageData {
   const tracks = dataset.trackIds;

--- a/src/components/Tabs/Lineage/lineage_utils.ts
+++ b/src/components/Tabs/Lineage/lineage_utils.ts
@@ -1,3 +1,5 @@
+import * as d3 from "d3";
+
 import type { Dataset } from "src/colorizer";
 
 import type { LineageData, LineageDataRelationships, TrackInfo } from "./types";
@@ -15,9 +17,9 @@ export function getLineageData(dataset: Dataset): LineageData {
 
   const allTracks = new Set<number>();
   const trackIdToTrackInfo = new Map<number, TrackInfo>();
-  for (let i = 0; i < tracks.length; i++) {
-    const trackId = tracks[i];
-    const time = times[i];
+  for (let id = 0; id < tracks.length; id++) {
+    const trackId = tracks[id];
+    const time = times[id];
 
     if (!trackIdToTrackInfo.has(trackId)) {
       trackIdToTrackInfo.set(trackId, { id: trackId, length: 1, startTime: time });
@@ -34,7 +36,7 @@ export function getLineageData(dataset: Dataset): LineageData {
   if (trackEdges.length % 2 !== 0) {
     console.warn(`Track edges array has an odd length (${trackEdges.length}), skipping the last edge.`);
   }
-  for (let i = 0; i < trackEdges.length + 1; i += 2) {
+  for (let i = 0; i + 1 < trackEdges.length; i += 2) {
     const source = trackEdges[i];
     const target = trackEdges[i + 1];
     // Skip edges that do not exist in the dataset
@@ -57,8 +59,10 @@ export function getLineageRelationships(data: LineageData): LineageDataRelations
   const idToChildrenRenderable = new Map<number, number[]>(trackIds.map((id) => [id, []]));
   const idToParents = new Map<number, number[]>(trackIds.map((id) => [id, []]));
 
-  // Links to a node where the node already has a parent (i.e. the second parent
-  // of a merge node).
+  /**
+   * Edges to a node where the node already has a parent (i.e. edges that would
+   * create the second/nth parent of a merge node).
+   */
   const multiparentEdges: [number, number][] = [];
   const idsWithParents = new Set<number>();
 
@@ -67,9 +71,9 @@ export function getLineageRelationships(data: LineageData): LineageDataRelations
       idToChildrenRenderable.get(source)?.push(target);
     } else {
       // If the target node already has a parent, intentionally prevent adding
-      // it to the children of this source node or else it will be duplicated in
-      // the tree. Instead, add it to a list of cross links that will be
-      // rendered separately.
+      // it to the children of this source node or else it (and all its
+      // children) will be duplicated in the tree. Instead, add it to a list of
+      // edges that will be rendered separately.
       multiparentEdges.push([source, target]);
     }
     idToChildren.get(source)?.push(target);
@@ -77,4 +81,23 @@ export function getLineageRelationships(data: LineageData): LineageDataRelations
     idsWithParents.add(target);
   }
   return { idToChildren, idToChildrenRenderable, idToParents, multiparentEdges };
+}
+
+/**
+ * Returns a d3 zoom transform that will fit the groupNode within the svgNode
+ * with some padding.
+ */
+export function getDefaultZoomTransform(
+  svgNode: SVGSVGElement,
+  groupNode: SVGGElement,
+  paddingPx: [number, number] = [10, 10]
+): d3.ZoomTransform {
+  const bbox = groupNode.getBBox();
+  const clientwidth = svgNode.clientWidth;
+  const clientHeight = svgNode.clientHeight;
+  const scale = Math.min((clientwidth - paddingPx[0]) / bbox.width, (clientHeight - paddingPx[1]) / bbox.height);
+  const panX = (clientwidth - bbox.width * scale) / 2 - bbox.x * scale;
+  const panY = (clientHeight - bbox.height * scale) / 2 - bbox.y * scale;
+  const initialTransform = d3.zoomIdentity.translate(panX, panY).scale(scale);
+  return initialTransform;
 }

--- a/src/components/Tabs/Lineage/types.ts
+++ b/src/components/Tabs/Lineage/types.ts
@@ -9,13 +9,31 @@ export type TrackInfo = {
 };
 
 export type LineageData = {
-  trackInfo: TrackInfo[];
+  trackIdToTrackInfo: Map<number, TrackInfo>;
   edges: [number, number][];
+};
+
+export type LineageDataRelationships = {
+  /** A map from a track ID to its children track IDs. */
+  idToChildren: Map<number, number[]>;
+  /**
+   * A version of idToChildren where edges that would cause nodes to have
+   * multiple parents are removed, as directly rendering this to a tree in d3
+   * would cause duplicated leaf nodes. This typically occurs during merges
+   * between two or more tracks. These edges are stored in `multiparentEdges`
+   * instead.
+   */
+  idToChildrenRenderable: Map<number, number[]>;
+  /** A list of edges that create a multi-parent relationship. */
+  multiparentEdges: [number, number][];
+  /** A map from a track ID to its parent track IDs. */
+  idToParents: Map<number, number[]>;
 };
 
 export type SharedLineageViewProps = {
   container: React.RefObject<HTMLDivElement>;
   data: LineageData;
+  relationships: LineageDataRelationships;
   selectedTracks: Set<number>;
   trackColors: Map<number, Color>;
   colorScale: d3.ScaleSequential<string>;

--- a/src/components/Tabs/Lineage/types.ts
+++ b/src/components/Tabs/Lineage/types.ts
@@ -1,0 +1,23 @@
+import type { Color } from "three";
+
+export type TrackInfo = {
+  id: number;
+  length: number;
+  startTime: number;
+};
+
+export type LineageData = {
+  trackInfo: TrackInfo[];
+  edges: [number, number][];
+};
+
+export type SharedLineageViewProps = {
+  container: React.RefObject<HTMLDivElement>;
+  data: LineageData;
+  selectedTracks: Set<number>;
+  trackColors: Map<number, Color>;
+  colorScale: d3.ScaleSequential<string>;
+  radiusScale: d3.ScalePower<number, number>;
+  onClick?: (trackId: number) => void;
+  onHover?: (trackId: number | null) => void;
+};

--- a/src/components/Tabs/Lineage/types.ts
+++ b/src/components/Tabs/Lineage/types.ts
@@ -1,3 +1,5 @@
+import type * as d3 from "d3";
+import type React from "react";
 import type { Color } from "three";
 
 export type TrackInfo = {

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,9 +1,19 @@
 import AnnotationTab from "./Annotation/AnnotationTab";
 import CorrelationPlotTab from "./CorrelationPlot/CorrelationPlotTab";
 import FeatureThresholdsTab from "./Filters/FeatureThresholdsTab";
+import LineageTab from "./Lineage/LineageTab";
 import Plot3dTab from "./Plot3d/Plot3dTab";
 import ScatterPlotTab from "./ScatterPlot/ScatterPlotTab";
 import SettingsTab from "./Settings/SettingsTab";
 import PlotTab from "./TrackPlot/PlotTab";
 
-export { AnnotationTab, CorrelationPlotTab, FeatureThresholdsTab, Plot3dTab, PlotTab, ScatterPlotTab, SettingsTab };
+export {
+  AnnotationTab,
+  CorrelationPlotTab,
+  FeatureThresholdsTab,
+  LineageTab,
+  Plot3dTab,
+  PlotTab,
+  ScatterPlotTab,
+  SettingsTab,
+};

--- a/src/components/Tooltips/CanvasHoverTooltip.tsx
+++ b/src/components/Tooltips/CanvasHoverTooltip.tsx
@@ -13,25 +13,13 @@ import { AppThemeContext } from "src/styles/AppStyle";
 import { FlexColumn, FlexRow } from "src/styles/utils";
 
 import HoverTooltip from "./HoverTooltip";
+import { TooltipCard } from "./TooltipCard";
 
 type CanvasHoverTooltipProps = {
   lastValidHoveredId: PixelIdInfo;
   showObjectHoverInfo: boolean;
   annotationState: AnnotationState;
 };
-
-const ObjectInfoCard = styled.div`
-  font-family: var(--default-font);
-
-  border-radius: var(--radius-control-small);
-  border: 1px solid var(--color-dividers);
-  background-color: var(--color-background);
-  padding: 6px 8px;
-  overflow-wrap: break-word;
-
-  transition: opacity 300ms ease-in-out;
-  width: fit-content;
-`;
 
 const DebugText = styled.p`
   font-size: var(--font-size-label-small) !important;
@@ -254,7 +242,7 @@ export default function CanvasHoverTooltip(props: PropsWithChildren<CanvasHoverT
     <FlexColumn $gap={6}>
       {annotationLabel}
       {noInteractionWarning}
-      <ObjectInfoCard style={{ opacity: props.showObjectHoverInfo ? 1 : 0 }}>{objectInfoContent}</ObjectInfoCard>
+      <TooltipCard style={{ opacity: props.showObjectHoverInfo ? 1 : 0 }}>{objectInfoContent}</TooltipCard>
     </FlexColumn>
   );
 

--- a/src/components/Tooltips/HoverTooltip.tsx
+++ b/src/components/Tooltips/HoverTooltip.tsx
@@ -67,7 +67,7 @@ export default function HoverTooltip(props: PropsWithChildren<HoverTooltipProps>
   const visible = isHovered && !props.disabled && props.tooltipContent;
 
   return (
-    <div ref={containerRef} style={{ position: "relative", ...props.style }}>
+    <div ref={containerRef} style={props.style}>
       <TooltipDiv ref={tooltipRef} style={{ opacity: visible ? 1 : 0, maxWidth: `${props.maxWidthPx}px` }}>
         {props.tooltipContent}
       </TooltipDiv>

--- a/src/components/Tooltips/HoverTooltip.tsx
+++ b/src/components/Tooltips/HoverTooltip.tsx
@@ -9,6 +9,7 @@ type HoverTooltipProps = {
   /** Offset of the tooltip box relative to the mouse, in pixels. By default, set to 15 pixels in x and y. */
   offsetPx?: [number, number];
   maxWidthPx?: number;
+  style?: React.CSSProperties;
 };
 
 const defaultProps: Partial<HoverTooltipProps> = {
@@ -66,7 +67,7 @@ export default function HoverTooltip(props: PropsWithChildren<HoverTooltipProps>
   const visible = isHovered && !props.disabled && props.tooltipContent;
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} style={{ position: "relative", ...props.style }}>
       <TooltipDiv ref={tooltipRef} style={{ opacity: visible ? 1 : 0, maxWidth: `${props.maxWidthPx}px` }}>
         {props.tooltipContent}
       </TooltipDiv>

--- a/src/components/Tooltips/TooltipCard.tsx
+++ b/src/components/Tooltips/TooltipCard.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const TooltipCard = styled.div`
+  font-family: var(--default-font);
+
+  border-radius: var(--radius-control-small);
+  border: 1px solid var(--color-dividers);
+  background-color: var(--color-background);
+  padding: 6px 8px;
+  overflow-wrap: break-word;
+
+  transition: opacity 300ms ease-in-out;
+  width: fit-content;
+`;


### PR DESCRIPTION
Problem
=======
Closes #945, "Lineage: Load + visualize track-level lineage data". 

This PR adds a new tab for lineage data, which is shown only if track edges or node edges are provided. The tab adds a tree view of the parent-child relationships between tracks in the dataset.

Much of the code was adapted from an initial solution created by Max Hess (@MaksHess), found here: https://github.com/MaksHess/d3-tree/

*Estimated review size: large, 50-60 minutes*

Solution
========
- Adds a new `LineageTab` that displays a `TreeLineageView`. In the future, multiple different view types can be supported.
  - Tracks can be clicked to select them from the tree lineage view, with support for multi-track selection.
  - Information about the track is shown when the track is hovered.
  - The lineage tab is hidden if no lineage data is provided.
- Added helper methods for calculating lineage data and lineage relationships form track edge data introduced in #950.

Misc:
- Moved `TooltipCard.tsx` out of `CanvasHoverTooltip.tsx`

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-952/viewer?dataset=https%3A%2F%2Fvast-files.int.allencell.org%2Fusers%2Fpeyton.lee%2Fliberali-data%2Ftfe%2Fmanifest.json&tab=lineage
2. Interact with the lineage tree view by clicking on tracks to select them.

Screenshots (optional):
-----------------------

<img width="911" height="786" alt="{FDDB460A-23AF-4F32-9CA1-6E5995117FB1}" src="https://github.com/user-attachments/assets/93a8cb29-2afb-498b-95a1-28de3372facb" />


Keyfiles (delete if not relevant):
-----------------------
1. `src/components/Tabs/Lineage/types.ts`
2. `lineage_utils.ts`
3. `LineageTab.tsx`
4. `TreeLineageView.tsx`