### PR TITLE
fix: Fixed unnormalized scaling in TFE 2D canvas calculations

### DIFF
--- a/src/colorizer/viewport/utils.ts
+++ b/src/colorizer/viewport/utils.ts
@@ -23,9 +23,9 @@ export function get2DCanvasScaling(
   if (canvasAspect > frameAspect) {
     // Canvas has a wider aspect ratio than the frame, so proportional height is
     // 1 and we scale width accordingly.
-    unscaledFrameSizeInCanvasCoords.x = canvasAspect / frameAspect;
+    unscaledFrameSizeInCanvasCoords.x = frameAspect / canvasAspect;
   } else {
-    unscaledFrameSizeInCanvasCoords.y = frameAspect / canvasAspect;
+    unscaledFrameSizeInCanvasCoords.y = canvasAspect / frameAspect;
   }
 
   // Get final size by applying the current zoom level, where `zoomMultiplier=2`
@@ -38,7 +38,9 @@ export function get2DCanvasScaling(
   // zoom is set to 2x. Assuming that the [0, 0] position of the frame and the
   // canvas are in the same position, the position [1, 1] on the canvas should
   // map to [0.5, 0.5] on the frame.
-  const canvasToFrameCoordinates = unscaledFrameSizeInCanvasCoords.clone().divideScalar(zoomMultiplier);
+  const canvasToFrameCoordinates = new Vector2(1, 1)
+    .divide(unscaledFrameSizeInCanvasCoords)
+    .divideScalar(zoomMultiplier);
 
   // Invert to get the frame to canvas coordinates. Useful for objects (e.g.
   // line mesh vertices) that are in frame coordinates and need to be drawn on


### PR DESCRIPTION
Problem
=======
Fixes a bug where the scale bar in TFE was incorrectly scaled on the newer Endo datasets. This was due to a calculation error for datasets where the frames had differing aspect ratio from the default TFE viewport.

Solution
========
- Fixed inversed calculation of frame scaling constants in `viewport/utils.ts`.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open broken main build. The frame should be 660 micrometers wide, but according to the scalebar it is only 330ish.  https://timelapse.allencell.org/viewer?dataset=https%3A%2F%2Fvast-files.int.allencell.org%2Fusers%2Fpeyton.lee%2Ftest-data%2Fjess-endo-scaling%2Fmanifest.json
2. Open the same dataset on the fixed build. The scalebar will show that the frame is roughly 660 micrometers wide. https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-956/viewer?dataset=https%3A%2F%2Fvast-files.int.allencell.org%2Fusers%2Fpeyton.lee%2Ftest-data%2Fjess-endo-scaling%2Fmanifest.json

I've also tested and visually verified that the scaling of other objects drawn with these values (track paths, vectors, etc.) are correct.

Screenshots (optional):
-----------------------

The frame should be ~667 micrometers wide.

| Before ❌ | After ✅ |
| --- | --- |
| <img width="1920" height="1527" alt="image" src="https://github.com/user-attachments/assets/d188d141-6bad-42c4-8fe3-fdf3dac244be" />  | <img width="1920" height="1527" alt="image" src="https://github.com/user-attachments/assets/b5766eb3-f600-49d3-8356-172bdac77819" /> |


